### PR TITLE
docs: rename 'Merge Requirements Checklist' to 'Merge Gate'

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -663,28 +663,29 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 ### Merge-Gate Command
 
 ```bash
-# Single command that surfaces every gate input
-gh pr view NUMBER --json \
-  reviewDecision,\
-  mergeStateStatus,\
-  mergeable,\
-  statusCheckRollup,\
-  reviewThreads
+# Primary gate — single gh pr view that returns every PR-level input.
+# --json takes a comma-separated field list with no spaces, so keep the
+# whole list on one line.
+gh pr view NUMBER --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup,reviewThreads
 
 # Merge-ready requires ALL of:
-#   reviewDecision      == "APPROVED"
-#   mergeStateStatus    == "CLEAN"
-#   mergeable           == "MERGEABLE"
-#   every statusCheckRollup[].conclusion == "SUCCESS"
-#   every reviewThreads.nodes[].isResolved == true
+#   reviewDecision                            == "APPROVED"
+#   mergeStateStatus                          == "CLEAN"
+#   mergeable                                 == "MERGEABLE"
+#   every statusCheckRollup[].conclusion      == "SUCCESS"
+#   every reviewThreads[].isResolved          == true   # gh flattens the GraphQL edges/nodes
+```
 
-# Check for CI annotations (warnings that don't fail the check but still
-# need addressing — actionlint/shellcheck reviewdog, CodeQL deprecations)
+The PR-level gate above covers review decision, merge state, required checks, and thread resolution in one response. A second check is needed for CI annotations (warnings — reviewdog / actionlint / CodeQL deprecations — that don't fail their check but still need addressing). These are a commit-level property, not a PR-level one:
+
+```bash
 gh api "repos/{owner}/{repo}/commits/SHA/check-runs" \
   --jq '.check_runs[] | select(.output.annotations_count > 0) | {name: .name, annotations: .output.annotations_count}'
 ```
 
-For automated enforcement at tool-invocation time, see the `merge-gate.sh` hook recipe in `references/claude-code-hooks.md` — it runs this same command via a `PreToolUse` hook and denies `gh pr merge` calls that don't clear every gate.
+> **Important:** CI annotations are invisible in the PR summary view but visible in the job detail "Annotations" section on the Files Changed tab. Always check for annotations before declaring a PR clean.
+
+For automated enforcement at tool-invocation time, see the `merge-gate.sh` hook recipe in `references/claude-code-hooks.md`. The hook enforces the **runtime-checkable subset** — `reviewDecision`, `mergeStateStatus`, and unresolved thread count — which covers the most common block reasons. Signed-commits and CI-annotations checks are not enforced by the hook (annotations in particular require the commit-level API call above); rely on the repo's branch-protection rules and local pre-commit hook for those.
 
 > **Important:** CI checks can PASS while emitting warning annotations (e.g., actionlint/shellcheck via reviewdog, CodeQL deprecation notices). These are invisible in the PR summary view but visible in the job detail "Annotations" section. Always check for annotations before declaring a PR clean.
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -647,39 +647,44 @@ gh api graphql -f query='
   }' -f owner=OWNER -f repo=REPO -F pr=NUMBER
 ```
 
-## Merge Requirements Checklist
+## Merge Gate
 
-Before merging any PR, verify ALL requirements:
+Before merging any PR, run this gate. If any check fails, stop and fix the underlying issue rather than overriding.
 
 ### Pre-Merge Checklist
 
-- [ ] **All review threads resolved** - No unresolved conversations
-- [ ] **Copilot review complete** (if assigned) - Wait for automated review
-- [ ] **Branch rebased on target** - No merge commits in PR branch
-- [ ] **All CI checks pass** - Green status on all required checks
-- [ ] **No CI annotations** - Check job annotations, not just pass/fail (see below)
-- [ ] **Signed commits** - All commits in PR are signed
+- [ ] **All review threads resolved** — no unresolved conversations
+- [ ] **Copilot review complete** (if assigned) — wait for automated review
+- [ ] **Branch rebased on target** — no stray merge commits in PR branch
+- [ ] **All CI checks pass** — green status on every required check
+- [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
+- [ ] **Signed commits** — every commit in the PR is signed
 
-### Check Programmatically
+### Merge-Gate Command
 
 ```bash
-# Get PR merge requirements status
+# Single command that surfaces every gate input
 gh pr view NUMBER --json \
   reviewDecision,\
   mergeStateStatus,\
   mergeable,\
-  statusCheckRollup
+  statusCheckRollup,\
+  reviewThreads
 
-# Expected for merge-ready:
-# reviewDecision: APPROVED
-# mergeStateStatus: CLEAN
-# mergeable: MERGEABLE
-# statusCheckRollup: all SUCCESS
+# Merge-ready requires ALL of:
+#   reviewDecision      == "APPROVED"
+#   mergeStateStatus    == "CLEAN"
+#   mergeable           == "MERGEABLE"
+#   every statusCheckRollup[].conclusion == "SUCCESS"
+#   every reviewThreads.nodes[].isResolved == true
 
-# Check for CI annotations (warnings that don't fail the check)
+# Check for CI annotations (warnings that don't fail the check but still
+# need addressing — actionlint/shellcheck reviewdog, CodeQL deprecations)
 gh api "repos/{owner}/{repo}/commits/SHA/check-runs" \
   --jq '.check_runs[] | select(.output.annotations_count > 0) | {name: .name, annotations: .output.annotations_count}'
 ```
+
+For automated enforcement at tool-invocation time, see the `merge-gate.sh` hook recipe in `references/claude-code-hooks.md` — it runs this same command via a `PreToolUse` hook and denies `gh pr merge` calls that don't clear every gate.
 
 > **Important:** CI checks can PASS while emitting warning annotations (e.g., actionlint/shellcheck via reviewdog, CodeQL deprecation notices). These are invisible in the PR summary view but visible in the job detail "Annotations" section. Always check for annotations before declaring a PR clean.
 


### PR DESCRIPTION
## Summary

SKILL.md's Critical Rule 2 tells readers to "run the merge gate in \`references/pull-request-workflow.md\`", but the reference had no section literally titled "Merge Gate" — it was called "Merge Requirements Checklist". Reviewer flagged the inconsistency on PR #23.

## Changes

- `references/pull-request-workflow.md`:
  - Section heading renamed: `## Merge Requirements Checklist` → `## Merge Gate`
  - Subsection `### Check Programmatically` → `### Merge-Gate Command`
  - \`gh pr view\` query now also fetches \`reviewThreads\`; merge-ready criteria spelled out inline (reviewDecision APPROVED + mergeStateStatus CLEAN + mergeable MERGEABLE + all checks SUCCESS + all threads isResolved)
  - Cross-link added to \`references/claude-code-hooks.md\` \`merge-gate.sh\` hook for automated enforcement

## Why

Terminology consistency. The Critical Rules, the hooks reference, and the gate check now all use the same name.

## Test plan

- [x] \`scripts/validate-skill.sh\` passes (SKILL.md 482 words)
- [x] Cross-links resolve to existing sections
- [x] No breaking changes to surrounding sections