### PR TITLE
docs(git-workflow): verify AI-reviewer claims against source before acting

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -263,6 +263,15 @@ These replies are banned:
 
 Every resolving reply must include: commit SHA (7+ chars), one sentence of what changed, one sentence of why if not obvious from the diff.
 
+### Verifying AI-reviewer claims before acting
+
+AI reviewers (GitHub Copilot, Gemini Code Assist, SonarCloud) mix correct findings with confident hallucinations. Before applying **or** declining a review comment, verify its load-bearing factual claim against an authoritative source — the framework/library code, official docs, or a quick local probe — not the reviewer's assertion alone.
+
+- **Applying blindly** ships wrong code (e.g. an edit based on a false API claim, which may also fail your own linter/type-checker).
+- **Declining blindly** dismisses real bugs — the same reviewer is often right about the next comment.
+
+Reply citing the evidence either way. When you applied a change, the reply must still carry the commit SHA and the what/why required above (e.g. `Verified against <source>: <fact> — applied in <SHA>, which …`); when you declined, state the source and fact (e.g. `Verified against <source>: <fact> — declining.`). When the suggestion is a code change, run the project's checks (lint, types, tests) on it before resolving, so the reply cites a green result rather than a guess.
+
 ### Verifying thread state from GitHub, not memory
 
 Before declaring a PR review-complete, re-fetch thread state from GitHub. Never trust your own belief about what you resolved:


### PR DESCRIPTION
## Summary

Adds a "Verifying AI-reviewer claims before acting" subsection to
`references/pull-request-workflow.md` (Review Thread Resolution).

AI reviewers (GitHub Copilot, Gemini Code Assist, SonarCloud) mix correct
findings with confident hallucinations. Acting on either without verification
risks shipping wrong code (applying a false-premise suggestion) or dismissing
real bugs (declining a valid one because the same bot was wrong elsewhere). The
guidance: verify each load-bearing factual claim against authoritative source
(framework code, docs, a local probe) before applying or declining, run the
project's checks on suggested code edits before resolving, and cite the
evidence in the reply.

## Changes
- `references/pull-request-workflow.md`: +1 subsection under "Review Thread Resolution".

Doc-only; no version bump (left to the release workflow).
