### PR TITLE
docs(git-workflow): add identity/signing preflight and DCO recovery guidance

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -467,8 +467,8 @@ git config user.name   # must look like "Firstname Lastname", NOT an email addre
 git config user.email  # must contain "@", NOT a plain name
 
 # Fix if swapped:
-git config user.name "Firstname Lastname"
-git config user.email "you@example.com"
+git config --global user.name "Firstname Lastname"
+git config --global user.email "you@example.com"
 ```
 
 **SSH signing keys on GitHub: auth keys ≠ signing keys.** An SSH key registered under *Settings → SSH and GPG keys → Authentication Key* cannot verify commits. It must also be added as a *Signing Key* (same page, different Key type dropdown). GitHub reports unsigned-with-known-key commits as `reason: unknown_key` in the commits API — identical to an unregistered key. Check before the first push to a repo with verified-signature branch protection:
@@ -479,7 +479,7 @@ gh auth refresh -h github.com -s admin:ssh_signing_key
 gh api /user/ssh_signing_keys --jq '.[].key'
 
 # Or check commit verification after pushing one commit:
-gh api repos/OWNER/REPO/commits/HEAD --jq '.commit.verification | {verified, reason}'
+gh api /repos/{owner}/{repo}/commits/HEAD --jq '.commit.verification | {verified, reason}'
 # "reason":"valid"        → OK
 # "reason":"unknown_key"  → key not registered as signing key
 # "reason":"unsigned"     → -S flag not used or signing config missing

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -460,11 +460,29 @@ git commit -S --signoff -m "feat: add login endpoint"
 
 **Why `--signoff`.** Adds the `Signed-off-by:` trailer. Required for DCO compliance on any repo that has the DCO check enabled (most netresearch repos do).
 
-**Sign-off identity must match `git config user.{name,email}`.** Mismatched identities fail the DCO check with an unhelpful "signoff required" error. Check before the first commit in a new worktree:
+**Sign-off identity must match `git config user.{name,email}`.** Mismatched identities fail the DCO check with an unhelpful "signoff required" error. Validate before the first commit in a new worktree — and specifically check that the values are not swapped (an email address in `user.name` is a silent misconfiguration that produces a malformed `Signed-off-by:` trailer):
 
 ```bash
-git config user.name
-git config user.email
+git config user.name   # must look like "Firstname Lastname", NOT an email address
+git config user.email  # must contain "@", NOT a plain name
+
+# Fix if swapped:
+git config user.name "Firstname Lastname"
+git config user.email "you@example.com"
+```
+
+**SSH signing keys on GitHub: auth keys ≠ signing keys.** An SSH key registered under *Settings → SSH and GPG keys → Authentication Key* cannot verify commits. It must also be added as a *Signing Key* (same page, different Key type dropdown). GitHub reports unsigned-with-known-key commits as `reason: unknown_key` in the commits API — identical to an unregistered key. Check before the first push to a repo with verified-signature branch protection:
+
+```bash
+# Verify the key is registered as a signing key (requires admin:ssh_signing_key token scope):
+gh auth refresh -h github.com -s admin:ssh_signing_key
+gh api /user/ssh_signing_keys --jq '.[].key'
+
+# Or check commit verification after pushing one commit:
+gh api repos/OWNER/REPO/commits/HEAD --jq '.commit.verification | {verified, reason}'
+# "reason":"valid"        → OK
+# "reason":"unknown_key"  → key not registered as signing key
+# "reason":"unsigned"     → -S flag not used or signing config missing
 ```
 
 **Never amend a commit with pre-commit-hook failures.** If the pre-commit hook fails, the commit **did not happen**. Running `git commit --amend` then modifies the PREVIOUS commit, which can destroy work. Fix the hook issue, re-stage, and create a new commit.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -756,8 +756,8 @@ git config user.name   # must look like "Firstname Lastname", NOT an email addre
 git config user.email  # must contain "@", NOT a plain name
 
 # Fix if swapped:
-git config user.name "Firstname Lastname"
-git config user.email "you@example.com"
+git config --global user.name "Firstname Lastname"
+git config --global user.email "you@example.com"
 ```
 
 **Step 2 — Add missing sign-offs to all commits in the branch.**
@@ -774,7 +774,7 @@ Auth keys and signing keys are separate registrations. An authentication key can
 
 ```bash
 # Check commit verification after pushing:
-gh api repos/OWNER/REPO/commits/HEAD --jq '.commit.verification | {verified, reason}'
+gh api /repos/{owner}/{repo}/commits/HEAD --jq '.commit.verification | {verified, reason}'
 # "reason":"valid"        → OK
 # "reason":"unknown_key"  → key is not registered as a signing key
 # "reason":"unsigned"     → -S flag was not used or signing config is missing

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -741,7 +741,46 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 - [ ] **Branch rebased on target** — no stray merge commits in PR branch
 - [ ] **All CI checks pass** — green status on every required check
 - [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
-- [ ] **Signed commits** — every commit in the PR is signed
+- [ ] **Signed commits** — every commit in the PR is signed (see "Signing and DCO Failures" below if blocked)
+- [ ] **DCO sign-off** — every commit has a `Signed-off-by:` trailer matching `git config user.{name,email}` (required when the `probot/dco` check is enabled)
+
+### Signing and DCO Failures
+
+When `mergeStateStatus: BLOCKED` and the blocking check is `dco` or a "Commits must have verified signatures" branch-protection rule, act on these in order:
+
+**Step 1 — Verify git identity is correct (not swapped).**
+A swapped name/email pair silently produces a malformed `Signed-off-by:` trailer that the DCO bot rejects:
+
+```bash
+git config user.name   # must look like "Firstname Lastname", NOT an email address
+git config user.email  # must contain "@", NOT a plain name
+
+# Fix if swapped:
+git config user.name "Firstname Lastname"
+git config user.email "you@example.com"
+```
+
+**Step 2 — Add missing sign-offs to all commits in the branch.**
+Rebase with `--exec` to amend every commit at once. Use `--signoff` for DCO, `-S` for signature, or both:
+
+```bash
+# Both DCO sign-off and GPG/SSH signature in one pass:
+git rebase origin/main --exec 'git commit --amend --no-edit --signoff -S'
+git push --force-with-lease
+```
+
+**Step 3 — If signatures still show `reason: unknown_key`, the SSH key is not registered as a *Signing Key* on GitHub.**
+Auth keys and signing keys are separate registrations. An authentication key cannot verify commits:
+
+```bash
+# Check commit verification after pushing:
+gh api repos/OWNER/REPO/commits/HEAD --jq '.commit.verification | {verified, reason}'
+# "reason":"valid"        → OK
+# "reason":"unknown_key"  → key is not registered as a signing key
+# "reason":"unsigned"     → -S flag was not used or signing config is missing
+```
+
+If `unknown_key`: go to *github.com → Settings → SSH and GPG keys*, find your key, and add it again under *New signing key* (same public key, different "Key type"). After adding, re-verify with the API call above.
 
 ### Merge-Gate Command
 


### PR DESCRIPTION
## Summary

- Adds an explicit swapped `user.name`/`user.email` detection step to the signed-commits section in `commit-conventions.md` — a silent misconfiguration that produces malformed `Signed-off-by:` trailers rejected by the DCO bot.
- Adds SSH auth key vs. signing key distinction: GitHub surfaces auth-only keys as `reason: unknown_key` even when signing succeeds locally. Adds API one-liner to verify and explains the re-registration path on `github.com/settings/keys`.
- Adds a **DCO sign-off** item to the Pre-Merge Checklist in `pull-request-workflow.md`.
- Adds a **"Signing and DCO Failures"** recovery block below the checklist with a step-by-step guide: swapped identity fix → batch `rebase --exec` to add `--signoff -S` → `unknown_key` diagnosis and fix.

## Motivation

These failure modes surfaced together in a single pr-finish session and cost multiple debugging round-trips:
1. Global git config had `user.name` and `user.email` swapped — `--signoff` produced `Signed-off-by: email <name>` which DCO rejected.
2. The SSH key was only registered as an authentication key, not a signing key — GitHub reported `reason: unknown_key` with no indication of the fix path.

Both issues are non-obvious and produce misleading error messages. The new guidance surfaces them at the earliest gate check, not post-push.

## Test plan
- [ ] `commit-conventions.md`: swapped identity block readable and accurate
- [ ] `commit-conventions.md`: `unknown_key` API snippet correct
- [ ] `pull-request-workflow.md`: DCO checklist item present
- [ ] `pull-request-workflow.md`: recovery block covers all three steps in order
- [ ] CI passes (yamllint, markdownlint)