### PR TITLE
chore(release): v1.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.16.0"
+  version: "1.17.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---
@@ -90,4 +90,4 @@ Before merging: threads resolved, CI green (incl. annotations), rebased, signed.
 
 ---
 
-> **Contributing:** https://github.com/netresearch/git-workflow-skill
+> **Contributing:** <https://github.com/netresearch/git-workflow-skill>


### PR DESCRIPTION
Release v1.17.0 (minor: new feature content since v1.16.0).

Changes since v1.16.0:
- feat: merge-gate watcher reference
- feat: GW-30 staging branch composer.lock merge strategy
- feat(mirrors): bash assignment exit-code gotcha and git push --mirror requirements
- fix: push ordering when uncommitted changes exist; fetch staging branch before git show
- docs: worktree hook gotchas, merge-queue arming gate, identity/signing preflight and DCO recovery

Also fixes a pre-existing MD034 bare-URL lint error in SKILL.md (file touched by the version bump).
