### PR TITLE
fix(pr-finish): correct reference path, README tree, add head-review merge guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Example queries:
 ## Structure
 
 ```
-git-workflow-skill/
+git-workflow-skill/                       # abbreviated — key files only
 ├── skills/git-workflow/
 │   ├── SKILL.md                          # Skill metadata and core patterns
+│   ├── ...                               # checkpoints.yaml, evals/, hooks
 │   └── references/
 │       ├── branching-strategies.md       # Branch management patterns
 │       ├── commit-conventions.md         # Commit message standards

--- a/README.md
+++ b/README.md
@@ -110,17 +110,18 @@ Example queries:
 
 ```
 git-workflow-skill/
-├── SKILL.md                              # Skill metadata and core patterns
-├── references/
-│   ├── branching-strategies.md           # Branch management patterns
-│   ├── commit-conventions.md             # Commit message standards
-│   ├── pull-request-workflow.md          # PR and review processes
-│   ├── ci-cd-integration.md              # Automation patterns
-│   └── advanced-git.md                   # Advanced Git operations
+├── skills/git-workflow/
+│   ├── SKILL.md                          # Skill metadata and core patterns
+│   └── references/
+│       ├── branching-strategies.md       # Branch management patterns
+│       ├── commit-conventions.md         # Commit message standards
+│       ├── pull-request-workflow.md      # PR and review processes
+│       ├── ci-cd-integration.md          # Automation patterns
+│       └── advanced-git.md               # Advanced Git operations
 ├── commands/
 │   └── pr-finish.md                      # /pr-finish slash command
 └── scripts/
-    └── verify-git-workflow.sh            # Verification script
+    └── verify-harness.sh                 # Harness verification script
 ```
 
 ## Expertise Areas

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -8,7 +8,7 @@ description: "Drive a PR to merge — rebase, fix CI, resolve review comments, u
 Bring the pull request to a fully-green, merged state. This is the canonical
 PR-completion request, so it runs through the **git-workflow** skill every time.
 
-**First, invoke the `git-workflow` skill** — `references/pull-request-workflow.md`
+**First, invoke the `git-workflow` skill** — its `references/pull-request-workflow.md`
 is authoritative for the merge gate, GraphQL thread resolution, and merge-queue
 handling. Then execute, in order:
 
@@ -45,9 +45,16 @@ handling. Then execute, in order:
    GraphQL `resolveReviewThread` mutation. Verify `isResolved` — green CI alone is not
    sufficient.
 4. **Update the PR title and description** to match the final state.
-5. **Merge only when fully green AND all threads resolved** — use `--merge` or
-   `--rebase`, never `--squash` (preserve atomic history). Dependabot/Renovate PRs
-   auto-merge via the repo's deps workflow — never merge those by hand.
+5. **Merge only when fully green AND all threads resolved.** Use `--merge` or
+   `--rebase`, never `--squash` (preserve atomic history). **`mergeStateStatus: CLEAN`
+   is not sufficient** — a `copilot_code_review` ruleset with `review_on_push:false`
+   stays satisfied by an *earlier* commit's review, so CLEAN can report green while the
+   head commit is unreviewed. Before merging, confirm the latest review from each required
+   reviewer is on the current `headRefOid` (not a prior commit) **and** `reviewRequests`
+   is empty — an empty list means the reviewer *finished*, not that a freshly-requested
+   review can be skipped. Never merge with a review in flight; if you re-request a reviewer,
+   wait for its review on the head commit to land first. Dependabot/Renovate PRs auto-merge
+   via the repo's deps workflow — never merge those by hand.
 6. **Post-merge:** confirm any merge-triggered async jobs, and clean up the branch.
 
 No version bumps or CHANGELOG entries in feature PRs. No bot attribution in

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -9,8 +9,8 @@ Bring the pull request to a fully-green, merged state. This is the canonical
 PR-completion request, so it runs through the **git-workflow** skill every time.
 
 **First, invoke the `git-workflow` skill** — its `references/pull-request-workflow.md`
-is authoritative for the merge gate, GraphQL thread resolution, and merge-queue
-handling. Then execute, in order:
+(under `skills/git-workflow/`) is authoritative for the merge gate, GraphQL thread
+resolution, and merge-queue handling. Then execute, in order:
 
 0. **Preflight — fetch the whole merge-gate picture in ONE mechanical block,
    before reasoning about merge-readiness.** Never discover a gate (BLOCKED,


### PR DESCRIPTION
## Summary

Follow-up to #54. The head-commit Copilot review landed just **after** #54 merged (the `copilot_code_review` ruleset is `review_on_push:false`, so an earlier commit's review kept `mergeStateStatus` green while the head commit was unreviewed). This PR fixes what that review correctly flagged, and hardens the command so the same gap can't recur.

## Fixes

- **`commands/pr-finish.md` — broken reference path.** The file said `references/pull-request-workflow.md`, which does not resolve from the command file's location. Reworded to "the git-workflow skill's `references/pull-request-workflow.md`".
- **`README.md` — stale Structure tree.** `SKILL.md` and `references/` actually live under `skills/git-workflow/`; corrected the nesting and the script name (`verify-harness.sh`).
- **`commands/pr-finish.md` — merge guard.** Documented that `mergeStateStatus: CLEAN` is **not** sufficient under `review_on_push:false`: require the latest required-reviewer review to be on the current `headRefOid` and `reviewRequests` to be empty before merging, and never merge with a review in flight.

## Verification

All pre-commit hooks pass (validate-skill, version parity, markdownlint). No version bump (release flow owns versioning).
