### PR TITLE
fix(refs): address Copilot review followups from #26

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -303,7 +303,7 @@ git worktree prune
 
 **One directory per branch; never switch branches in the same folder.**
 
-Rationale: IDEs that index the tree (gopls, Intellij, VS Code) choke on in-place branch switches, and running parallel work on feature branches without losing the main-branch state is painful. Using a bare repo with per-branch subdirectories gives you parallel checkouts, cheap hotfix spin-ups, and a main checkout that's never "dirty because I was exploring".
+Rationale: IDEs that index the tree (gopls, IntelliJ, VS Code) choke on in-place branch switches, and running parallel work on feature branches without losing the main-branch state is painful. Using a bare repo with per-branch subdirectories gives you parallel checkouts, cheap hotfix spin-ups, and a main checkout that's never "dirty because I was exploring".
 
 ```
 /projects/<repo>/
@@ -313,7 +313,7 @@ Rationale: IDEs that index the tree (gopls, Intellij, VS Code) choke on in-place
 └── bugfix-y/       # optional bugfix branch worktree
 ```
 
-**Setup a new project this way:**
+**Set up a new project this way:**
 
 ```bash
 cd ~/projects
@@ -335,7 +335,7 @@ cd feature-x
 # ... edit, commit, push ...
 cd ..
 git -C .bare worktree list          # audit trail of what's checked out
-git -C .bare worktree remove feature-x   # clean up when the PR merges
+git -C .bare worktree remove ../feature-x   # clean up when the PR merges
 ```
 
 When removing a worktree leaves a dangling branch reference (e.g., after deleting the physical directory manually), `git worktree prune` in `.bare/` cleans up the metadata.

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -446,7 +446,7 @@ Run every commit with both flags explicit:
 git commit -S --signoff -m "feat: add login endpoint"
 ```
 
-**Why explicit `-S`.** Even with `commit.gpgsign=true` set globally, signing can silently fail in subprocess environments where the SSH agent isn't accessible. An explicit `-S` makes that failure visible instead of shipping an unsigned commit and finding out when branch protection rejects the push.
+**Why explicit `-S`.** Even with `commit.gpgsign=true` set globally, signing can silently fail in subprocess environments where the signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`) or its pinentry prompt isn't accessible. An explicit `-S` makes that failure visible instead of shipping an unsigned commit and finding out when branch protection rejects the push.
 
 **Why `--signoff`.** Adds the `Signed-off-by:` trailer. Required for DCO compliance on any repo that has the DCO check enabled (most netresearch repos do).
 
@@ -459,7 +459,9 @@ git config user.email
 
 **Never amend a commit with pre-commit-hook failures.** If the pre-commit hook fails, the commit **did not happen**. Running `git commit --amend` then modifies the PREVIOUS commit, which can destroy work. Fix the hook issue, re-stage, and create a new commit.
 
-**Never skip hooks** unless explicitly told to. `--no-verify`, `--no-gpg-sign`, and `-c commit.gpgsign=false` all bypass enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
+**Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
+
+**Never bypass signing** unless explicitly told to. `--no-gpg-sign` and `-c commit.gpgsign=false` disable commit signing; the result will fail branch-protection or policy checks that require signed commits later.
 
 ## Atomic Commits
 


### PR DESCRIPTION
Follow-up to Copilot review comments on the bare-worktree + signed-commits refs merged in #26:

## Changes

**`advanced-git.md`:**
- `Intellij` -> `IntelliJ` (correct product capitalization)
- `**Setup a new project this way:**` -> `**Set up a new project this way:**` (verb form)
- Fix worktree-remove path: `git -C .bare worktree remove ../feature-x` so the path targets the worktree that the earlier `worktree add ../feature-x` actually created (a relative `feature-x` from `.bare/` would miss it)

**`commit-conventions.md`:**
- Broaden the `-S` rationale from 'SSH agent' to 'signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`)' — the previous wording conflated the two. GPG-only users have `gpg-agent` + pinentry; only GPG-SSH users see SSH-agent involvement.
- Split 'Never skip hooks' into two rules: hooks (`--no-verify`) and signing (`--no-gpg-sign` / `commit.gpgsign=false`). They were incorrectly bundled — `--no-gpg-sign` disables signing, it does not bypass hooks.

## Thread IDs resolved after merge

- PRRT_kwDOQoBsD858Z5FF (worktree path)
- PRRT_kwDOQoBsD858Z5Fg (signing agent)
- PRRT_kwDOQoBsD858Z5Fv (hooks vs signing)
- PRRT_kwDOQoBsD858Z5F4 (IntelliJ)
- PRRT_kwDOQoBsD858Z5GC (Set up)