### PR TITLE
feat: add merge-gate watcher reference

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 
 # Git Workflow Skill
 
-Expert patterns for Git version control: branching, commits, collaboration, and CI/CD.
+Expert patterns for Git: branching, commits, collaboration, CI/CD.
 
 ## Critical Rules (Non-Negotiable)
 
@@ -28,7 +28,7 @@ See `references/pull-request-workflow.md` for merge-gate, atomic-commit, and SHA
 
 ## Reference Files
 
-Load references on demand based on the task at hand:
+Load references on demand:
 
 | Reference | Content Triggers |
 |-----------|-----------------|
@@ -41,6 +41,7 @@ Load references on demand based on the task at hand:
 | `references/git-hooks-setup.md` | Hook frameworks, detection, recommended hooks per stage |
 | `references/claude-code-hooks.md` | Claude Code `settings.json` hooks — merge gate, cache-path rejection, auto-lint |
 | `references/code-quality-tools.md` | shellcheck, shfmt, git-absorb, difftastic |
+| `references/merge-gate-watcher.md` | Merge-driver loop, hard/soft check taxonomy, rerun stale-SHA, review-bot rounds |
 
 ## Conventional Commits
 
@@ -63,7 +64,7 @@ hotfix/1.2.1-security-patch
 
 ## Hook Detection
 
-Before first commit, detect and install hooks:
+Detect hooks before first commit:
 
 ```bash
 ls lefthook.yml .lefthook.yml captainhook.json .pre-commit-config.yaml .husky/pre-commit 2>/dev/null || echo "No hooks"
@@ -79,7 +80,7 @@ Install: `lefthook install` | `composer install` | `npm install` | `pre-commit i
 
 ## PR Merge Requirements
 
-Before merging: threads resolved, CI green (incl. annotations), rebased, signed. Signed commits + rebase-only: use `git merge --ff-only`.
+Before merging: threads resolved, CI green (incl. annotations), rebased, signed. Rebase-only + signed: `git merge --ff-only`.
 
 ## Verification
 

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -1,0 +1,64 @@
+# Merge-Gate Watcher
+
+Canonical polling loop to drive a PR to merge once review threads are handled. Hand-rolling this per PR invites classification bugs (a soft check counted as hard ⇒ false HOLD; a missed one ⇒ premature merge).
+
+## Check taxonomy
+
+Classify every failing check BEFORE reacting:
+
+| Class | Examples | Reaction |
+|-------|----------|----------|
+| **Hard** | unit/integration/E2E tests, lint, build | HOLD and fix — except known infra flakes (Docker Hub pull timeout, buildx setup): one `gh run rerun <id> --failed` |
+| **Soft, self-healing** | `codecov/*` while sibling jobs still run (partial uploads) | Ignore while `pending > 0`; if persisting after completion: one full `gh run rerun <id>` |
+| **Soft, structural** | SonarCloud PR gate on refactor PRs | Introspect before deciding (below) |
+
+## Sonar gate introspection
+
+Never merge on a red Sonar gate without knowing *why* it is red:
+
+```bash
+AUTH="Authorization: Bearer $SONAR_TOKEN"
+curl -s -H "$AUTH" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$KEY&pullRequest=$PR" \
+  | jq -r '[.projectStatus.conditions[]|select(.status!="OK")|.metricKey]|join(",")'
+curl -s -H "$AUTH" "https://sonarcloud.io/api/issues/search?componentKeys=$KEY&pullRequest=$PR&resolved=false&ps=1" | jq .total
+```
+
+Merge-despite is defensible only when the sole failing condition is a touched-line re-attribution metric (`new_duplicated_lines_density`, patch coverage on refactor-moved lines), open PR issues are 0, and the PR body documents the rationale. Real findings: fix them.
+
+## Watcher skeleton
+
+```bash
+R=owner/repo; PR=123; BR=branch; RERUN_DONE=0
+for i in $(seq 1 100); do
+  sleep 30
+  STATE=$(gh pr view $PR --repo $R --json state,mergeStateStatus) || continue
+  [ "$(jq -r .state <<<"$STATE")" = "MERGED" ] && exit 0
+  MS=$(jq -r .mergeStateStatus <<<"$STATE")
+  UNRES=$(gh api graphql -f query="{repository(owner:\"${R%/*}\",name:\"${R#*/}\"){pullRequest(number:$PR){reviewThreads(first:100){nodes{isResolved}}}}}" \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved|not)]|length') || continue
+  CHECKS=$(gh pr checks $PR --repo $R 2>/dev/null)
+  PENDING=$(grep -c -E "pending|in_progress" <<<"$CHECKS" || true)
+  HARD=$(grep "fail" <<<"$CHECKS" | grep -v -c -E "codecov|SonarCloud Code Analysis" || true)
+  SOFT=$(grep "fail" <<<"$CHECKS" | grep -c -E "codecov|SonarCloud Code Analysis" || true)
+  [ "$MS" = "BLOCKED" ] && [ "$UNRES" -gt 0 ] && { echo "HOLD: $UNRES threads"; exit 1; }
+  if [ "$HARD" -gt 0 ] && [ "$PENDING" -eq 0 ]; then
+    # one rerun for infra flakes only, then HOLD
+    if [ "$RERUN_DONE" -eq 0 ] && grep "fail" <<<"$CHECKS" | grep -qE "E2E|Integration|docker"; then
+      gh run rerun "$(gh run list --repo $R --branch $BR --workflow CI --limit 1 --json databaseId --jq '.[0].databaseId')" --repo $R --failed
+      RERUN_DONE=1; sleep 60; continue
+    fi
+    echo "HOLD: hard fails"; grep fail <<<"$CHECKS"; exit 1
+  fi
+  if [ "$PENDING" -eq 0 ] && [ "$UNRES" -eq 0 ] && { [ "$MS" = "CLEAN" ] || [ "$MS" = "UNSTABLE" ]; } && [ "$HARD" -eq 0 ] && [ "$SOFT" -eq 0 ]; then
+    gh pr merge $PR --repo $R --merge && exit 0
+  fi
+done
+```
+
+Pitfalls baked in: `grep -c` exits 1 on zero matches (`|| true`); decide hard-fail only at `PENDING -eq 0` (codecov posts transient FAILURE mid-run); never count a check class you did not explicitly list.
+
+## Two facts the loop depends on
+
+**`gh run rerun` reuses the original `GITHUB_SHA`.** For `pull_request` events that is the merge commit computed at first run — a rerun after a base-branch fix still tests against the broken base. Rerun is only for flakes; to pick up a repaired base, rebase the branch and push.
+
+**Review bots converge over multiple rounds.** Every push invalidates the review (ruleset `copilot_code_review` needs a fresh review on the latest head), so re-request after each push: `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Later rounds may flag UNCHANGED lines adjacent to the diff (latent legacy bugs) — triage each finding on its merits; expect 3–6 rounds on large refactor PRs, with finding severity decreasing per round. Re-arm the watcher after every push.


### PR DESCRIPTION
Adds `references/merge-gate-watcher.md`: the canonical polling loop to drive a PR to merge, with

- a **hard/soft check taxonomy** (infra flakes → one `gh run rerun --failed`; codecov partial uploads → tolerate while pending, one full rerun after; SonarCloud gate → introspect conditions via API before any merge-despite decision),
- the **`gh run rerun` stale-SHA fact** (pull_request reruns test the ORIGINAL merge commit — after a base-branch fix, rebase+push instead), and
- **review-bot convergence guidance** (every push invalidates the review; re-request per push; later rounds may flag unchanged lines; expect 3–6 rounds on large refactor PRs).

SKILL.md gains the references-table row; prose elsewhere trimmed to stay within the 500-word cap (validator green, 0 errors / 0 warnings).

Distilled from driving netresearch/timetracker #325–#331 through their review cycles, where hand-rolled watcher variants produced two check-classification bugs (false HOLDs).