### PR TITLE
test(git-workflow): add eval for merging blocked by an in-flight review

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -281,6 +281,28 @@
       {
         "type": "content",
         "pattern": "(rebase|signed|annotation)"
+      },
+      {
+        "type": "content",
+        "pattern": "(in.?flight|announced|pending review|in progress|wait for)"
+      }
+    ]
+  },
+  {
+    "name": "merge_blocked_by_inflight_review",
+    "prompt": "gh pr view says mergeStateStatus is CLEAN and reviewRequests is empty, but I just re-requested the Copilot reviewer a moment ago. Is it safe to merge now?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(do not merge|don.t merge|not safe|hold off|wait)"
+      },
+      {
+        "type": "content",
+        "pattern": "(in.?flight|in progress|announced|still reviewing|hasn.t submitted|not yet submitted)"
+      },
+      {
+        "type": "content",
+        "pattern": "(not sufficient|not enough|isn.t enough|stale|review_on_push)"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -284,7 +284,7 @@
       },
       {
         "type": "content",
-        "pattern": "(in.?flight|announced|pending review|in progress|wait for)"
+        "pattern": "(in.?flight review|pending review|review in progress|review still running|wait for the review|review to land|in-flight or pending review)"
       }
     ]
   },
@@ -294,15 +294,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(do not merge|don.t merge|not safe|hold off|wait)"
+        "pattern": "(do not merge|don.t merge|not safe to merge|should not merge|hold off|don.t merge yet|do not merge yet|wait for the review|wait until the review)"
       },
       {
         "type": "content",
-        "pattern": "(in.?flight|in progress|announced|still reviewing|hasn.t submitted|not yet submitted)"
+        "pattern": "(in.?flight|still reviewing|pending review|review in progress|hasn.t submitted|has not submitted|not yet submitted|announced review|review you just requested|review you requested)"
       },
       {
         "type": "content",
-        "pattern": "(not sufficient|not enough|isn.t enough|stale|review_on_push)"
+        "pattern": "(CLEAN is not sufficient|CLEAN isn.t sufficient|CLEAN alone|CLEAN can be stale|CLEAN doesn.t mean|not sufficient to merge|review_on_push|empty reviewRequests doesn|reviewRequests is not)"
       }
     ]
   }


### PR DESCRIPTION
## Summary
Locks in the lesson from the `/pr-finish` incident as an eval. The skill had `pr_merge_checklist` but its assertions (CI / threads / rebase) would pass even for the buggy "merge on CLEAN" behavior.

## Changes
- New eval **`merge_blocked_by_inflight_review`**: prompt describes CLEAN + empty `reviewRequests` right after re-requesting Copilot; asserts the answer advises *not* merging / waiting, references the in-flight/announced review, and notes CLEAN is not sufficient.
- Strengthen **`pr_merge_checklist`**: add an assertion that the checklist mentions waiting for in-flight/pending reviews.

Would fail against the #54 behavior; passes against the corrected command. No version bump.