### PR TITLE
feat: add GitHub Immutable Releases documentation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -33,6 +33,11 @@ Expert patterns for Git version control workflows including branching strategies
 - Branch protection rules
 - Automated versioning
 
+### GitHub Release Management
+- Immutable Releases security feature
+- Release sequence patterns
+- Version synchronization
+
 ## Reference Files
 
 - `references/branching-strategies.md` - Branch management patterns
@@ -40,6 +45,7 @@ Expert patterns for Git version control workflows including branching strategies
 - `references/pull-request-workflow.md` - PR and review processes
 - `references/ci-cd-integration.md` - Automation patterns
 - `references/advanced-git.md` - Advanced Git operations
+- `references/github-releases.md` - Release management and immutable releases
 
 ## Core Patterns
 
@@ -370,7 +376,79 @@ git rebase --continue         # Or: git merge --continue
 git rebase --abort            # Or: git merge --abort
 ```
 
+## GitHub Immutable Releases
+
+### ⚠️ CRITICAL: Deleted Releases Block Tag Names PERMANENTLY
+
+**GitHub Immutable Releases** (GA October 2024) is a security feature that prevents tag name reuse after a release is deleted.
+
+**What happens:**
+1. You create release `v1.2.3`
+2. Something goes wrong, you delete the release
+3. **The tag name `v1.2.3` is PERMANENTLY BLOCKED**
+4. You cannot create a new release with that version number - EVER
+
+**Why it exists:** Prevents supply chain attacks where attackers could delete a release and publish malicious code under the same version.
+
+**Cannot be disabled:** This is a permanent GitHub security feature with no bypass.
+
+### Consequences
+
+```
+❌ BLOCKED: v1.2.3 (deleted release)
+❌ BLOCKED: v1.2.4 (also deleted trying to fix)
+❌ BLOCKED: v1.2.5 (deleted again...)
+✅ AVAILABLE: v1.2.6 (first unblocked version)
+```
+
+### Prevention: Get Releases Right FIRST TIME
+
+**Release Sequence (TYPO3 Extensions):**
+```bash
+# 1. Update version in source files FIRST
+sed -i "s/'version' => '.*'/'version' => '1.2.3'/" ext_emconf.php
+
+# 2. Commit and merge to main
+git add ext_emconf.php CHANGELOG.md
+git commit -m "chore: bump version to 1.2.3"
+git push && gh pr create && gh pr merge
+
+# 3. Verify version is correct
+grep "'version'" ext_emconf.php  # Must show 1.2.3
+
+# 4. ONLY THEN create release
+gh release create v1.2.3 --title "v1.2.3" --notes "..."
+```
+
+**Pre-Release Checklist:**
+```
+[ ] Version in ext_emconf.php matches intended tag
+[ ] Version in CHANGELOG.md matches intended tag
+[ ] All changes merged to main branch
+[ ] CI passes (including TER compatibility check)
+[ ] Double-check: grep "'version'" ext_emconf.php
+[ ] Ready to create release (NO SECOND CHANCES!)
+```
+
+### Recovery from Failed Release
+
+If TER/npm/PyPI publish fails after release creation:
+
+1. **DO NOT DELETE THE RELEASE** - the tag will be blocked forever
+2. Fix the issue (e.g., remove strict_types from ext_emconf.php)
+3. Create a NEW release with the NEXT version number
+4. Update CHANGELOG to explain skipped versions
+
+**Example CHANGELOG entry:**
+```markdown
+## [1.2.6] - 2025-01-15
+
+Note: Versions 1.2.3-1.2.5 were skipped due to release process issues.
+GitHub's immutable releases feature blocks tag names after deletion.
+```
+
 ## Related Skills
 
 - **enterprise-readiness-skill**: Git workflow is part of CI/CD maturity
 - **security-audit-skill**: Git hooks for security checks
+- **typo3-conformance-skill**: TER publishing requirements and validation

--- a/references/github-releases.md
+++ b/references/github-releases.md
@@ -1,0 +1,249 @@
+# GitHub Releases Reference
+
+**Purpose:** Document GitHub release management, immutable releases security feature, and release sequence patterns.
+
+---
+
+## Immutable Releases Security Feature
+
+### Overview
+
+**GitHub Immutable Releases** (GA October 2024) is a permanent security feature that prevents tag name reuse after a release is deleted.
+
+**Security Purpose:** Prevents supply chain attacks where an attacker could:
+1. Delete a legitimate release
+2. Create a new release with the same version containing malicious code
+3. Users downloading "v1.2.3" would get the malicious version
+
+### Behavior
+
+| Action | Result |
+|--------|--------|
+| Create release v1.2.3 | ✅ Success |
+| Delete release v1.2.3 | ✅ Allowed |
+| Create NEW release v1.2.3 | ❌ PERMANENTLY BLOCKED |
+| Create release v1.2.4 | ✅ Success (new version) |
+
+### Key Facts
+
+- **Cannot be disabled:** No repository setting, API call, or GitHub support request can bypass this
+- **Permanent:** Once blocked, a tag name stays blocked forever
+- **Per-repository:** Each repository has its own blocked tag list
+- **Applies to:** Published releases only (not draft releases)
+
+### Detection
+
+```bash
+# Attempt to create release - if blocked, you'll see:
+# "tag_name was used by an immutable release"
+gh release create v1.2.3 --notes "test" 2>&1 | grep -i "immutable"
+```
+
+---
+
+## Release Sequence Patterns
+
+### TYPO3 Extension Release
+
+**Correct Sequence:**
+```bash
+# 1. Create release branch
+git checkout -b release/v1.2.3
+
+# 2. Update version in source files
+# ext_emconf.php
+sed -i "s/'version' => '.*'/'version' => '1.2.3'/" ext_emconf.php
+
+# CHANGELOG.md - add new version section
+
+# 3. Commit version bump
+git add ext_emconf.php CHANGELOG.md
+git commit -m "chore: bump version to 1.2.3"
+
+# 4. Create PR and merge
+git push -u origin release/v1.2.3
+gh pr create --title "chore: bump version to 1.2.3"
+# Wait for CI to pass
+gh pr merge --squash
+
+# 5. Switch to main and verify
+git checkout main && git pull
+grep "'version'" ext_emconf.php  # MUST show 1.2.3
+
+# 6. Create release ONLY after verification
+gh release create v1.2.3 \
+  --title "v1.2.3" \
+  --notes "Release notes here"
+```
+
+**Common Mistakes:**
+| Mistake | Consequence |
+|---------|-------------|
+| Create release before updating version | Version mismatch, TER/npm publish fails |
+| Create release before merging PR | Tag points to wrong commit |
+| Delete release to "fix" something | Tag name permanently blocked |
+| Rush without verification | Multiple blocked versions |
+
+### NPM Package Release
+
+```bash
+# 1. Update package.json version
+npm version patch  # or minor/major
+
+# 2. Verify version
+grep '"version"' package.json
+
+# 3. Push changes
+git push && git push --tags
+
+# 4. Create GitHub release (if using GitHub releases)
+gh release create v$(node -p "require('./package.json').version")
+```
+
+### Python Package Release
+
+```bash
+# 1. Update version in pyproject.toml or setup.py
+# 2. Update CHANGELOG
+
+# 3. Commit and push
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore: bump version to 1.2.3"
+git push
+
+# 4. Create and push tag
+git tag v1.2.3
+git push --tags
+
+# 5. Create release
+gh release create v1.2.3
+```
+
+---
+
+## Pre-Release Validation
+
+### Automated Checks
+
+Add to CI workflow:
+```yaml
+- name: Version Consistency Check
+  run: |
+    # Extract versions from different sources
+    EMCONF_VERSION=$(grep -oP "'version' => '\K[0-9]+\.[0-9]+\.[0-9]+" ext_emconf.php)
+
+    # For tagged builds, verify tag matches
+    if [[ "${GITHUB_REF}" =~ ^refs/tags/v ]]; then
+      TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+      if [[ "${TAG_VERSION}" != "${EMCONF_VERSION}" ]]; then
+        echo "::error::Version mismatch! Tag: ${TAG_VERSION}, ext_emconf.php: ${EMCONF_VERSION}"
+        exit 1
+      fi
+    fi
+    echo "Version check passed: ${EMCONF_VERSION}"
+```
+
+### Manual Checklist
+
+Before creating ANY release:
+```
+[ ] All code changes merged to main/master
+[ ] CI pipeline passes on main branch
+[ ] Version updated in ALL source files:
+    [ ] ext_emconf.php (TYPO3)
+    [ ] package.json (Node)
+    [ ] pyproject.toml / setup.py (Python)
+    [ ] composer.json (if version is tracked there)
+[ ] CHANGELOG.md updated with new version
+[ ] Local main is up to date: git pull origin main
+[ ] Version verification: grep -r "version" | grep "1.2.3"
+[ ] READY - No second chances after release creation!
+```
+
+---
+
+## Recovery Procedures
+
+### Scenario: TER/npm/PyPI Publish Failed After Release
+
+**DO NOT DELETE THE RELEASE!**
+
+Instead:
+1. Identify the root cause of publish failure
+2. Fix the issue in a new commit
+3. Update version to NEXT number (skipping the broken version)
+4. Create new release with new version
+
+Example:
+```bash
+# v1.2.3 release created but TER publish failed
+# DO NOT: gh release delete v1.2.3
+
+# Fix the issue
+vim ext_emconf.php  # remove strict_types or fix other issues
+
+# Bump to NEXT version
+sed -i "s/'version' => '1.2.3'/'version' => '1.2.4'/" ext_emconf.php
+
+# Update CHANGELOG
+cat >> CHANGELOG.md << 'EOF'
+## [1.2.4] - 2025-01-15
+
+### Fixed
+- Fixed TER publishing issue (strict_types in ext_emconf.php)
+
+Note: v1.2.3 was skipped due to publish failure.
+EOF
+
+# Commit, merge, then create new release
+git add -A && git commit -m "fix: resolve TER publish issue, bump to 1.2.4"
+git push && gh pr create && gh pr merge
+gh release create v1.2.4 --notes "..."
+```
+
+### Scenario: Multiple Versions Blocked
+
+If you've blocked v1.2.3, v1.2.4, v1.2.5 through repeated failures:
+
+1. **Stop and think** - don't create more releases
+2. List what went wrong each time
+3. Fix ALL issues before next attempt
+4. Use next available version (v1.2.6)
+5. Document skipped versions in CHANGELOG
+
+```markdown
+## [1.2.6] - 2025-01-15
+
+Note: Versions 1.2.3-1.2.5 are unavailable due to GitHub's immutable
+releases feature. These versions were blocked after release deletion
+attempts during troubleshooting.
+
+### Fixed
+- Resolved TER compatibility issue with ext_emconf.php
+```
+
+---
+
+## Best Practices
+
+### Do
+- ✅ Update version files BEFORE creating release
+- ✅ Verify version with grep before release
+- ✅ Use CI checks for version consistency
+- ✅ Keep releases - never delete published releases
+- ✅ Test publish process in staging first (if possible)
+
+### Don't
+- ❌ Create release before version is updated in source
+- ❌ Delete releases to "fix" issues
+- ❌ Rush releases without verification
+- ❌ Assume you can recreate a deleted release
+- ❌ Create multiple releases hoping one will work
+
+---
+
+## Resources
+
+- **GitHub Blog:** Immutable Releases announcement
+- **GitHub Docs:** Managing releases in a repository
+- **TYPO3 TER:** Extension publishing requirements


### PR DESCRIPTION
## Summary

Critical knowledge for release management learned from painful experience with rte_ckeditor_image where **5 version numbers (v13.1.0-v13.1.4) were permanently blocked** due to repeated release deletion attempts.

## Changes

### SKILL.md
- Added **GitHub Release Management** to expertise areas
- Added reference to new `github-releases.md`
- Added complete **GitHub Immutable Releases** section with:
  - Explanation of the security feature (GA October 2024)
  - Correct release sequence (version update FIRST, then release)
  - Pre-release checklist
  - Recovery procedures

### references/github-releases.md (NEW)
Complete reference documentation:
- Immutable Releases behavior and consequences
- Release sequence patterns (TYPO3, npm, Python)
- Pre-release validation (CI workflow snippet)
- Recovery procedures for failed publishes
- Best practices do/don't list

## Why This Matters

**GitHub Immutable Releases cannot be disabled.** Once you delete a release, that tag name is blocked FOREVER.

The correct sequence is:
1. Update version in source files FIRST
2. Merge to main
3. VERIFY version is correct
4. THEN create release

Getting this wrong means:
- Blocked version numbers that can never be used
- Skipped versions in your release history
- Confusion for users about "missing" versions

## Real-World Example

```
❌ v13.1.0 - TER publish failed (strict_types), deleted release → BLOCKED
❌ v13.1.1 - Created before updating version → BLOCKED  
❌ v13.1.2 - Created before merging version update → BLOCKED
❌ v13.1.3 - Same mistake → BLOCKED
❌ v13.1.4 - Version mismatch again → BLOCKED
✅ v13.1.5 - Finally got the sequence right
```