### PR TITLE
feat: add /pr-finish slash command

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,8 @@
   },
   "skills": [
     "./skills/git-workflow"
+  ],
+  "commands": [
+    "./commands/pr-finish.md"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Example queries:
 - "Configure branch protection rules"
 - "Implement pull request review process"
 
+### Commands
+
+- `/pr-finish [PR]` — drive a pull request to a fully-green, merged state:
+  preflight the merge gate in one block, rebase, fix CI locally, reply to and
+  resolve every review thread, update the title/description, and merge when
+  green. Operates on the named PR or the current branch's PR.
+
 ## Structure
 
 ```
@@ -110,6 +117,8 @@ git-workflow-skill/
 │   ├── pull-request-workflow.md          # PR and review processes
 │   ├── ci-cd-integration.md              # Automation patterns
 │   └── advanced-git.md                   # Advanced Git operations
+├── commands/
+│   └── pr-finish.md                      # /pr-finish slash command
 └── scripts/
     └── verify-git-workflow.sh            # Verification script
 ```

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -19,17 +19,17 @@ handling. Then execute, in order:
    *why*. Run this up front and re-run only after a state-changing push:
 
    ```bash
-   R=<owner/repo>; PR=<number>
+   R=<owner/repo>; PR=<number>; BASE=<base-branch>
    gh pr view   $PR --repo $R --json state,mergeable,mergeStateStatus,reviewDecision,headRefOid,baseRefName,title
    gh pr checks $PR --repo $R
-   gh api repos/$R/rules/branches/main   # effective rules INCL. rulesets (e.g. copilot_code_review) — classic branch-protection API misses these
+   gh api repos/$R/rules/branches/$BASE   # effective rules INCL. rulesets (e.g. copilot_code_review) — evaluated against the BASE branch; classic branch-protection API misses these
    gh pr view   $PR --repo $R --json reviewRequests --jq '.reviewRequests'
-   gh api graphql -f query='{repository(owner:"<owner>",name:"<repo>"){pullRequest(number:'"$PR"'){reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{databaseId author{login} path body}}}}}}}'
+   gh api graphql -F owner="${R%/*}" -F repo="${R#*/}" -F pr="$PR" -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{databaseId author{login} path body}}}}}}}'
    ```
 
    This yields, in one shot: merge state + why, every required check, **rulesets**
    (a CLEAN-blocking `copilot_code_review` rule needs a fresh Copilot review on
-   the *latest* commit — re-request via `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`), pending review requests, and the thread IDs + comment `databaseId`s needed to reply and resolve. Reason once from this, not serially.
+   the *latest* commit — re-request via `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`), pending review requests, and the thread IDs needed to reply to and resolve each thread. Reason once from this, not serially.
 
 1. **Rebase** onto the base branch if the branch is behind. In bare-repo worktree
    setups, fetch explicitly (`git fetch origin <branch>:refs/remotes/origin/<branch>`)
@@ -39,10 +39,11 @@ handling. Then execute, in order:
    as applicable) and fix everything locally; don't push half-fixes that re-trigger
    CI. For Python projects with ruff, run both `ruff format` and `ruff check` before
    committing.
-3. **Resolve every review thread** — reply directly to each comment via
-   `gh api .../comments/{id}/replies` (never a general PR comment), reference the
-   fixing commit, then resolve the thread via the GraphQL `resolveReviewThread`
-   mutation. Verify `isResolved` — green CI alone is not sufficient.
+3. **Resolve every review thread** — reply directly to each thread via the GraphQL
+   `addPullRequestReviewThreadReply` mutation (using the thread ID from preflight, never
+   a general PR comment), reference the fixing commit, then resolve the thread via the
+   GraphQL `resolveReviewThread` mutation. Verify `isResolved` — green CI alone is not
+   sufficient.
 4. **Update the PR title and description** to match the final state.
 5. **Merge only when fully green AND all threads resolved** — use `--merge` or
    `--rebase`, never `--squash` (preserve atomic history). Dependabot/Renovate PRs

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -1,0 +1,57 @@
+---
+name: pr-finish
+description: "Drive a PR to merge — rebase, fix CI, resolve review comments, update title/description, merge when green"
+---
+
+# /pr-finish
+
+Bring the pull request to a fully-green, merged state. This is the canonical
+PR-completion request, so it runs through the **git-workflow** skill every time.
+
+**First, invoke the `git-workflow` skill** — `references/pull-request-workflow.md`
+is authoritative for the merge gate, GraphQL thread resolution, and merge-queue
+handling. Then execute, in order:
+
+0. **Preflight — fetch the whole merge-gate picture in ONE mechanical block,
+   before reasoning about merge-readiness.** Never discover a gate (BLOCKED,
+   required reviews, rulesets, unresolved threads, failing checks) one
+   round-trip at a time — `mergeStateStatus: BLOCKED` alone never tells you
+   *why*. Run this up front and re-run only after a state-changing push:
+
+   ```bash
+   R=<owner/repo>; PR=<number>
+   gh pr view   $PR --repo $R --json state,mergeable,mergeStateStatus,reviewDecision,headRefOid,baseRefName,title
+   gh pr checks $PR --repo $R
+   gh api repos/$R/rules/branches/main   # effective rules INCL. rulesets (e.g. copilot_code_review) — classic branch-protection API misses these
+   gh pr view   $PR --repo $R --json reviewRequests --jq '.reviewRequests'
+   gh api graphql -f query='{repository(owner:"<owner>",name:"<repo>"){pullRequest(number:'"$PR"'){reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{databaseId author{login} path body}}}}}}}'
+   ```
+
+   This yields, in one shot: merge state + why, every required check, **rulesets**
+   (a CLEAN-blocking `copilot_code_review` rule needs a fresh Copilot review on
+   the *latest* commit — re-request via `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`), pending review requests, and the thread IDs + comment `databaseId`s needed to reply and resolve. Reason once from this, not serially.
+
+1. **Rebase** onto the base branch if the branch is behind. In bare-repo worktree
+   setups, fetch explicitly (`git fetch origin <branch>:refs/remotes/origin/<branch>`)
+   — `origin/*` may not auto-update and `--force-with-lease` then fails "stale info".
+   Force-push only with `--force-with-lease`, never plain `--force`.
+2. **Fix CI** — run the full local suite first (tests, type-check, linters/formatters
+   as applicable) and fix everything locally; don't push half-fixes that re-trigger
+   CI. For Python projects with ruff, run both `ruff format` and `ruff check` before
+   committing.
+3. **Resolve every review thread** — reply directly to each comment via
+   `gh api .../comments/{id}/replies` (never a general PR comment), reference the
+   fixing commit, then resolve the thread via the GraphQL `resolveReviewThread`
+   mutation. Verify `isResolved` — green CI alone is not sufficient.
+4. **Update the PR title and description** to match the final state.
+5. **Merge only when fully green AND all threads resolved** — use `--merge` or
+   `--rebase`, never `--squash` (preserve atomic history). Dependabot/Renovate PRs
+   auto-merge via the repo's deps workflow — never merge those by hand.
+6. **Post-merge:** confirm any merge-triggered async jobs, and clean up the branch.
+
+No version bumps or CHANGELOG entries in feature PRs. No bot attribution in
+commits or PR bodies. Preserve commit signing.
+
+If the user named a PR (`$ARGUMENTS`), operate on that one; otherwise resolve the
+PR for the current branch. Also check already-closed PRs for unresolved threads
+when the user asks for a sweep. Confirm before any push to a private repo.


### PR DESCRIPTION
## Summary

Ships the `/pr-finish` slash command with the skill instead of keeping it as a local-only user command. It is the canonical PR-completion request and already delegated to this skill, so it belongs here.

`/pr-finish [PR]` drives a pull request to a fully-green, merged state:

- **Preflight** the whole merge gate (state, checks, rulesets, review requests, thread IDs) in one mechanical block before reasoning about merge-readiness.
- **Rebase** onto the base branch (with explicit-fetch guidance for bare-repo worktrees).
- **Fix CI locally** before pushing — no half-fixes that re-trigger CI.
- **Resolve every review thread** via direct comment replies + the GraphQL `resolveReviewThread` mutation, verifying `isResolved`.
- **Update** the PR title/description, then **merge** only when green and all threads resolved (`--merge`/`--rebase`, never `--squash`).

## Changes

- `commands/pr-finish.md` — the command (generalized from the local copy: dropped personal references, kept the substance).
- `.claude-plugin/plugin.json` — register the `commands` array, following the same convention as `github-release-skill`.
- `README.md` — document `/pr-finish` under Usage and add `commands/` to the Structure tree.

No version bump (left to the release flow). All pre-commit hooks pass locally (validate-skill, version parity, markdownlint).
