### PR TITLE
docs(git-workflow): make the merge gate ruleset-aware

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -737,7 +737,7 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 
 - [ ] **All review threads resolved** — no unresolved conversations
 - [ ] **Copilot review complete on the _latest_ commit** (if assigned) — a `copilot_code_review` ruleset re-blocks after every push; see "Rulesets" below
-- [ ] **Rulesets checked** — `gh api repos/{owner}/{repo}/rules/branches/<base>`, not just classic branch protection
+- [ ] **Rulesets checked** — `gh api repos/{owner}/{repo}/rules/branches/BASE`, not just classic branch protection
 - [ ] **Branch rebased on target** — no stray merge commits in PR branch
 - [ ] **All CI checks pass** — green status on every required check
 - [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
@@ -813,7 +813,7 @@ on the latest commit `oid`:
 gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:NUMBER){
   headRefOid
   reviewRequests(first:10){nodes{requestedReviewer{... on Bot{login}}}}
-  reviews(last:5){nodes{author{login} state commit{oid}}}}}}'
+  reviews(last:20){nodes{author{login} state commit{oid}}}}}}'  # last:N must exceed the review count
 # Ready only when: no pending reviewRequests AND the bot's latest review.commit.oid == headRefOid.
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -736,7 +736,8 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 ### Pre-Merge Checklist
 
 - [ ] **All review threads resolved** — no unresolved conversations
-- [ ] **Copilot review complete** (if assigned) — wait for automated review
+- [ ] **Copilot review complete on the _latest_ commit** (if assigned) — a `copilot_code_review` ruleset re-blocks after every push; see "Rulesets" below
+- [ ] **Rulesets checked** — `rules/branches/{branch}`, not just classic branch protection
 - [ ] **Branch rebased on target** — no stray merge commits in PR branch
 - [ ] **All CI checks pass** — green status on every required check
 - [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
@@ -770,6 +771,39 @@ gh api "repos/{owner}/{repo}/commits/SHA/check-runs" \
 For automated enforcement at tool-invocation time, see the `merge-gate.sh` hook recipe in `references/claude-code-hooks.md`. The hook enforces the **runtime-checkable subset** — `reviewDecision`, `mergeStateStatus`, and unresolved thread count — which covers the most common block reasons. Signed-commits and CI-annotations checks are not enforced by the hook (annotations in particular require the commit-level API call above); rely on the repo's branch-protection rules and local pre-commit hook for those.
 
 > **Important:** CI checks can PASS while emitting warning annotations (e.g., actionlint/shellcheck via reviewdog, CodeQL deprecation notices). These are invisible in the PR summary view but visible in the job detail "Annotations" section. Always check for annotations before declaring a PR clean.
+
+### Rulesets: the gate `gh pr view` doesn't show
+
+`mergeStateStatus: BLOCKED` with `reviewDecision: ""`, every check green, and
+every thread resolved almost always means a **repository ruleset** — rulesets
+are evaluated for merge but are invisible to both the merge-gate `gh pr view`
+and the classic `branches/{branch}/protection` API. Don't discover this by
+trial-and-error; fetch the *effective* rules as part of the gate:
+
+```bash
+gh api repos/{owner}/{repo}/rules/branches/{branch} \
+  --jq 'group_by(.type)[] | {type: .[0].type, n: length}'
+```
+
+The common culprit is a `copilot_code_review` rule: it requires a Copilot
+review on the **latest commit**, so any push after Copilot's last review
+re-blocks the PR — and Copilot is **not** re-requested automatically. Re-request
+it explicitly, then re-poll the gate:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/NUMBER/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+```
+
+(`gh pr edit --add-reviewer` rejects the bot login with "Could not resolve
+user"; the REST `requested_reviewers` endpoint is the working path.) Other
+ruleset rules to expect: `required_approving_review_count`,
+`required_review_thread_resolution`, `non_fast_forward`.
+
+> **Front-load the whole picture.** Gather merge state, checks, rulesets,
+> requested reviewers, and thread IDs in one mechanical block before reasoning
+> about merge-readiness — see the Merge-Gate Command above plus this ruleset
+> call. Discovering gates one round-trip at a time is the anti-pattern.
 
 ## Signed Commits with Rebase Merge
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -816,9 +816,7 @@ gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(numb
 # Ready only when: no pending reviewRequests AND the bot's latest review.commit.oid == headRefOid.
 ```
 
-Other
-ruleset rules to expect: `required_approving_review_count`,
-`required_review_thread_resolution`, `non_fast_forward`.
+Other ruleset rules to expect: `required_approving_review_count`, `required_review_thread_resolution`, `non_fast_forward`.
 
 > **Front-load the whole picture.** Gather merge state, checks, rulesets,
 > requested reviewers, and thread IDs in one mechanical block before reasoning

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -737,7 +737,7 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 
 - [ ] **All review threads resolved** — no unresolved conversations
 - [ ] **Copilot review complete on the _latest_ commit** (if assigned) — a `copilot_code_review` ruleset re-blocks after every push; see "Rulesets" below
-- [ ] **Rulesets checked** — `rules/branches/{branch}`, not just classic branch protection
+- [ ] **Rulesets checked** — `gh api repos/{owner}/{repo}/rules/branches/<base>`, not just classic branch protection
 - [ ] **Branch rebased on target** — no stray merge commits in PR branch
 - [ ] **All CI checks pass** — green status on every required check
 - [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
@@ -781,9 +781,9 @@ and the classic `branches/{branch}/protection` API. Don't discover this by
 trial-and-error; fetch the *effective* rules as part of the gate:
 
 ```bash
-# gh resolves {owner}/{repo} from git context; the branch is NOT resolved, so
-# name it — use the PR's BASE branch (what you merge into), not the feature branch:
-gh api repos/{owner}/{repo}/rules/branches/main \
+# gh resolves {owner}/{repo} from git context but NOT the branch, so name it.
+# Derive the PR's BASE branch (what you merge into) rather than hard-coding main:
+gh api repos/{owner}/{repo}/rules/branches/$(gh pr view --json baseRefName -q .baseRefName) \
   --jq 'group_by(.type)[] | {type: .[0].type, n: length}'
 ```
 
@@ -809,7 +809,8 @@ ready while it persists. Poll until the request clears *and* the review lands
 on the latest commit `oid`:
 
 ```bash
-gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:NUMBER){
+  headRefOid
   reviewRequests(first:10){nodes{requestedReviewer{... on Bot{login}}}}
   reviews(last:5){nodes{author{login} state commit{oid}}}}}}'
 # Ready only when: no pending reviewRequests AND the bot's latest review.commit.oid == headRefOid.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -796,7 +796,24 @@ gh api repos/{owner}/{repo}/pulls/NUMBER/requested_reviewers \
 ```
 
 (`gh pr edit --add-reviewer` rejects the bot login with "Could not resolve
-user"; the REST `requested_reviewers` endpoint is the working path.) Other
+user"; the REST `requested_reviewers` endpoint is the working path.)
+
+**Wait for in-progress reviews — don't merge on a transient `CLEAN`.** After
+re-requesting (or right after a push), the reviewer's review is *in progress*:
+`mergeStateStatus` can read `CLEAN` for a few seconds before the bot posts its
+comments, and merging then strands fresh review threads on a closed PR. A
+**pending review request is the in-progress signal** — treat the PR as not
+ready while it persists. Poll until the request clears *and* the review lands
+on the latest commit `oid`:
+
+```bash
+gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){
+  reviewRequests(first:10){nodes{requestedReviewer{... on Bot{login}}}}
+  reviews(last:5){nodes{author{login} state commit{oid}}}}}}'
+# Ready only when: no pending reviewRequests AND the bot's latest review.commit.oid == headRefOid.
+```
+
+Other
 ruleset rules to expect: `required_approving_review_count`,
 `required_review_thread_resolution`, `non_fast_forward`.
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -781,7 +781,9 @@ and the classic `branches/{branch}/protection` API. Don't discover this by
 trial-and-error; fetch the *effective* rules as part of the gate:
 
 ```bash
-gh api repos/{owner}/{repo}/rules/branches/{branch} \
+# gh resolves {owner}/{repo} from git context; the branch is NOT resolved, so
+# name it — use the PR's BASE branch (what you merge into), not the feature branch:
+gh api repos/{owner}/{repo}/rules/branches/main \
   --jq 'group_by(.type)[] | {type: .[0].type, n: length}'
 ```
 
@@ -791,7 +793,7 @@ re-blocks the PR — and Copilot is **not** re-requested automatically. Re-reque
 it explicitly, then re-poll the gate:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/NUMBER/requested_reviewers \
+gh api repos/{owner}/{repo}/pulls/$(gh pr view --json number -q .number)/requested_reviewers \
   -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -781,9 +781,10 @@ and the classic `branches/{branch}/protection` API. Don't discover this by
 trial-and-error; fetch the *effective* rules as part of the gate:
 
 ```bash
-# gh resolves {owner}/{repo} from git context but NOT the branch, so name it.
-# Derive the PR's BASE branch (what you merge into) rather than hard-coding main:
-gh api repos/{owner}/{repo}/rules/branches/$(gh pr view --json baseRefName -q .baseRefName) \
+# gh resolves {owner}/{repo} from git context but NOT the branch — fill in BASE,
+# the branch you merge INTO (e.g. main / develop), not the feature branch.
+# The endpoint returns an array of rule objects, so group_by(.type) works:
+gh api repos/{owner}/{repo}/rules/branches/BASE \
   --jq 'group_by(.type)[] | {type: .[0].type, n: length}'
 ```
 
@@ -793,7 +794,7 @@ re-blocks the PR — and Copilot is **not** re-requested automatically. Re-reque
 it explicitly, then re-poll the gate:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/$(gh pr view --json number -q .number)/requested_reviewers \
+gh api repos/{owner}/{repo}/pulls/NUMBER/requested_reviewers \
   -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 


### PR DESCRIPTION
## Summary

Makes the **Merge Gate** ruleset-aware. A PR can sit at `mergeStateStatus: BLOCKED` with every check green, `reviewDecision: ""` (no *required* approvals), and all threads resolved — and the existing gate gives no clue why, because the blocker is a repository **ruleset**, which is invisible to both the merge-gate `gh pr view` and the classic `branches/{branch}/protection` API.

## What it adds

A "Rulesets: the gate `gh pr view` doesn't show" subsection in `references/pull-request-workflow.md`:

- Fetch *effective* rules: `gh api repos/{owner}/{repo}/rules/branches/{branch}`.
- The common culprit — a `copilot_code_review` rule requires a Copilot review on the **latest commit** and re-blocks after every push, **without** auto-re-requesting Copilot. Documents the working re-request (`requested_reviewers` REST endpoint — `gh pr edit --add-reviewer` rejects the bot login with "Could not resolve user").
- A note to front-load merge state + checks + rulesets + reviewers + thread IDs in one mechanical block, rather than discovering gates one round-trip at a time.

Pre-Merge Checklist updated to call out latest-commit Copilot review and ruleset checking.

## Motivation

Surfaced finishing a PR where 15 green checks + 0 unresolved threads still read `BLOCKED`; tracing it to a `copilot_code_review` ruleset (needing a fresh review on the latest commit) took several avoidable round-trips. Docs-only change.
