### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ composer require netresearch/git-workflow-skill
 ```
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
+
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/git-workflow-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Usage
 
 This skill is automatically triggered when:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@netresearch/git-workflow-skill",
+  "version": "0.0.0-source",
+  "description": "Netresearch AI skill for Git branching strategies, Conventional Commits and CI/CD pipelines.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/git-workflow-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/git-workflow-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/git-workflow-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "git",
+    "git-workflow",
+    "conventional-commits",
+    "ci-cd",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/git-workflow/SKILL.md",
+  "files": [
+    "skills/git-workflow/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

```bash
npm install --save-dev \
  @netresearch/agent-skill-coordinator \
  github:netresearch/git-workflow-skill
```

After install, the coordinator's `postinstall` walks `node_modules`, finds this package via `aiAgentSkill: skills/git-workflow/SKILL.md` (or the `ai-agent-skill` keyword fallback), validates the frontmatter, and writes a `<skills_system>` block into the project's `AGENTS.md`. Same shape as the Composer plugin's output, so any agent that reads either works here unchanged.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing Composer release workflow (which uses `netresearch/skill-repo-skill/.github/workflows/release.yml`). A real npm version would be set at publish time; until then, `0.0.0-source` is the standard "this manifest exists for tooling, not as a release marker" placeholder.

## Test plan
- [x] `npm pack --dry-run` produces a 46 kB tarball with skills/git-workflow/, both LICENSE files, README.md
- [x] Manual install of coordinator + this package's tarball in a tmp consumer project produces a clean AGENTS.md with the `git-workflow` skill listed and readable via `npx agent-skills read git-workflow`
- [x] No new toolchain — package.json is metadata-only; no JS code, no Node deps to maintain

## Sibling PR
- Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (released as `@netresearch/agent-skill-coordinator@0.1.1`)