### PR TITLE
feat(checkpoints): add GW-29 worktree branch-switch guard

### DIFF
--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -277,7 +277,7 @@ llm_reviews:
 
   # === BARE-WORKTREE LAYOUT ===
   - id: GW-29
-    domain: branching
+    domain: git-workflow
     severity: warning
     desc: "Bare-worktree layout: never switch branches in an existing worktree — use `git worktree add`"
     prompt: |
@@ -286,13 +286,20 @@ llm_reviews:
       Standard discovery: `ls -d .bare/ 2>/dev/null && git -C .bare worktree list`.
 
       If the layout is in use, verify the working pattern:
-      1. Recent reflog of any worktree should NOT show `git checkout -b <newbranch>`
-         or `git switch -c <newbranch>` events (those create branches in place).
+      1. Recent reflog of any worktree should NOT show in-place branch switch
+         events such as `checkout: moving from <a> to <b>` or
+         `switch: moving from <a> to <b>` (these are recorded by `git checkout`
+         and `git switch`, including the `-b`/`-c` create-and-switch variants).
       2. New branches should appear as new worktree directories, registered via
          `git worktree add <path> -b <branch>`.
 
-      Pass when no in-place branch creation is found in the last ~50 reflog
-      entries across worktrees. Warn when in-place creation events exist —
+      Use `git reflog show HEAD -n 50` inside each worktree to inspect entries.
+      Note: the reflog records the resulting move, not the CLI flags — so
+      `checkout -b feat/x` and `switch feat/x` both surface as
+      `checkout:`/`switch: moving from … to …` lines.
+
+      Pass when no in-place branch switching is found in the last ~50 reflog
+      entries across worktrees. Warn when in-place switch events exist —
       they violate the convention and produce branches that are confusing to
       reason about (working tree vs branch tip diverge for the original
       worktree's intended branch).

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -274,3 +274,28 @@ llm_reviews:
       Identify release workflows by filename (release, publish) or content (gh release create, semantic-release).
       For each, check for workflow_dispatch trigger.
       Flag missing workflow_dispatch as warning.
+
+  # === BARE-WORKTREE LAYOUT ===
+  - id: GW-29
+    domain: branching
+    severity: warning
+    desc: "Bare-worktree layout: never switch branches in an existing worktree — use `git worktree add`"
+    prompt: |
+      Detect bare-worktree layout: a `.bare/` directory at the repo root
+      AND at least one sibling worktree directory (e.g. `main/`, `feat-*/`).
+      Standard discovery: `ls -d .bare/ 2>/dev/null && git -C .bare worktree list`.
+
+      If the layout is in use, verify the working pattern:
+      1. Recent reflog of any worktree should NOT show `git checkout -b <newbranch>`
+         or `git switch -c <newbranch>` events (those create branches in place).
+      2. New branches should appear as new worktree directories, registered via
+         `git worktree add <path> -b <branch>`.
+
+      Pass when no in-place branch creation is found in the last ~50 reflog
+      entries across worktrees. Warn when in-place creation events exist —
+      they violate the convention and produce branches that are confusing to
+      reason about (working tree vs branch tip diverge for the original
+      worktree's intended branch).
+
+      Skip cleanly (pass) when the repo is a regular clone (`.git/` is a
+      directory, no `.bare/` sibling) — the convention does not apply.


### PR DESCRIPTION
## Summary

Adds a single new LLM-type checkpoint, **GW-29**, that catches a common bare-worktree mistake: switching branches in place inside a worktree dir instead of creating a new worktree.

## Why

The bare-worktree layout (`<project>/.bare/` + sibling worktree dirs like `main/`, `feat-foo/`) is the documented convention in the user's global `~/.claude/CLAUDE.md`:

> NEVER: Switch branches with `git checkout` or `git switch` in a folder
> ALWAYS: Create a NEW FOLDER for each branch using git worktrees

A recent session violated this — `git checkout -b feat/sonarqube-reusable` was run inside the `main/` worktree, creating the branch in place. Had to undo and redo correctly. The 24 existing checkpoints (GW-01..GW-28) don't catch the symptom; GW-29 fills the gap.

## The checkpoint

```yaml
- id: GW-29
  domain: branching
  severity: warning
  desc: "Bare-worktree layout: never switch branches in an existing worktree — use `git worktree add`"
  prompt: |
    Detect bare-worktree layout: a `.bare/` directory at the repo root
    AND at least one sibling worktree directory (e.g. `main/`, `feat-*/`).
    Standard discovery: `ls -d .bare/ 2>/dev/null && git -C .bare worktree list`.

    If the layout is in use, verify the working pattern:
    1. Recent reflog of any worktree should NOT show `git checkout -b <newbranch>`
       or `git switch -c <newbranch>` events (those create branches in place).
    2. New branches should appear as new worktree directories, registered via
       `git worktree add <path> -b <branch>`.

    Pass when no in-place branch creation is found in the last ~50 reflog
    entries across worktrees. Warn when in-place creation events exist —
    they violate the convention and produce branches that are confusing to
    reason about (working tree vs branch tip diverge for the original
    worktree's intended branch).

    Skip cleanly (pass) when the repo is a regular clone (`.git/` is a
    directory, no `.bare/` sibling) — the convention does not apply.
```

## Why `severity: warning` (not error)

Not every Netresearch repo follows the bare-worktree layout. The check skips cleanly when `.bare/` is absent, and only warns (rather than blocks) when it is present — keeping the assessment usable across the heterogeneous repo fleet.

## Notes

- **`domain: branching`** is a new domain string for `llm_reviews` (existing entries use `git-workflow` or `release`). Open to changing it to `git-workflow` if reviewers prefer to avoid introducing a new domain.
- **SKILL.md description left untouched** — it already ends with "...debugging hook-install failures in git **worktrees**." so the trigger keyword is present. The description is also already at 506 chars; expanding further would push it further past the agent-skills 280-char guideline.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open("skills/git-workflow/checkpoints.yaml"))'` parses cleanly.
- `yamllint` with the same default config used by `skill-repo-skill`'s reusable validate workflow: pass.
- Local pre-commit hook (`validate-skill.sh`): 0 errors, 0 warnings.
- Commit signed (ED25519) and signed off; conventional-commit subject.

## Test plan

- [ ] CI Lint job (`netresearch/skill-repo-skill/.github/workflows/validate.yml@main`) green
- [ ] Eval Validation green
- [ ] Reviewer sanity-check on the new `domain: branching` value vs existing domains