### PR TITLE
feat: add GW-30 staging branch composer.lock merge strategy

### DIFF
--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -306,3 +306,28 @@ llm_reviews:
 
       Skip cleanly (pass) when the repo is a regular clone (`.git/` is a
       directory, no `.bare/` sibling) — the convention does not apply.
+
+  # === STAGING BRANCH COMPOSER.LOCK MERGE STRATEGY ===
+  - id: GW-30
+    domain: git-workflow
+    severity: warning
+    desc: >-
+      When merging into a staging branch that pins dev-branch Composer packages,
+      take --ours on composer.lock then re-run `composer update <packages>` to
+      apply only the intended upgrades. Taking --theirs overwrites staging's
+      dev-* pins and may deploy wrong package versions.
+    prompt: |
+      Check if the repository has a `staging` branch and a `composer.lock`
+      containing `dev-` versioned packages (e.g. `dev-staging`, `dev-main`).
+
+      Run:
+        git show origin/staging:composer.lock 2>/dev/null | grep '"version": "dev-' | head -5
+
+      If dev-versioned packages exist, verify that the project's contributing
+      guide or AGENTS.md documents the staging merge strategy:
+      - On merge conflict in composer.lock: take `--ours` (staging base) first
+      - Then run `composer update <targeted-packages>` to apply only the
+        intended version changes
+      - Do NOT take `--theirs` — it overwrites all dev-* pins
+
+      Report as warning if dev-* packages exist but the strategy is not documented.

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -321,7 +321,8 @@ llm_reviews:
       containing `dev-` versioned packages (e.g. `dev-staging`, `dev-main`).
 
       Run:
-        git show origin/staging:composer.lock 2>/dev/null | grep '"version": "dev-' | head -5
+        git fetch origin staging:refs/remotes/origin/staging --depth=1 2>/dev/null || true
+        (git show origin/staging:composer.lock || git show staging:composer.lock) 2>/dev/null | grep '"version": "dev-' | head -5
 
       If dev-versioned packages exist, verify that the project's contributing
       guide or AGENTS.md documents the staging merge strategy:


### PR DESCRIPTION
## Summary

- **GW-30** (LLM review): detects repos with a staging branch containing `dev-*` Composer packages and warns if the safe merge strategy is not documented

## Motivation

During OPSCHEM-499 (TYPO3 12.4.46 ELTS merge into staging), a merge conflict arose in `composer.lock`. The staging branch pins several packages to `dev-staging` branches (e.g. `nrc-template-chemnitz dev-staging`). Taking `--theirs` from the feature branch would have overwritten all those pins, potentially deploying wrong package versions to staging.

The safe strategy:
1. Take `--ours` on `composer.lock` (preserve staging base)
2. Re-run `composer update <targeted-packages>` to apply only the intended upgrades

This pattern is not obvious and not documented in most projects. The checkpoint prompts the reviewer to verify it is captured in AGENTS.md or a contributing guide.

## Test plan

- [ ] `checkpoints.yaml` is valid YAML
- [ ] Checkpoint correctly identifies repos with `dev-` packages in the staging lock file
- [ ] Prompt is clear and describes both the detection criteria and the expected documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)