### PR TITLE
feat: timeline-event check for old-head review + CLEAN merge decisions

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -305,5 +305,27 @@
         "pattern": "(CLEAN is not sufficient|CLEAN isn.t sufficient|CLEAN alone|CLEAN can be stale|CLEAN doesn.t mean|not sufficient to merge|review_on_push|empty reviewRequests doesn|reviewRequests is not)"
       }
     ]
+  },
+  {
+    "name": "old_head_review_clean_timeline_check",
+    "prompt": "PR has all checks green and mergeStateStatus CLEAN, but the only Copilot review is on the previous commit; I pushed a docs-only commit afterwards. Can I merge?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)timeline"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)review.?request"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(after|since|following).{0,50}(push|commit|head)"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(mergeable|safe to merge|can merge|merge it).{0,160}(no (new |further )?review|nothing (was )?announced|not.{0,20}announced)|((no (new |further )?review|nothing (was )?announced).{0,160}(mergeable|safe to merge|can merge))"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -784,6 +784,25 @@ Arm auto-merge / enqueue **only when all three hold**:
 Bot reviews (Copilot, Gemini) land 2–5 minutes after each push — wait that
 window out before concluding "no threads".
 
+**Review on an earlier head + `CLEAN`: decide via the timeline, not the
+review list.** After a follow-up push (docs-only changes often do not
+re-trigger Copilot), the only review on record may sit on a previous commit
+while `mergeStateStatus` reports `CLEAN` off it. Whether that is mergeable
+depends on one question: was any review (re)announced *after* the latest
+push? The reviews list cannot answer it — query the timeline events:
+
+```bash
+gh api repos/OWNER/REPO/issues/NUMBER/timeline --jq \
+  '[.[] | select(.event=="review_requested" or .event=="reviewed")
+        | {event, actor: (.actor.login // .user.login), at: (.created_at // .submitted_at)}]'
+```
+
+- Last `review_requested` is **before** the latest push and a matching
+  `reviewed` followed it, no newer request → no review is in flight; the
+  old-head review + `CLEAN` is mergeable.
+- A `review_requested` **after** the latest push with no `reviewed` yet →
+  a review is in flight; wait (see *Never merge over an announced review*).
+
 **Recovery when armed too early:**
 
 ```bash

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -792,7 +792,8 @@ depends on one question: was any review (re)announced *after* the latest
 push? The reviews list cannot answer it — query the timeline events:
 
 ```bash
-gh api repos/OWNER/REPO/issues/NUMBER/timeline --jq \
+R=<owner/repo>; PR=<number>
+gh api repos/$R/issues/$PR/timeline --jq \
   '[.[] | select(.event=="review_requested" or .event=="reviewed")
         | {event, actor: (.actor.login // .user.login), at: (.created_at // .submitted_at)}]'
 ```


### PR DESCRIPTION
Companion to the arming gate and the 'never merge over an announced review' rule: after a follow-up push, the only review on record may sit on the previous commit while `mergeStateStatus` reports `CLEAN` off it (a `review_on_push: false` ruleset). `reviewRequests: []` and the reviews list cannot distinguish 'no new review will come' from 'one is in flight'.

The new subsection documents the deciding query — the issue timeline's `review_requested`/`reviewed` events compared against the latest push time — and both outcomes. Used three times during the nr-repurpose v0.1.0 release day (2026-06-12), incl. a docs-only push that did not re-trigger Copilot.

Eval `old_head_review_clean_timeline_check` added.