### PR TITLE
docs(merge-gate): require gate query and merge as separate invocations

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -327,5 +327,23 @@
         "pattern": "(?i)(mergeable|safe to merge|can merge|merge it).{0,160}(no (new |further )?review|nothing (was )?announced|not.{0,20}announced)|((no (new |further )?review|nothing (was )?announced).{0,160}(mergeable|safe to merge|can merge))"
       }
     ]
+  },
+  {
+    "name": "merge_gate_separate_invocation",
+    "prompt": "PR #42 has green CI and mergeStateStatus CLEAN, but its review threads may still be open. Run the merge gate check and merge it in one go.",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)(separate|two|distinct).{0,40}(invocation|command|step)|(read|inspect|check).{0,60}output.{0,80}(then|before).{0,40}merge"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(never|don.t|do not|won.t|refus).{0,60}(chain|&&|one (go|command|compound)|same command|single command)"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(exit (code|status)|CLEAN (does not|doesn.t).{0,40}(unresolved|thread)|unresolved (review )?thread)"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -338,11 +338,11 @@
       },
       {
         "type": "content",
-        "pattern": "(?i)(never|don.t|do not|won.t|refus).{0,60}(chain|&&|one (go|command|compound)|same command|single command)"
+        "pattern": "(?i)(never|don.t|do not|won.t|refus|can.t|cannot|should not|shouldn.t|must not|mustn.t).{0,60}(chain|&&|one (go|command|compound)|same command|single command)"
       },
       {
         "type": "content",
-        "pattern": "(?i)(exit (code|status)|CLEAN (does not|doesn.t).{0,40}(unresolved|thread)|unresolved (review )?thread)"
+        "pattern": "(?i)(exit.{0,12}(code|status|0|zero)|CLEAN (does not|doesn.t).{0,40}(unresolved|thread|conversation)|unresolved (review )?(thread|conversation))"
       }
     ]
   }

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -813,7 +813,7 @@ PRID=$(gh api graphql -F owner=OWNER -F repo=REPO -F pr=NUMBER \
   -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){id}}}' \
   --jq .data.repository.pullRequest.id)
 gh api graphql -F id="$PRID" \
-  -f query='mutation($id:ID!){ dequeuePullRequest(input:{id:$id}) { mergeQueueEntry { id } } }' 
+  -f query='mutation($id:ID!){ dequeuePullRequest(input:{id:$id}) { mergeQueueEntry { id } } }'
 # Branch is pushable again; fix threads, then re-arm through this gate.
 ```
 
@@ -869,6 +869,26 @@ gh pr view NUMBER --json reviewDecision,mergeStateStatus,mergeable,statusCheckRo
 #   mergeable                                 == "MERGEABLE"
 #   every statusCheckRollup[].conclusion      == "SUCCESS"
 #   every reviewThreads[].isResolved          == true   # gh flattens the GraphQL edges/nodes
+```
+
+**The gate and the merge are two separate invocations.** Run the gate query,
+read its output, and only then issue `gh pr merge` as a new command. Never
+chain them (`gate-query && gh pr merge`, or query-then-merge in one
+heredoc/compound command): shell chaining decides on **exit codes**, not on
+the gate's content — `gh pr view` exits 0 whether it reports zero unresolved
+threads or three, so the merge fires before anyone has read the gate's
+output. And `mergeStateStatus: CLEAN` does **not** imply zero unresolved
+threads — GitHub only couples the two when the "require conversation
+resolution" branch-protection rule is enabled, which most repos don't turn on.
+
+```bash
+# ❌ Wrong — merge already executed by the time "unresolved: 3" is visible
+gh pr view 42 --json mergeStateStatus,reviewThreads && gh pr merge 42 --merge
+
+# ✅ Right — two invocations, with an explicit read of the gate output between
+gh pr view 42 --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup,reviewThreads
+# READ the output: all threads resolved? all checks green? Only then, as a new command:
+gh pr merge 42 --merge
 ```
 
 The PR-level gate above covers review decision, merge state, required checks, and thread resolution in one response. A second check is needed for CI annotations (warnings — reviewdog / actionlint / CodeQL deprecations — that don't fail their check but still need addressing). These are a commit-level property, not a PR-level one:


### PR DESCRIPTION
## Why

Incident (2026-06-12): a PR was merged while 3 review threads were still unresolved. The merge-gate query and `gh pr merge` had been chained in one compound shell command (`gate-query && gh pr merge` style). The gate's output ("unresolved: 3") only became visible after the merge had already executed. The unresolved threads contained a high-severity security finding (worker running as root) that then required a follow-up PR.

The root cause is structural, not a one-off mistake: shell chaining decides on **exit codes**, not on the gate's **content**. `gh pr view` exits 0 whether it reports zero unresolved threads or three, so any `query && merge` (or query-then-merge inside one heredoc/compound command) merges unconditionally. A `CLEAN` `mergeStateStatus` does not close this gap either — GitHub only couples merge state to thread resolution when the "require conversation resolution" branch-protection rule is enabled, which most repos don't turn on.

## What

- `skills/git-workflow/references/pull-request-workflow.md` (Merge-Gate Command section): new rule — **the gate and the merge are two separate invocations**; run the gate query, read its output, only then issue `gh pr merge` as a new command. Includes a wrong/right example pair in the file's existing style.
- `skills/git-workflow/evals/evals.json`: new eval `merge_gate_separate_invocation` — given a PR with green CI, `CLEAN` merge state, and possibly-open threads, the assistant must not merge in the same command as the gate query.

## Validation

- `pre-commit run --all-files`: all hooks pass on the changed files; the only failures are two pre-existing shellcheck findings in untouched files (`.envrc` SC2148, `verify-git-workflow.sh` SC2001), present on `main` before this change.
- evals.json parsed and all assertion regexes compile.
