### PR TITLE
chore(release): v1.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.13.1"
+  version: "1.14.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
## Release v1.14.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/git-workflow/SKILL.md` frontmatter `metadata.version` from `1.13.1` to `1.14.0`. Picks up eleven commits since `v1.13.1`.

### Highlights since v1.13.1

- `feat`: ship as an npm package via `@netresearch/agent-skill-coordinator` so the skill is consumable from JS/TS toolchains alongside the existing composer install path.
- `feat(checkpoints)`: GW-29 worktree branch-switch guard catches the case where a stale worktree silently anchors a release on an outdated tree. Companion follow-up addresses Copilot review feedback.
- `fix(checkpoints)`: clarify GW-10 `enforce_admins` as an optional policy and address review feedback on its description.
- `docs(pull-request-workflow)`: new "annotations first" diagnosis recipe for CI failures, plus a follow-up review pass on the annotations example.
- `docs`: warn about the `git -C <bare> worktree add` relpath gotcha that resolves paths relative to the bare repo, not `$PWD`.
- `ci(release)`: SLSA provenance permissions, trailing-newline yamllint fix, and drop the deprecated `with:` block + `workflow_dispatch.bump` input.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
