### PR TITLE
feat: add critical-rules, PR reference expansion, and Claude Code hook recipes

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -72,9 +72,9 @@ Install: lefthook.yml -> `lefthook install` | captainhook.json -> `composer inst
 
 ## Critical Release Rules
 
-1. **Immutable releases**: Deleted GitHub releases block tag names PERMANENTLY. Never delete releases to "fix" issues -- bump version instead.
-2. **Multi-branch releases**: Always use `--latest=false` when releasing from non-default branches (LTS, maintenance, hotfix).
-3. **Pre-release checklist**: Version updated in source files, CI passes, CHANGELOG updated, `git pull` on main -- verify BEFORE `gh release create`.
+1. **Immutable releases**: Deleted releases permanently block tag reuse; bump version instead.
+2. **Multi-branch releases**: Use `--latest=false` from non-default branches.
+3. **Pre-release**: Version bumped, CI green, CHANGELOG updated, `git pull` BEFORE `gh release create`.
 
 ## PR Merge Requirements
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -38,6 +38,7 @@ Load references on demand based on the task at hand:
 | `references/advanced-git.md` | Rebase, cherry-pick, bisect, stash, worktrees, reflog, submodules, recovery |
 | `references/github-releases.md` | Release management, immutable releases, `--latest=false`, multi-branch |
 | `references/git-hooks-setup.md` | Hook frameworks, detection, recommended hooks per stage |
+| `references/claude-code-hooks.md` | Claude Code `settings.json` hooks — merge gate, cache-path rejection, auto-lint |
 | `references/code-quality-tools.md` | shellcheck, shfmt, git-absorb, difftastic |
 
 ## Conventional Commits

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -14,6 +14,17 @@ allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 
 Expert patterns for Git version control: branching, commits, collaboration, and CI/CD.
 
+## Critical Rules (Non-Negotiable)
+
+1. **No direct push to main** — always open a PR.
+2. **No merge before all review threads are resolved** — run the merge gate in `references/pull-request-workflow.md`.
+3. **No squash unless user asked** — atomic commits preserved; keeps GPG signatures and bisection.
+4. **No "tested/verified/working" without pasted command output** — if you cannot run the check, say so.
+5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree. Verify `pwd` first.
+6. **Force-push only with `--force-with-lease`** — never plain `--force`.
+
+See `references/pull-request-workflow.md` for the merge-gate command, atomic-commit guidance, and review-thread SHA-citation pattern.
+
 ## Reference Files
 
 Load references on demand based on the task at hand:

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -18,6 +18,8 @@ Merge carefully — read the existing `hooks:` block, add to arrays, never repla
 
 Blocks any `gh pr merge` invocation that would merge a PR with unresolved threads or missing approval.
 
+Because the merge-gate logic is non-trivial, keep it as an external script rather than inline JSON. Install `scripts/merge-gate.sh` and reference it:
+
 ```json
 {
   "hooks": {
@@ -28,7 +30,7 @@ Blocks any `gh pr merge` invocation that would merge a PR with unresolved thread
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "jq -r '.tool_input.command' | awk 'match($0, /gh pr merge[[:space:]]+([0-9]+)/, a) {print a[1]; exit}' | { read -r PR; [ -z \"$PR\" ] && exit 0; STATE=$(gh pr view \"$PR\" --json reviewDecision,mergeStateStatus,reviewThreads 2>/dev/null || echo '{}'); UNRES=$(echo \"$STATE\" | jq '[.reviewThreads.nodes[]? | select(.isResolved==false)] | length'); DEC=$(echo \"$STATE\" | jq -r '.reviewDecision // \"null\"'); MSS=$(echo \"$STATE\" | jq -r '.mergeStateStatus // \"null\"'); if [ \"$UNRES\" -gt 0 ] || [ \"$DEC\" != \"APPROVED\" ] || [ \"$MSS\" != \"CLEAN\" ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"merge-gate fail: unresolved=$UNRES, review=$DEC, mergeState=$MSS\\\"}}\"; fi; }"
+            "command": "~/.claude/hooks/merge-gate.sh"
           }
         ]
       }
@@ -37,7 +39,47 @@ Blocks any `gh pr merge` invocation that would merge a PR with unresolved thread
 }
 ```
 
-The hook runs the `gh pr view` gate and denies the tool call if any gate fails. The reason string surfaces in the permission prompt.
+`~/.claude/hooks/merge-gate.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Reads the Claude Code hook payload on stdin; emits a PreToolUse deny if the
+# target PR has unresolved review threads, pending/rejected review, or a
+# non-CLEAN merge state.
+set -euo pipefail
+CMD=$(jq -r '.tool_input.command // ""')
+
+# Extract PR identifier. Supports the three forms that cover all real usage:
+#   gh pr merge 123
+#   gh pr merge --auto 123
+#   gh pr merge https://github.com/owner/repo/pull/123
+#   gh pr merge owner/repo#123
+PR=""; REPO_FLAG=()
+if [[ "$CMD" =~ gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+(--[a-z-]+[[:space:]]+)*([0-9]+)([[:space:]]|$) ]]; then
+  PR="${BASH_REMATCH[2]}"
+elif [[ "$CMD" =~ gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+(--[a-z-]+[[:space:]]+)*https?://github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  PR="${BASH_REMATCH[3]}"; REPO_FLAG=(--repo "${BASH_REMATCH[2]}")
+elif [[ "$CMD" =~ gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+(--[a-z-]+[[:space:]]+)*([^/[:space:]]+/[^#[:space:]]+)#([0-9]+) ]]; then
+  PR="${BASH_REMATCH[3]}"; REPO_FLAG=(--repo "${BASH_REMATCH[2]}")
+fi
+
+# Could not parse a PR id — let the call through rather than false-positive block.
+[[ -z "$PR" ]] && exit 0
+
+STATE=$(gh pr view "$PR" "${REPO_FLAG[@]}" \
+  --json reviewDecision,mergeStateStatus,reviewThreads 2>/dev/null) || exit 0
+UNRES=$(echo "$STATE" | jq '[.reviewThreads.nodes[]? | select(.isResolved==false)] | length')
+DEC=$(echo "$STATE" | jq -r '.reviewDecision // "null"')
+MSS=$(echo "$STATE" | jq -r '.mergeStateStatus // "null"')
+
+if [[ "$UNRES" -gt 0 || "$DEC" != "APPROVED" || "$MSS" != "CLEAN" ]]; then
+  jq -cn \
+    --arg r "merge-gate fail: unresolved=$UNRES, review=$DEC, mergeState=$MSS" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+fi
+```
+
+The hook denies `gh pr merge` when any of: review threads unresolved, `reviewDecision != APPROVED`, or `mergeStateStatus != CLEAN`. It parses the three PR-reference forms `gh pr merge` accepts (plain number, full URL, `owner/repo#N`); if parsing fails, the hook allows the call rather than producing false-positive denies.
 
 ## Recipe 2: Reject Edits to Installed Cache Paths
 

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -1,0 +1,155 @@
+# Claude Code Hooks for Workflow Enforcement
+
+Ready-to-drop `settings.json` hook recipes that enforce the critical rules from `SKILL.md` at tool-invocation time. These run in the Claude Code harness, not in git — they catch violations before the command executes.
+
+For git-side hooks (pre-commit, pre-push), see `references/git-hooks-setup.md` instead.
+
+## Where to put these
+
+| Scope | File | When to use |
+|-------|------|-------------|
+| Personal, all projects | `~/.claude/settings.json` | Enforce your own rules everywhere |
+| Team, committed to repo | `.claude/settings.json` | Enforce team rules for this project |
+| Personal, one project | `.claude/settings.local.json` | Overrides for this project only |
+
+Merge carefully — read the existing `hooks:` block, add to arrays, never replace wholesale.
+
+## Recipe 1: Block `gh pr merge` When Review Threads Are Open
+
+Blocks any `gh pr merge` invocation that would merge a PR with unresolved threads or missing approval.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr merge *)",
+            "command": "jq -r '.tool_input.command' | awk 'match($0, /gh pr merge[[:space:]]+([0-9]+)/, a) {print a[1]; exit}' | { read -r PR; [ -z \"$PR\" ] && exit 0; STATE=$(gh pr view \"$PR\" --json reviewDecision,mergeStateStatus,reviewThreads 2>/dev/null || echo '{}'); UNRES=$(echo \"$STATE\" | jq '[.reviewThreads.nodes[]? | select(.isResolved==false)] | length'); DEC=$(echo \"$STATE\" | jq -r '.reviewDecision // \"null\"'); MSS=$(echo \"$STATE\" | jq -r '.mergeStateStatus // \"null\"'); if [ \"$UNRES\" -gt 0 ] || [ \"$DEC\" != \"APPROVED\" ] || [ \"$MSS\" != \"CLEAN\" ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"merge-gate fail: unresolved=$UNRES, review=$DEC, mergeState=$MSS\\\"}}\"; fi; }"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook runs the `gh pr view` gate and denies the tool call if any gate fails. The reason string surfaces in the permission prompt.
+
+## Recipe 2: Reject Edits to Installed Cache Paths
+
+Prevents `Write` / `Edit` / `MultiEdit` from targeting `~/.claude/skills/...`, `~/.claude/plugins/cache/...`, or any `.bare/` path — which would be silently clobbered on the next update.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // \"\"' | { read -r P; case \"$P\" in */.claude/skills/*|*/.claude/plugins/cache/*|*/.claude/plugins/marketplaces/*|*/.bare/*) echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"cache path rejected: $P — edit the source worktree instead\\\"}}\";; esac; }"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Recipe 3: Warn on Unauthorized Squash
+
+Does not block — just emits a warning. Squash is legitimate on repos with a squash policy; full blocking would be too noisy. The warning is enough to prompt the user to confirm intent.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr merge *)",
+            "command": "jq -r '.tool_input.command' | grep -qE -- '--squash\\b' && echo '{\"systemMessage\":\"⚠ squash merge requested — confirm the repo uses squash policy; default is atomic commits\"}' || true"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Recipe 4: Auto-Lint Go Files After Write/Edit
+
+Runs `golangci-lint` on the file's directory after any write. Silent-success; logs only on failure.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // \"\"' | { read -r F; [ -z \"$F\" ] && exit 0; case \"$F\" in *.go) cd \"$(dirname \"$F\")\" && golangci-lint run --fast 2>&1 | head -40 || true;; esac; } 2>/dev/null"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Swap `golangci-lint` for your project's linter of choice. For PHP: `vendor/bin/php-cs-fixer fix --dry-run -- "$F"`. For JS/TS: `bunx eslint "$F"`.
+
+## Recipe 5: Sentinel on "Verified" Claims Without Tool Output
+
+Experimental — uses a `prompt` hook to audit assistant messages declaring pass/verified. Only runs on Stop events (end of assistant turn).
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check the just-ended assistant turn. If it contains any of: 'verified', 'tested', 'all green', 'tests pass', 'should work now', 'try again' — AND no Bash/Read tool result in the same turn shows actual command output substantiating the claim — emit a systemMessage warning. Otherwise stay silent.\n\n$ARGUMENTS"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This is a soft guardrail — the hook can't block a past message, only flag it to the user. Useful as a "you said tested but didn't run anything" reminder.
+
+## Deploying Hooks
+
+After editing `settings.json`:
+
+```bash
+# Validate JSON syntax first — broken JSON silently disables ALL settings
+jq -e '.hooks' .claude/settings.json
+
+# Reload config — open and close the /hooks menu in Claude Code, or restart
+```
+
+The settings watcher only picks up new hook files if `.claude/` existed at session start. If you created `.claude/settings.json` during a session, open `/hooks` once to reload.
+
+## Anti-Patterns
+
+| Anti-pattern | Why wrong | Fix |
+|--------------|-----------|-----|
+| Using `xargs` on stdin JSON | xargs splits on spaces; breaks paths with spaces | `{ read -r F; ... "$F"; }` pattern |
+| Forgetting `2>/dev/null || true` on PostToolUse | Hook failure pollutes transcript | Wrap non-blocking hooks |
+| `Write|Edit` matcher without file-path extraction | Hook runs on wrong files | `jq -r '.tool_input.file_path'` |
+| Blocking hooks that hit flaky services | One GitHub-API outage blocks all merges | Soft-fail: warn instead of deny for infra-dependent gates |
+| Per-hook large shell scripts inline in JSON | Unreadable, un-testable | Keep inline ≤3 lines; call external script for more |

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -209,6 +209,80 @@ Nice catch handling the edge case where the array might be empty!
 - [ ] CHANGELOG entry added
 ```
 
+## Atomic Commits (Default — No Squash Unless Asked)
+
+**The project default is atomic commits preserved end-to-end.** Squash is destructive: it loses GPG signatures, collapses bisection granularity, and destroys narrative. Never squash unless the user asks for it in this task.
+
+### What "atomic" means
+
+- One commit = one self-contained logical change
+- Each commit builds and passes tests independently
+- No "WIP", "fixup", or "oops" commits in final history — rebase them away before merge
+- Mixed changes get split (`git add -p`, `git commit --fixup`, `git rebase --autosquash`)
+
+### Preferred merge strategies (in order)
+
+1. **Rebase + merge commit** (`gh pr merge --merge` after `git rebase origin/main`): linear feature history with an explicit merge point. Preserves signatures. This is the default for Netresearch repos.
+2. **Fast-forward merge** (local `git merge --ff-only`): when signed commits are required AND only rebase is allowed (see "Signed Commits with Rebase Merge" below).
+3. **Squash**: only when the user explicitly asks.
+
+### If you catch yourself typing `--squash`
+
+Stop. Re-read the task. Did the user say "squash"? If not, use `--merge` or `--rebase` (with the signed-commits caveat). The correction "no squash! atomic commits!" is a repeat interruption — prevent it by defaulting to merge-commit.
+
+## Review Thread Resolution (SHA Citation Required)
+
+**Never reply with "Addressed" or "Fixed" without citing the resolving commit SHA.** Review threads are resolved on GitHub's side, not by agent assertion.
+
+### Correct reply pattern
+
+```bash
+# After pushing the fix
+SHA=$(git rev-parse HEAD)
+
+gh api graphql -f query='
+  mutation($body: String!, $id: ID!) {
+    addPullRequestReviewThreadReply(input: {body: $body, pullRequestReviewThreadId: $id}) {
+      comment { id }
+    }
+  }' \
+  -f body="Fixed in ${SHA:0:7} — <1-sentence explanation of what changed and why>." \
+  -f id="PRRT_xxx"
+
+# Then resolve the thread
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_xxx"}) { thread { isResolved } } }'
+```
+
+### Refusing the lazy pattern
+
+These replies are banned:
+- `Addressed` (no SHA, no explanation)
+- `Fixed — merged` (merged what? where?)
+- `Done` (done how?)
+- `Good point, updated` (updated what, in which commit?)
+
+Every resolving reply must include: commit SHA (7+ chars), one sentence of what changed, one sentence of why if not obvious from the diff.
+
+### Verifying thread state from GitHub, not memory
+
+Before declaring a PR review-complete, re-fetch thread state from GitHub. Never trust your own belief about what you resolved:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+        }
+      }
+    }
+  }' -f owner=OWNER -f repo=REPO -F pr=NUMBER \
+  | jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, first_comment: .comments.nodes[0].body[:80]}'
+```
+
+If that returns any rows, the PR is not merge-ready.
+
 ## Merge Strategies
 
 ### Merge Commit


### PR DESCRIPTION
## Summary

Adds non-negotiable workflow rules and operational hook recipes derived from recurring high-cost friction patterns (see also sibling PRs across the skill-repo fleet).

## Changes

### `skills/git-workflow/SKILL.md`
- New **Critical Rules (Non-Negotiable)** section listing six rules: no direct push to main, no merge before threads resolved, no squash unless asked, no unverified success claims, no cache-path edits, force-push only with \`--force-with-lease\`.

### `skills/git-workflow/references/pull-request-workflow.md`
- **Atomic Commits (Default — No Squash Unless Asked)** — strategy order, what \"atomic\" means, the \"if you catch yourself typing --squash\" check.
- **Review Thread Resolution (SHA Citation Required)** — correct reply pattern, banned lazy replies (\`Addressed\`, \`Fixed — merged\`, etc.), GitHub-side verification pattern that re-fetches thread state.

### `skills/git-workflow/references/claude-code-hooks.md` (new)
- Recipe 1: Block \`gh pr merge\` when review threads unresolved / mergeState not CLEAN
- Recipe 2: Reject Write/Edit/MultiEdit on installed skill/plugin cache paths
- Recipe 3: Warn (not block) on \`--squash\` to allow squash-policy repos
- Recipe 4: Auto-lint Go files on PostToolUse (template adaptable to PHP/JS)
- Recipe 5: Stop-hook sentinel for \"verified/tested\" claims without tool output
- Scope/file-location table, deployment caveats, anti-patterns

## Why

These rules codify the recurring process violations that have caused force-pushes, follow-up PRs, manual cache restorations, and untested-fix breakage in prior sessions. Making them explicit at the skill level — rather than re-teaching per project — closes the loop.

## Test plan

- [ ] \`scripts/validate-skill.sh\` passes (SKILL.md ≤ 500 words)
- [ ] Reference cross-links resolve
- [ ] No breaking changes to existing sections