### PR TITLE
docs(pr-workflow): merge-queue arming gate and CI-decoupled thread work

### DIFF
--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -43,7 +43,10 @@ resolution, and merge-queue handling. Then execute, in order:
    `addPullRequestReviewThreadReply` mutation (using the thread ID from preflight, never
    a general PR comment), reference the fixing commit, then resolve the thread via the
    GraphQL `resolveReviewThread` mutation. Verify `isResolved` — green CI alone is not
-   sufficient.
+   sufficient. **Work threads the moment they land — never gate thread work on the CI
+   matrix settling** (bot reviews are actionable 2–5 min after a push; a thread may
+   target a pre-push range a later commit already fixed — answer with the fixing SHA
+   and resolve).
 4. **Update the PR title and description** to match the final state.
 5. **Merge only when fully green AND all threads resolved** — `--merge` or `--rebase`,
    never `--squash` (preserve atomic history). **Never merge while a review is announced
@@ -57,6 +60,11 @@ resolution, and merge-queue handling. Then execute, in order:
    responds. You don't force a review to materialize where none is required (reviews may
    legitimately never run), but any review that *is* announced must finish.
    Dependabot/Renovate PRs auto-merge via the deps workflow — never merge those by hand.
+   **Merge-queue repos: arm `gh pr merge --auto` only after this gate passes** (threads
+   resolved + checks green + no pending review request) — the queue ignores review
+   threads, so arming at PR creation merges over unaddressed feedback; a queued PR
+   rejects branch pushes and needs the GraphQL `dequeuePullRequest` mutation to recover
+   (see the skill's pull-request-workflow reference, "Arming Gate").
 6. **Post-merge:** confirm any merge-triggered async jobs, and clean up the branch.
 
 No version bumps or CHANGELOG entries in feature PRs. No bot attribution in

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -766,6 +766,35 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 - [ ] **Signed commits** — every commit in the PR is signed (see "Signing and DCO Failures" below if blocked)
 - [ ] **DCO sign-off** — every commit has a `Signed-off-by:` trailer matching `git config user.{name,email}` (required when the `probot/dco` check is enabled)
 
+### Auto-Merge / Merge-Queue Arming Gate
+
+`gh pr merge --auto` is a **deferred merge with no human in the loop** — and a
+merge queue only re-runs *required checks*; it does **not** wait for review
+threads, bot reviews in flight, or Sonar-style informational checks. Arming at
+PR creation therefore merges over unaddressed review feedback the moment CI is
+green.
+
+Arm auto-merge / enqueue **only when all three hold**:
+
+1. **Zero unresolved review threads** (GraphQL `reviewThreads`, not the UI).
+2. **All checks green** — including non-required ones you intend to honor.
+3. **No pending review request** (`gh pr view --json reviewRequests` is `[]`)
+   — a re-requested bot review that has not landed yet counts as pending.
+
+Bot reviews (Copilot, Gemini) land 2–5 minutes after each push — wait that
+window out before concluding "no threads".
+
+**Recovery when armed too early:**
+
+```bash
+# A PR already picked up by the queue rejects --disable-auto AND branch pushes
+# ("Pull request is already queued to merge"). Dequeue it via GraphQL:
+PRID=$(gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:N){id}}}' \
+  --jq .data.repository.pullRequest.id)
+gh api graphql -f query="mutation { dequeuePullRequest(input: {id: \"$PRID\"}) { mergeQueueEntry { id } } }"
+# Branch is pushable again; fix threads, then re-arm through this gate.
+```
+
 ### Signing and DCO Failures
 
 When `mergeStateStatus: BLOCKED` and the blocking check is `dco` or a "Commits must have verified signatures" branch-protection rule, act on these in order:
@@ -984,6 +1013,15 @@ gh api "repos/OWNER/REPO/commits/SHA/check-runs" \
 
 ### 2. Resolve Review Comments
 
+**Work threads the moment they land — decoupled from CI.** Review comments
+are workable input 2–5 minutes after a push; there is no reason to wait for
+the full check matrix before starting on them. Poll `reviewThreads`
+independently of `gh pr checks` (a watcher that gates thread reporting on
+"all checks settled" hides actionable feedback for the length of the longest
+job). Bot reviews also race your pushes: a thread may flag code a commit you
+just pushed already fixed — answer it with the fixing SHA and resolve; no
+churn needed.
+
 ```bash
 # List unresolved threads
 gh api graphql -f query='query {
@@ -1030,7 +1068,9 @@ STRATEGY=$(gh api "repos/OWNER/REPO" --jq '
 [ "$STRATEGY" = "--squash" ] && echo "WARNING: only squash is enabled — this rewrites history and drops signatures" >&2
 gh pr merge <NUMBER> --auto "$STRATEGY"
 
-# For repos with merge queue, just queue it
+# For repos with merge queue, queue it — but ONLY after passing the
+# "Auto-Merge / Merge-Queue Arming Gate" above (the queue ignores
+# unresolved review threads and in-flight bot reviews).
 gh pr merge <NUMBER> --auto
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -789,9 +789,11 @@ window out before concluding "no threads".
 ```bash
 # A PR already picked up by the queue rejects --disable-auto AND branch pushes
 # ("Pull request is already queued to merge"). Dequeue it via GraphQL:
-PRID=$(gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:N){id}}}' \
+PRID=$(gh api graphql -F owner=OWNER -F repo=REPO -F pr=NUMBER \
+  -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){id}}}' \
   --jq .data.repository.pullRequest.id)
-gh api graphql -f query="mutation { dequeuePullRequest(input: {id: \"$PRID\"}) { mergeQueueEntry { id } } }"
+gh api graphql -F id="$PRID" \
+  -f query='mutation($id:ID!){ dequeuePullRequest(input:{id:$id}) { mergeQueueEntry { id } } }' 
 # Branch is pushable again; fix threads, then re-arm through this gate.
 ```
 


### PR DESCRIPTION
## Summary

Two lessons from a live session (netresearch/t3x-nr-llm#240/#241), both user-flagged:

1. **Merge-queue arming gate** — `gh pr merge --auto` armed at PR creation lets the queue merge over unresolved review threads: queues re-run *required checks* only. New subsection in `pull-request-workflow.md` with the three arming conditions (threads resolved, checks green, no pending review request), the 2–5-min bot-review landing window, and the `dequeuePullRequest` GraphQL recovery (queued branches reject pushes and `--disable-auto`). The "just queue it" line in the merge section now points at the gate; `/pr-finish` step 5 carries the same rule.

2. **CI-decoupled thread work** — review threads are workable 2–5 minutes after a push; gating thread reporting/work on "all checks settled" hides actionable feedback for the length of the longest job. Documented in the Resolve-Review-Comments step plus the race pattern (thread targets a pre-push range → answer with the fixing SHA, resolve).

## Test plan

- Docs-only; rendered locally, anchors and code blocks verified.