### PR TITLE
fix: align SKILL.md description with quality standard

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, managing PR review threads, merging PRs with signed commits, or integrating Git with CI/CD."
+description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, managing PR review threads, merging PRs with signed commits, handling merge conflicts, or integrating Git with CI/CD."
 ---
 
 # Git Workflow Skill

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Agent Skill: Git workflow best practices for teams and CI/CD. This skill should be used when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, managing PR review threads, merging PRs with signed commits, handling merge conflicts, or integrating Git with CI/CD. By Netresearch."
+description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, managing PR review threads, merging PRs with signed commits, or integrating Git with CI/CD."
 ---
 
 # Git Workflow Skill


### PR DESCRIPTION
## Summary
- Fix SKILL.md description to use "Use when..." trigger format
- Remove "Agent Skill:" prefix and "By Netresearch." suffix
- Remove workflow summaries from description

Addresses netresearch/claude-code-marketplace#32