### PR TITLE
fix(commit-conventions): address Copilot second-sweep finding from #27

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -446,7 +446,7 @@ Run every commit with both flags explicit:
 git commit -S --signoff -m "feat: add login endpoint"
 ```
 
-**Why explicit `-S`.** Even with `commit.gpgsign=true` set globally, signing can silently fail in subprocess environments where the signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`) or its pinentry prompt isn't accessible. An explicit `-S` makes that failure visible instead of shipping an unsigned commit and finding out when branch protection rejects the push.
+**Why explicit `-S`.** Git honors `commit.gpgsign=true` only when the global config is actually loaded. Subprocess environments (CI runners, some IDEs, tools that set their own `$HOME` or scrub env) can miss it — you get an unsigned commit with no error, because from git's perspective signing was never requested. An explicit `-S` pins the requirement to the invocation: if the signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`) or its pinentry prompt is unreachable, git aborts the commit with an error instead of silently shipping unsigned. You find out now, not when branch protection rejects the push later.
 
 **Why `--signoff`.** Adds the `Signed-off-by:` trailer. Required for DCO compliance on any repo that has the DCO check enabled (most netresearch repos do).
 


### PR DESCRIPTION
Follow-up to a Copilot comment on #27 (the follow-up to #26).

## Changes

**`commit-conventions.md`:** rewrite the `-S` rationale. The prior phrasing said signing could silently fail when `commit.gpgsign=true` is set — that's inaccurate: git aborts noisily in that case. The real failure mode is that **global config isn't loaded** (subprocess env isolation, different `$HOME`, env scrubbing), so git doesn't realize signing was requested and creates an unsigned commit with no error. Explicit `-S` pins the requirement to the invocation so the 'config not loaded' case becomes visible.

## Thread ID resolved after merge

- PRRT_kwDOQoBsD858lFR9