### PR TITLE
fix(checkpoints): clarify GW-10 enforce_admins as optional policy

### DIFF
--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -76,9 +76,9 @@ mechanical:
     json_path: ".enforce_admins.enabled"
     severity: info
     desc: >-
-      Branch protection MAY apply to admins too. Org default at netresearch
+      Branch protection may apply to admins too. Org default at Netresearch
       leaves this off so admins keep bypass for emergency response; tighten
-      to true only if your policy requires admin-bind.
+      to true only if your policy requires admin enforcement.
 
   # === SIGNED COMMITS REQUIREMENT ===
   - id: GW-11

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -75,7 +75,10 @@ mechanical:
     endpoint: repos/{owner}/{repo}/branches/main/protection
     json_path: ".enforce_admins.enabled"
     severity: info
-    desc: "Branch protection should apply to admins too"
+    desc: >-
+      Branch protection MAY apply to admins too. Org default at netresearch
+      leaves this off so admins keep bypass for emergency response; tighten
+      to true only if your policy requires admin-bind.
 
   # === SIGNED COMMITS REQUIREMENT ===
   - id: GW-11


### PR DESCRIPTION
## Summary
- GW-10 was already `severity=info`, but the description read as a recommendation without explaining why netresearch's org default leaves it off (admins keep bypass for emergency response).
- Updated description to make the policy choice explicit.

## Test plan
- [x] Verified locally with `bash /home/sme/p/automated-assessment-skill/main/skills/automated-assessment/scripts/run-checkpoints.sh --force <this-skill>/checkpoints.yaml /home/sme/p/file-search-skill/main`
- [x] All commits SSH-signed and DCO sign-off present