### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.14.0"
+  version: "1.15.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Release **v1.15.0** (minor bump, conventional commits since v1.14.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.15.0.

Changes since v1.14.0:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- - package.json scripts.prepare: invokes pre-commit install --install-hooks
-   if pre-commit is on PATH; silent no-op otherwise. Auto-activates hooks
-   on `npm install`.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- 
- feat: add .pre-commit-config.yaml mirroring CI checks
- docs(branching): add default-branch check and gh-CLI preference
- 
- Migrated from a personal global rules file:
- - check the default branch (gh api ... --jq .default_branch) before operating;

After merge: a signed tag `v1.15.0` on `main` triggers the release workflow.