### PR TITLE
fix(commit-conventions): refine -S rationale per #28 review

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -446,7 +446,7 @@ Run every commit with both flags explicit:
 git commit -S --signoff -m "feat: add login endpoint"
 ```
 
-**Why explicit `-S`.** Git honors `commit.gpgsign=true` only when the global config is actually loaded. Subprocess environments (CI runners, some IDEs, tools that set their own `$HOME` or scrub env) can miss it — you get an unsigned commit with no error, because from git's perspective signing was never requested. An explicit `-S` pins the requirement to the invocation: if the signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`) or its pinentry prompt is unreachable, git aborts the commit with an error instead of silently shipping unsigned. You find out now, not when branch protection rejects the push later.
+**Why explicit `-S`.** Git honors `commit.gpgsign=true` only when the configuration is actually loaded. Subprocess environments (CI runners, some IDEs, tools that set their own `$HOME` or scrub env) can miss the global config — and without the config, git doesn't even *try* to sign. The commit records unsigned with no error, because from git's perspective signing was never requested. Explicit `-S` pins the requirement to the invocation: now git *always* attempts to sign, and if the signing agent (gpg-agent, or ssh-agent when using `gpg.format=ssh`) or its pinentry prompt is unreachable, the commit aborts noisily. You find out now, not when branch protection rejects the push later.
 
 **Why `--signoff`.** Adds the `Signed-off-by:` trailer. Required for DCO compliance on any repo that has the DCO check enabled (most netresearch repos do).
 


### PR DESCRIPTION
Further Copilot review on #28 asked to distinguish two failure modes unambiguously. Applied.

## Change

Rewrite the second half of 'Why explicit `-S`' so the two cases are explicit:
- **Without loaded config**: git doesn't even attempt to sign. Commit records unsigned silently.
- **With `-S`**: git always attempts. A missing signing agent or unreachable pinentry aborts noisily.

Also use 'records unsigned' (commit-time) instead of 'ships unsigned' (push-time).

## Thread resolved after merge

PRRT_kwDOQoBsD858lNtu