### PR TITLE
feat(mirrors): bash assignment exit-code gotcha + git push --mirror requirements

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -671,6 +671,61 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 ```
 
+## Git Mirror Repositories
+
+Use `git clone --mirror` + `git push --mirror` to keep a target repository in sync with an
+upstream source — for example, mirroring a public TYPO3 repository into a private GitLab
+instance or creating read-only forks for controlled distribution.
+
+```bash
+git clone --mirror "$SOURCE_URL" repo.git
+cd repo.git
+git push --mirror "$TARGET_URL"
+```
+
+### Default Branch Requirement
+
+`git push --mirror` pushes **all** refs from the source and **deletes** any ref at the target
+that no longer exists in the source. GitLab and GitHub will refuse to delete their repository's
+default branch, causing the push to fail with an error like:
+
+```
+remote: GitLab: You can only delete protected branches using the web interface.
+error: failed to push some refs to 'git@gitlab.example.com:org/repo.git'
+```
+
+**Root cause**: the target was initialised with a default branch (e.g. `main`) that does not
+exist in the upstream (e.g. source uses `12.4`). Every mirror run tries to delete `main` and
+GitLab refuses.
+
+**Fix — preferred**: create the target as an **empty project** (no README, no initial commit).
+The default branch is then set automatically when the first `git push --mirror` runs.
+
+**Fix — existing repo**: change the default branch in Settings before mirroring. On GitLab:
+*Settings → Repository → Default branch*. On GitHub: *Settings → Branches → Default branch*.
+
+### Notes-Ref Gotcha
+
+`git push --mirror` deletes any ref at the target that does not exist in the upstream. If you
+store cache data (e.g. split commit maps) in `refs/notes/*` on the mirror target, those refs
+will be wiped on every sync run because they are absent from the upstream.
+
+Do not rely on `refs/notes/*` for persistent caching in mirror repositories. Store such state
+in a separate repository, a file in object storage, or a CI/CD cache artifact.
+
+### Example CI Job (GitLab)
+
+```yaml
+mirror-sync:
+  image: alpine/git:latest
+  script:
+    - git clone --mirror "$SOURCE_URL" repo.git
+    - cd repo.git
+    - git push --mirror "$TARGET_URL"
+  only:
+    - schedules
+```
+
 ## Best Practices
 
 1. **Fast Feedback**: Keep CI under 10 minutes

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -717,7 +717,7 @@ in a separate repository, a file in object storage, or a CI/CD cache artifact.
 
 ```yaml
 mirror-sync:
-  image: alpine/git:latest
+  image: alpine/git:2.43.0
   script:
     - git clone --mirror "$SOURCE_URL" repo.git
     - cd repo.git

--- a/skills/git-workflow/references/code-quality-tools.md
+++ b/skills/git-workflow/references/code-quality-tools.md
@@ -83,10 +83,11 @@ git push origin "${commit}:refs/tags/v1.0"
 Always add an explicit empty-value guard after command substitution whose output is load-bearing:
 
 ```bash
+tag="v1.0"
 commit=$(git commit-tree "$tree" -p "$parent" -m "msg")
 if [ -z "${commit}" ]; then
   echo "ERROR: git commit-tree produced no output for tag ${tag}" >&2
-  continue   # or: exit 1, depending on context
+  exit 1   # or: continue, if inside a loop
 fi
 git push origin "${commit}:refs/tags/${tag}"
 ```

--- a/skills/git-workflow/references/code-quality-tools.md
+++ b/skills/git-workflow/references/code-quality-tools.md
@@ -59,6 +59,43 @@ cd /some/dir
 cd /some/dir || exit 1
 ```
 
+### Gotcha: Command Substitution with Empty Output
+
+`set -e` fires when `var=$(failing_cmd)` — the assignment propagates the non-zero exit code and
+aborts the script. **However**, `set -e` cannot detect a command that exits 0 but produces
+**no output**. An empty variable is a valid result from the shell's point of view. No shellcheck
+rule covers this case for regular (non-`local`) variables.
+
+This means downstream code that uses `$var` without checking can silently misbehave. A common
+consequence: an empty variable interpolated into a refspec becomes an accidental delete operation.
+
+```bash
+# Silent failure — git commit-tree succeeds but produces no output
+# (e.g. tree already exists, permission issue, or wrong arguments).
+# set -e does NOT fire here. commit is empty string "".
+commit=$(git commit-tree "$tree" -p "$parent" -m "msg")
+
+# Downstream: the empty commit SHA becomes a delete refspec.
+# This pushes ":refs/tags/v1.0" — which DELETES the tag on the remote.
+git push origin "${commit}:refs/tags/v1.0"
+```
+
+Always add an explicit empty-value guard after command substitution whose output is load-bearing:
+
+```bash
+commit=$(git commit-tree "$tree" -p "$parent" -m "msg")
+if [ -z "${commit}" ]; then
+  echo "ERROR: git commit-tree produced no output for tag ${tag}" >&2
+  continue   # or: exit 1, depending on context
+fi
+git push origin "${commit}:refs/tags/${tag}"
+```
+
+Note: SC2155 (`Declare and assign separately to avoid masking return values`) only applies to
+`local var=$(cmd)` — where the `local` builtin masks the exit code. For plain `var=$(cmd)`, the
+exit code is propagated and `set -e` works normally. The empty-output case is distinct and not
+covered by any shellcheck rule.
+
 ### CI Integration
 
 ```yaml


### PR DESCRIPTION
## Summary

Two documentation gaps surfaced during a session implementing a TYPO3 ELTS subtree-split pipeline using `git commit-tree` and `git push --mirror`:

- **`references/code-quality-tools.md`**: Added a new gotcha subsection under the shellcheck "Common Rules and Fixes" block documenting that command substitution whose command succeeds but emits no output produces a silently empty variable. `set -e` cannot catch this because the command exited 0. No shellcheck rule covers it for plain (non-`local`) variable assignments. An empty SHA interpolated into a push refspec becomes `:<ref>` — a delete operation. The fix is an explicit `[ -z "$var" ]` guard after every load-bearing command substitution.

- **`references/ci-cd-integration.md`**: Added a new top-level section "Git Mirror Repositories" documenting the `git clone --mirror` + `git push --mirror` workflow, the default-branch requirement (target must be created empty to avoid push failure when the upstream default branch name differs), and the notes-ref wipe gotcha (local `refs/notes/*` are deleted on every mirror push because they don't exist upstream).

## Session context

During a `git commit-tree`-based subtree-split rewrite, a code review found:
1. `commit_sha=$(git commit-tree ...)` — when `git commit-tree` produced no output, the empty SHA was silently interpolated as ` :refs/tags/X`, turning a tag-create push into a tag-delete push.
2. Mirror repos initialised with `main` as default branch caused every `git push --mirror` to fail because the upstream TYPO3 branch was `12.4`, not `main`, and GitLab refused to delete its default branch.
3. `refs/notes/*` caches written to the mirror target were wiped on each push run.

## Test plan

- [ ] Read both changed files end-to-end and verify the new content is consistent with the surrounding style
- [ ] Confirm the shellcheck gotcha section correctly distinguishes the empty-output case from SC2155 (local var masking)
- [ ] Confirm the mirror section covers: basic workflow, default-branch root cause + both fixes, notes-ref wipe, and example CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)