### PR TITLE
feat: add CI annotations to pre-merge checklist

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -603,7 +603,7 @@ gh pr view NUMBER --json \
 # statusCheckRollup: all SUCCESS
 
 # Check for CI annotations (warnings that don't fail the check)
-gh api "repos/OWNER/REPO/commits/SHA/check-runs" \
+gh api "repos/{owner}/{repo}/commits/SHA/check-runs" \
   --jq '.check_runs[] | select(.output.annotations_count > 0) | {name: .name, annotations: .output.annotations_count}'
 ```
 


### PR DESCRIPTION
## Summary
- Add "No CI annotations" to the pre-merge checklist in pull-request-workflow.md
- Add API command to check for annotations programmatically
- Add explanatory note about how CI checks can pass while emitting invisible warning annotations

Learned from [netresearch/go-cron#322](https://github.com/netresearch/go-cron/pull/322) where actionlint/shellcheck warnings were invisible in the PR summary but present as job annotations.

## Test plan
- [ ] Markdown renders correctly
- [ ] API command is copy-pasteable