### PR TITLE
docs(pr-workflow): stop auto-selecting squash in merge-strategy snippet

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -955,12 +955,16 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_
 ### 3. Merge
 
 ```bash
-# Auto-detect merge strategy and queue
+# Auto-detect merge strategy and queue.
+# Prefer atomic-history methods; NEVER auto-pick squash (see "Never squash
+# unless the user asks" above). Squash is selected only if it is the sole
+# method the repo allows — and then warn, because it rewrites history.
 STRATEGY=$(gh api "repos/OWNER/REPO" --jq '
-  if .allow_squash_merge then "--squash"
-  elif .allow_merge_commit then "--merge"
+  if .allow_merge_commit then "--merge"
   elif .allow_rebase_merge then "--rebase"
-  else "--squash" end')
+  elif .allow_squash_merge then "--squash"
+  else "--merge" end')
+[ "$STRATEGY" = "--squash" ] && echo "WARNING: only squash is enabled — this rewrites history and drops signatures"
 gh pr merge <NUMBER> --auto $STRATEGY
 
 # For repos with merge queue, just queue it

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -963,9 +963,11 @@ STRATEGY=$(gh api "repos/OWNER/REPO" --jq '
   if .allow_merge_commit then "--merge"
   elif .allow_rebase_merge then "--rebase"
   elif .allow_squash_merge then "--squash"
-  else "--merge" end')
-[ "$STRATEGY" = "--squash" ] && echo "WARNING: only squash is enabled — this rewrites history and drops signatures"
-gh pr merge <NUMBER> --auto $STRATEGY
+  else "" end') || { echo "ERROR: could not query repo merge methods" >&2; exit 1; }
+# Fail fast rather than fall through to gh's default method (which may be squash).
+[ -z "$STRATEGY" ] && { echo "ERROR: no merge method enabled on this repo" >&2; exit 1; }
+[ "$STRATEGY" = "--squash" ] && echo "WARNING: only squash is enabled — this rewrites history and drops signatures" >&2
+gh pr merge <NUMBER> --auto "$STRATEGY"
 
 # For repos with merge queue, just queue it
 gh pr merge <NUMBER> --auto


### PR DESCRIPTION
## What

Fixes the merge-strategy auto-detect snippet in `references/pull-request-workflow.md` §3 Merge. It preferred **and** fell back to `--squash`:

```diff
- if .allow_squash_merge then "--squash"
- elif .allow_merge_commit then "--merge"
- elif .allow_rebase_merge then "--rebase"
- else "--squash" end
+ if .allow_merge_commit then "--merge"
+ elif .allow_rebase_merge then "--rebase"
+ elif .allow_squash_merge then "--squash"
+ else "--merge" end
```

Plus a warning when squash is the only enabled method.

## Why

This contradicted the skill's own rules — "Never squash unless the user asks" (Critical Rule #3) and the "default to merge-commit" guidance earlier in the same file. An agent following the snippet literally would squash-merge a repo that allows it, dropping GPG signatures and bisection granularity. Reordering to prefer `--merge` → `--rebase` makes the executable snippet match the prose.

Surfaced during a `/pr-finish` run: I had to check allowed merge methods manually because trusting the snippet would have squashed.
