### PR TITLE
feat: spec-cleanup capability — keep intermediate planning artifacts off the base branch

### DIFF
--- a/.spec-cleanup.yml.example
+++ b/.spec-cleanup.yml.example
@@ -1,0 +1,30 @@
+# .spec-cleanup.yml — declares intermediate planning artifacts that must NOT
+# reach the base branch. Copy to `.spec-cleanup.yml` to activate.
+# Read by skills/git-workflow/scripts/spec-cleanup-guard.sh (requires yq v4 when
+# this file is present). Without an active config the guard's baked-in defaults
+# apply. See skills/git-workflow/references/spec-cleanup.md.
+
+# Throwaway planning artifacts (Guard detects; Capture removes after capture).
+# Globs are git pathspecs: a trailing /** means "this directory, recursively";
+# a suffix pattern (e.g. **/*.plan.md) MUST be path-anchored to avoid matching
+# real project files like src/foo.plan.md.
+intermediate_paths:
+  - docs/superpowers/**
+  - claudedocs/**
+  - docs/working/**
+  - docs/superpowers/**/*.plan.md
+
+# Deliberate keepers that would otherwise match a glob above (optional).
+exclude:
+  - docs/superpowers/specs/**/KEEP-*.md
+
+# Where Capture proposes durable knowledge. v1 ships the ADR target only;
+# prd (update-in-place) and docs (user-doc stubs) are deferred phase-2 targets.
+capture_targets:
+  adr: docs/adr/
+  # prd:  docs/PRD.md
+  # docs: Documentation/
+
+# convert (default): propose an ADR, then remove the raw artifacts recoverably.
+# remove: skip conversion, remove recoverably (still manifest + confirm).
+mode: convert

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ Expert patterns for Git version control: branching, commits, collaboration, and 
 │   ├── evals/                      # Skill evaluations
 │   ├── references/                 # Detailed reference docs (see below)
 │   └── scripts/
-│       └── verify-git-workflow.sh  # Git workflow verification
+│       ├── verify-git-workflow.sh  # Git workflow verification
+│       └── spec-cleanup-guard.sh   # Read-only gate for intermediate planning artifacts
+├── .spec-cleanup.yml.example       # Template config for the spec-cleanup guard
 ├── Build/
 │   ├── Scripts/                    # Build/validation scripts
 │   └── hooks/                      # Git hook templates (pre-commit, pre-push)
@@ -25,6 +27,18 @@ Expert patterns for Git version control: branching, commits, collaboration, and 
 ├── composer.json                   # Composer package manifest
 └── README.md
 ```
+
+### Doc folder taxonomy (for the spec-cleanup guard)
+
+The spec-cleanup capability (`references/spec-cleanup.md`) distinguishes two
+classes of doc folder. The machine-readable source of truth is
+`.spec-cleanup.yml` (here, `.spec-cleanup.yml.example` — this repo ships no
+active config so the guard does not flag its own dogfooded design spec).
+
+- **Persisted / durable** — keep in the base branch: `docs/adr/`, `docs/PRD.md`,
+  `Documentation/`, plus this repo's `docs/` architecture/planning notes.
+- **Intermediate / working** — must never reach the base branch:
+  `docs/superpowers/`, `claudedocs/`, `docs/working/`, ad-hoc `*.plan.md`.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Expert patterns for Git version control: branching, commits, collaboration, and 
 The spec-cleanup capability (`references/spec-cleanup.md`) distinguishes two
 classes of doc folder. The machine-readable source of truth is
 `.spec-cleanup.yml` (here, `.spec-cleanup.yml.example` — this repo ships no
-active config so the guard does not flag its own dogfooded design spec).
+active config, so the guard is not wired into its own gate; run manually with the
+baked-in defaults it *does* flag the dogfooded design spec, by design).
 
 - **Persisted / durable** — keep in the base branch: `docs/adr/`, `docs/PRD.md`,
   `Documentation/`, plus this repo's `docs/` architecture/planning notes.

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -31,6 +31,19 @@ resolution, and merge-queue handling. Then execute, in order:
    (if a `copilot_code_review` rule is blocking because no review has been triggered yet,
    you can request one via `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` — but once requested you must wait for it to land before merging; see step 5, never merge over an in-flight review), pending review requests, and the thread IDs needed to reply to and resolve each thread. Reason once from this, not serially.
 
+   **Spec-cleanup gate (run before step 1, while the branch is yours to clean).**
+   Run `bash skills/git-workflow/scripts/spec-cleanup-guard.sh` (or the repo's
+   installed path). If it reports intermediate planning artifacts — superpowers
+   specs/plans (`docs/superpowers/**`), ad-hoc `PLAN.md`, planning-tool output —
+   that would reach the base branch, resolve them first: **convert** the durable
+   decisions into an ADR (propose the diff, get review, commit), then **remove**
+   the raw files recoverably (never bare-`rm` an untracked file; stage it so it
+   enters history, then `git rm` in a `chore: remove working specs/plans` commit),
+   or **acknowledge** "nothing durable" with a `Spec-Cleanup: acknowledged`
+   trailer. Verify the capture commit landed before removing. Do this before the
+   rebase so the branch is clean when the gate runs. See
+   `skills/git-workflow/references/spec-cleanup.md`.
+
 1. **Rebase** onto the base branch if the branch is behind. In bare-repo worktree
    setups, fetch explicitly (`git fetch origin <branch>:refs/remotes/origin/<branch>`)
    — `origin/*` may not auto-update and `--force-with-lease` then fails "stale info".

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -37,8 +37,9 @@ resolution, and merge-queue handling. Then execute, in order:
    specs/plans (`docs/superpowers/**`), ad-hoc `PLAN.md`, planning-tool output —
    that would reach the base branch, resolve them first: **convert** the durable
    decisions into an ADR (propose the diff, get review, commit), then **remove**
-   the raw files recoverably (never bare-`rm` an untracked file; stage it so it
-   enters history, then `git rm` in a `chore: remove working specs/plans` commit),
+   the raw files recoverably (never bare-`rm` an untracked file; `git add -- <that
+   path>` only — never `-A/-u` — so it enters history, then `git rm` in a
+   `chore: remove working specs/plans` commit),
    or **acknowledge** "nothing durable" with a `Spec-Cleanup: acknowledged`
    trailer. Verify the capture commit landed before removing. Do this before the
    rebase so the branch is clean when the gate runs. See

--- a/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
@@ -1,0 +1,190 @@
+# Spec-Cleanup Capability — Design
+
+- **Date:** 2026-06-16
+- **Status:** Draft (pending implementation plan)
+- **Home:** `git-workflow-skill` (global org skill)
+- **Origin:** #team-ecom discussion 2026-06-15 — superpowers spec/plan files
+  (~5000 lines) committed on a feature branch (HMKG-2227) and dragged across
+  branches via `develop`. Team agreed intermediate planning artifacts must not
+  land in the base branch and durable knowledge should be captured first.
+
+## 1. Problem
+
+Dev-time planning artifacts — superpowers specs/plans (`docs/superpowers/**`),
+Claude's own scratch plans, output from other planning tools — get committed to
+feature branches and then carried into the base branch on merge. They are
+throwaway working notes, not durable documentation, so they rot in the repo and
+pollute history.
+
+Two distinct needs, with different failure modes, were conflated in the chat:
+
+- **Hygiene / gate** — keep throwaway planning files out of the base branch.
+  Deterministic, mechanical, safe to enforce.
+- **Knowledge capture** — distil durable decisions into PRD/ADR/user docs before
+  the raw files are removed. Creative, judgment-heavy, must stay human-reviewed.
+
+Bundling them into one silent "convert + remove on merge" does both badly: a
+poor auto-summary becomes a false source of truth, or a skipped capture blocks
+the merge. The design keeps them as two layers in one capability.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- Block the base branch from receiving tracked intermediate artifacts.
+- Catch artifacts in **all three states**: committed/tracked, staged, untracked
+  working-tree files.
+- Propose (never silent-write) durable docs — PRD update, ADR(s), user docs —
+  from the intermediate artifacts, for human review.
+- Default mode = **convert**, falling back to **remove-with-acknowledgement**.
+- Ship usable defaults; let repos extend via config and declare layout in
+  `AGENTS.md`.
+- Be a no-op when a branch has no intermediate artifacts (no cosmetic gate).
+
+**Non-Goals**
+- Auto-discovering "every intermediate file everywhere" by heuristic. Detection
+  is anchored to declared paths (Guard) plus in-session knowledge (Capture).
+- Auto-writing documentation without review.
+- Replacing the existing merge gate or `oro-qa-reviewer`; this composes with them.
+- A standalone skill — this lives inside `git-workflow-skill`.
+
+## 3. Architecture
+
+Two layers, one capability, wired into the existing `/pr-finish` flow and merge
+gate:
+
+```
+/pr-finish
+  └─ Guard (deterministic): tracked|staged|untracked intermediate artifacts?
+        ├─ none → existing merge gate → merge
+        └─ some → Capture (in-session, context-aware)
+                    → reads artifacts (declared globs ∪ session-known paths)
+                    → proposes PRD/ADR/docs diff ──review──┐
+                    → accept: commit docs + remove raw      │
+                    → none/reject: acknowledge + remove raw │
+                    → Guard re-check → clean → merge gate ──┘
+```
+
+### 3.1 Guard (deterministic, the enforceable net)
+
+`scripts/spec-cleanup-guard.sh`. Context-free so it can run at the merge gate
+and in CI. Given the config glob set, it reports any intermediate artifacts in
+three states:
+
+| State | Detection |
+|-------|-----------|
+| committed/tracked | `git ls-files -- <globs>` |
+| staged | `git diff --cached --name-only -- <globs>` |
+| untracked working-tree | `git ls-files --others --exclude-standard -- <globs>` |
+
+Exit non-zero with a message listing the offending files grouped by state and
+the three resolutions (convert / remove / acknowledge). Wired into:
+
+- the **merge gate** in `references/pull-request-workflow.md` (blocks merge), and
+- an **optional pre-commit hook** in `hooks/` (off by default — initial commit of
+  working notes is allowed per Paul's point; opt-in for repos wanting early
+  blocking per Ertner's point).
+
+### 3.2 Capture (assisted, proposes only)
+
+A `/pr-finish` step that runs in-session, so it can use **both** declared globs
+and **conversation context** (spec/plan files the agent authored this session,
+including ad-hoc `PLAN.md` or other-tool output that no static glob matches).
+Detection set = `declared globs ∪ session-known artifact paths`.
+
+It dispatches a sub-agent that **reads** the artifacts and **proposes a diff**:
+
+- PRD update (`capture_targets.prd`, update-in-place) — if present.
+- ADR(s) into the repo's existing ADR dir/numbering (`capture_targets.adr`).
+- User-doc stubs (`capture_targets.docs`).
+
+The human reviews the diff. On accept: commit the durable docs, then remove the
+raw artifacts (`git rm` for tracked, `rm` for untracked). On "nothing durable":
+record an explicit acknowledgement (commit trailer `Spec-Cleanup: acknowledged`)
+and remove-only. Capture **never** writes docs unattended; low-confidence or
+empty extraction surfaces "nothing durable found, confirm removal."
+
+### 3.3 Config — `.spec-cleanup.yml`
+
+Machine-readable mirror of the `AGENTS.md` layout declaration. Built-in defaults
+ship in the skill, so a repo with no config still guards `docs/superpowers/**`.
+
+```yaml
+intermediate_paths:        # throwaway planning artifacts (Guard + Capture)
+  - docs/superpowers/**
+  - claudedocs/**
+  - "**/*.plan.md"
+  - docs/working/**
+capture_targets:           # where durable knowledge goes; each optional
+  prd:  docs/PRD.md
+  adr:  docs/adr/
+  docs: Documentation/
+mode: convert              # convert | remove | block   (default: convert)
+pre_commit_block: false    # opt-in early blocking
+```
+
+Absent `capture_targets` → Capture degrades to remove-with-acknowledgement.
+
+### 3.4 AGENTS.md — canonical layout declaration
+
+`AGENTS.md` gains a layout subsection distinguishing **persisted/durable** doc
+folders from **intermediate/working** folders, e.g.:
+
+```
+docs/PRD.md, docs/adr/, Documentation/   # persisted — durable knowledge
+docs/superpowers/, claudedocs/, docs/working/  # intermediate — never reach base
+```
+
+`AGENTS.md` is the human source of truth; `.spec-cleanup.yml` is its
+machine-readable mirror. A consistency check (agent-harness "doc-drift" style)
+warns when the two diverge.
+
+## 4. Data flow / state resolution
+
+The gate is clean only when **no** intermediate artifact remains in **any** of
+the three states. Resolution paths:
+
+1. **Convert** (default) — Capture proposes docs → human accepts → docs committed
+   → raw removed.
+2. **Remove** — raw removed without conversion (mode `remove`, or human declines
+   conversion).
+3. **Acknowledge** — human asserts nothing durable; commit trailer recorded; raw
+   removed.
+
+## 5. Error handling / edge cases
+
+- **No config** → built-in defaults (`docs/superpowers/**`), convert mode, no
+  capture targets → remove-with-ack.
+- **Capture low-confidence / empty** → no auto-write; surfaces confirm-removal.
+- **Reference project / empty `src/`** → no intermediate files → Guard is a no-op
+  (avoids the "cosmetic stage" smell raised in the same chat).
+- **Binary / very large plans** → Guard only checks path presence; Capture reads
+  text and skips binaries.
+- **Already-clean branch** → Guard no-op, merge proceeds normally.
+- **CI context (no session)** → only the Guard runs; Capture is interactive-only.
+
+## 6. Adoption by team repos
+
+The `ecom-orocommerce-docker` repo adopts the capability by adding its own
+`.spec-cleanup.yml` (orocommerce-specific globs + doc targets) — no forked logic.
+It composes with the existing `oro-qa-reviewer` agent rather than replacing it.
+
+## 7. Testing
+
+Evals in `skills/git-workflow/evals/` plus a `checkpoints.yaml` entry:
+
+- **E1** branch with `docs/superpowers/**` tracked → Guard fails, lists files by
+  state.
+- **E2** untracked intermediate file present → Guard fails (untracked state).
+- **E3** after convert + remove → Guard passes.
+- **E4** repo with no config → default Guard active on `docs/superpowers/**`.
+- **E5** acknowledge path → Guard passes with removal only + trailer present.
+- **E6** clean branch → Guard no-op.
+- **E7** `AGENTS.md` ↔ `.spec-cleanup.yml` divergence → consistency check warns.
+
+## 8. Delivery
+
+- Feature PR on `git-workflow-skill` (`feature/spec-cleanup-capability`).
+- No version bump / CHANGELOG entry in the feature PR (separate release flow).
+- Signed commits (`git commit -s`); DCO-enforced repo.
+- This design doc lives under `docs/superpowers/specs/` as intentional
+  dogfooding — the shipped capability would later capture-and-remove it.

--- a/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
@@ -1,7 +1,7 @@
 # Spec-Cleanup Capability — Design
 
 - **Date:** 2026-06-16
-- **Status:** Draft (pending implementation plan)
+- **Status:** Draft (revised after adversarial review; pending implementation plan)
 - **Home:** `git-workflow-skill` (global org skill)
 - **Origin:** #team-ecom discussion 2026-06-15 — superpowers spec/plan files
   (~5000 lines) committed on a feature branch (HMKG-2227) and dragged across
@@ -16,33 +16,36 @@ feature branches and then carried into the base branch on merge. They are
 throwaway working notes, not durable documentation, so they rot in the repo and
 pollute history.
 
-Two distinct needs, with different failure modes, were conflated in the chat:
+Two distinct needs with different failure modes were conflated in the chat:
 
 - **Hygiene / gate** — keep throwaway planning files out of the base branch.
-  Deterministic, mechanical, safe to enforce.
-- **Knowledge capture** — distil durable decisions into PRD/ADR/user docs before
+  Deterministic, mechanical, read-only, safe to enforce in CI.
+- **Knowledge capture** — distil durable decisions into ADR/PRD/user docs before
   the raw files are removed. Creative, judgment-heavy, must stay human-reviewed.
 
 Bundling them into one silent "convert + remove on merge" does both badly: a
 poor auto-summary becomes a false source of truth, or a skipped capture blocks
-the merge. The design keeps them as two layers in one capability.
+the merge. The design keeps them as two layers in one capability, and removal is
+always recoverable (it goes through git history, never bare `rm`).
 
 ## 2. Goals / Non-Goals
 
 **Goals**
 - Block the base branch from receiving tracked intermediate artifacts.
-- Catch artifacts in **all three states**: committed/tracked, staged, untracked
-  working-tree files.
-- Propose (never silent-write) durable docs — PRD update, ADR(s), user docs —
-  from the intermediate artifacts, for human review.
-- Default mode = **convert**, falling back to **remove-with-acknowledgement**.
-- Ship usable defaults; let repos extend via config and declare layout in
-  `AGENTS.md`.
+- Detect artifacts in **all three states**: committed/tracked, staged, and
+  untracked working-tree files.
+- Make every removal **recoverable** — go through git, never destroy untracked
+  content with bare `rm`.
+- Propose (never silent-write) durable docs from the artifacts, for human review.
 - Be a no-op when a branch has no intermediate artifacts (no cosmetic gate).
+- Ship usable defaults; let repos extend via `.spec-cleanup.yml`; declare the
+  folder taxonomy in `AGENTS.md`.
 
 **Non-Goals**
-- Auto-discovering "every intermediate file everywhere" by heuristic. Detection
-  is anchored to declared paths (Guard) plus in-session knowledge (Capture).
+- Auto-discovering "every intermediate file everywhere" by heuristic. Enforced
+  detection is anchored to declared globs (§3.2). Session context is used only to
+  *discover and register* stray artifacts (§3.4), never as a silent deletion
+  driver.
 - Auto-writing documentation without review.
 - Replacing the existing merge gate or `oro-qa-reviewer`; this composes with them.
 - A standalone skill — this lives inside `git-workflow-skill`.
@@ -53,138 +56,246 @@ Two layers, one capability, wired into the existing `/pr-finish` flow and merge
 gate:
 
 ```
-/pr-finish
-  └─ Guard (deterministic): tracked|staged|untracked intermediate artifacts?
-        ├─ none → existing merge gate → merge
-        └─ some → Capture (in-session, context-aware)
-                    → reads artifacts (declared globs ∪ session-known paths)
-                    → proposes PRD/ADR/docs diff ──review──┐
-                    → accept: commit docs + remove raw      │
-                    → none/reject: acknowledge + remove raw │
-                    → Guard re-check → clean → merge gate ──┘
+/pr-finish  (new step 0.5, before Rebase — branch must be clean before the gate)
+  └─ Guard (deterministic, READ-ONLY): tracked|staged|untracked intermediate artifacts?
+        ├─ none → existing Rebase → Merge Gate → Merge
+        └─ some → Capture (in-session)
+                    → print deletion manifest (grouped by state)  ── confirm ──┐
+                    → convert: propose ADR diff → human accepts → commit docs    │
+                    → verify docs commit landed                                  │
+                    → stage any untracked raw → commit removal (recoverable)     │
+                    → Guard re-check → clean → Rebase → Merge Gate → Merge ──────┘
 ```
 
-### 3.1 Guard (deterministic, the enforceable net)
+### 3.1 Guard — deterministic, read-only (the enforceable net)
 
-`scripts/spec-cleanup-guard.sh`. Context-free so it can run at the merge gate
-and in CI. Given the config glob set, it reports any intermediate artifacts in
-three states:
+`skills/git-workflow/scripts/spec-cleanup-guard.sh` (skill-scoped, alongside
+`verify-git-workflow.sh`; `set -euo pipefail` per repo convention). Context-free
+so it runs at the merge gate and in CI with no session.
 
-| State | Detection |
-|-------|-----------|
-| committed/tracked | `git ls-files -- <globs>` |
-| staged | `git diff --cached --name-only -- <globs>` |
-| untracked working-tree | `git ls-files --others --exclude-standard -- <globs>` |
+**Invariant: the Guard NEVER deletes, stages, or modifies any file.** It reports
+and exits non-zero. Only the interactive Capture step removes files (§3.5).
 
-Exit non-zero with a message listing the offending files grouped by state and
-the three resolutions (convert / remove / acknowledge). Wired into:
+It is **branch-local and state-based**: it flags the *presence* of intermediate
+artifacts in the current working tree / index, independent of any base branch
+(intermediate paths must never be tracked anywhere, so presence ⇒ fail; this
+sidesteps base-branch resolution entirely). The three states:
 
-- the **merge gate** in `references/pull-request-workflow.md` (blocks merge), and
-- an **optional pre-commit hook** in `hooks/` (off by default — initial commit of
-  working notes is allowed per Paul's point; opt-in for repos wanting early
-  blocking per Ertner's point).
+| State | Detection (exact) |
+|-------|-------------------|
+| committed/tracked | `git ls-files -- <pathspecs>` |
+| staged | `git diff --cached --name-only --diff-filter=AM -- <pathspecs>` |
+| untracked working-tree | `git ls-files --others --exclude-standard -- <pathspecs>` |
 
-### 3.2 Capture (assisted, proposes only)
+**Pathspec mechanism (pinned).** Git pathspec globbing is NOT shell/gitignore
+globbing. The Guard normalizes each config glob to a git pathspec:
+- a directory glob (`docs/superpowers/**`, `claudedocs/**`) → a **directory
+  pathspec** (`docs/superpowers/`, `claudedocs/`), which matches all files
+  beneath it recursively;
+- a suffix glob (`docs/superpowers/**/*.plan.md`) → **`:(glob)` magic**
+  (`:(glob)docs/superpowers/**/*.plan.md`), where `**` is explicitly recursive.
 
-A `/pr-finish` step that runs in-session, so it can use **both** declared globs
-and **conversation context** (spec/plan files the agent authored this session,
-including ad-hoc `PLAN.md` or other-tool output that no static glob matches).
-Detection set = `declared globs ∪ session-known artifact paths`.
+`exclude:` globs are applied as negative pathspecs / post-filter. A `--selftest`
+asserts a nested file `docs/superpowers/a/b/c.md` is caught in all three states.
 
-It dispatches a sub-agent that **reads** the artifacts and **proposes a diff**:
+`--dry-run`/default output lists every match grouped by state. On matches it
+exits non-zero with the three resolutions (convert / remove / acknowledge).
 
-- PRD update (`capture_targets.prd`, update-in-place) — if present.
-- ADR(s) into the repo's existing ADR dir/numbering (`capture_targets.adr`).
-- User-doc stubs (`capture_targets.docs`).
+**Config parsing.** Defaults (§3.3) are baked into the script. If
+`.spec-cleanup.yml` exists it is parsed with `yq`. If the config exists but `yq`
+is absent, the Guard **fails closed** with a clear error (it must not silently
+fall back to defaults and under-enforce). `yq` is declared in SKILL.md
+compatibility as required-when-a-config-is-present.
 
-The human reviews the diff. On accept: commit the durable docs, then remove the
-raw artifacts (`git rm` for tracked, `rm` for untracked). On "nothing durable":
-record an explicit acknowledgement (commit trailer `Spec-Cleanup: acknowledged`)
-and remove-only. Capture **never** writes docs unattended; low-confidence or
-empty extraction surfaces "nothing durable found, confirm removal."
+### 3.2 Wiring (read-only enforcement points)
+
+- **Merge gate** — add a Guard checklist item + command recipe to the Merge Gate
+  section of `references/pull-request-workflow.md` (mirroring the existing
+  annotations check). The merge gate is prose + recipes, not an executable
+  pipeline; the recipe runs `spec-cleanup-guard.sh` and blocks on non-zero.
+- **Optional runtime block** — for repos wanting earlier enforcement, a recipe in
+  `references/claude-code-hooks.md` extends the documented `merge-gate.sh` Claude
+  Code **PreToolUse** hook to also run the guard. A **git** `pre-commit` template
+  (distinct system) can be added under `Build/hooks/` calling the guard; **off by
+  default** (initial commit of working notes is allowed — Paul's point). The spec
+  never says "pre-commit hook in `hooks/`": `hooks/hooks.json` is Claude-hook
+  config; git-hook templates live in `Build/hooks/`.
 
 ### 3.3 Config — `.spec-cleanup.yml`
 
-Machine-readable mirror of the `AGENTS.md` layout declaration. Built-in defaults
-ship in the skill, so a repo with no config still guards `docs/superpowers/**`.
+Single source of truth for paths. Built-in defaults ship in the guard, so a repo
+with no config still guards `docs/superpowers/**`.
 
 ```yaml
-intermediate_paths:        # throwaway planning artifacts (Guard + Capture)
+intermediate_paths:               # throwaway planning artifacts (Guard + Capture)
   - docs/superpowers/**
   - claudedocs/**
-  - "**/*.plan.md"
   - docs/working/**
-capture_targets:           # where durable knowledge goes; each optional
-  prd:  docs/PRD.md
-  adr:  docs/adr/
-  docs: Documentation/
-mode: convert              # convert | remove | block   (default: convert)
-pre_commit_block: false    # opt-in early blocking
+  - docs/superpowers/**/*.plan.md  # anchored — NOT a bare **/*.plan.md
+exclude:                          # never treat these as intermediate
+  - docs/superpowers/specs/**/KEEP-*.md
+capture_targets:
+  adr: docs/adr/                  # v1 target (append new file)
+  # prd:  docs/PRD.md             # deferred to phase 2 (update-in-place)
+  # docs: Documentation/          # deferred to phase 2 (user-doc stubs)
+mode: convert                     # convert | remove   (default: convert)
 ```
 
-Absent `capture_targets` → Capture degrades to remove-with-acknowledgement.
+- Default `intermediate_paths` are **path-anchored**; the bare `**/*.plan.md`
+  pattern is forbidden (it would match arbitrary project files).
+- `exclude:` lets a repo keep a deliberate artifact that matches a glob.
+- `mode`: **`convert`** (default) or **`remove`**. There is no `block` mode — the
+  Guard's hard block already covers "just block."
 
-### 3.4 AGENTS.md — canonical layout declaration
+### 3.4 Detection sources — enforcement vs discovery
 
-`AGENTS.md` gains a layout subsection distinguishing **persisted/durable** doc
-folders from **intermediate/working** folders, e.g.:
+- **Enforced detection** (Guard *and* Capture deletion set) = declared globs
+  only. This is the single, deterministic deletion driver.
+- **Discovery** (Capture, in-session only) = the agent additionally surfaces
+  **session-known artifact paths** it authored this session that match no glob
+  (ad-hoc `PLAN.md`, other-tool output). These are **not** silently deleted;
+  Capture proposes **adding them to `.spec-cleanup.yml`** (or committing them
+  under a globbed path) so the deterministic Guard — including CI, which cannot
+  see session state — catches them thereafter. This closes the "CI can't see
+  session paths" gap by funnelling discovery back into the enforced globs.
+
+### 3.5 Capture — assisted, proposes only, recoverable removal
+
+A `/pr-finish` step (in-session). Sequence:
+
+1. **Manifest + confirm.** Print every match grouped by tracked/staged/untracked.
+   Require explicit human confirmation. The untracked subset is called out
+   separately because it is the only irrecoverable-by-default class.
+2. **Convert (default).** A sub-agent reads the artifacts and **proposes an ADR
+   diff** into `capture_targets.adr` (v1). Routing heuristic: *decisions with
+   alternatives considered → ADR* (v1's only target). Phase 2 adds *requirement/
+   scope changes → PRD update* and *end-user-facing behavior → user doc*. Human
+   reviews the diff; on accept the docs are committed.
+3. **Verify capture landed.** Before any removal, assert the docs commit exists
+   and contains the intended paths (`git show --stat HEAD`) and the tree no longer
+   reports them uncommitted. On any failure (blocked hook, signing failure, empty
+   diff) **abort removal** and surface the error.
+4. **Recoverable removal.** Stage any untracked raw artifacts so they enter
+   history, then commit their deletion as `chore: remove working specs/plans
+   (captured in <ADR>)`. Because the team never squashes (repo rule), the raw
+   content remains recoverable from branch/merge history. **Bare `rm` of untracked
+   content is forbidden** — every removal is a git deletion of a tracked file.
+5. **Acknowledge path.** If the human asserts nothing durable (or `mode: remove`),
+   skip step 2; still do steps 1, 3-trivially, 4, and record a
+   `Spec-Cleanup: acknowledged` trailer **on the removal commit**, body listing
+   the removed paths. The acknowledging actor is whoever runs `/pr-finish`; the
+   acknowledgement covers all artifacts at the gate regardless of original author;
+   the trailer commit is signed/DCO-compliant by that actor.
+
+**Mode precedence.** `mode` is the default offered; a human may always escalate to
+a stricter outcome (decline conversion → remove) but the tooling never silently
+loosens. `mode: remove` still requires the manifest+confirm of step 1 and the
+recoverable-removal of step 4.
+
+### 3.6 AGENTS.md — folder taxonomy declaration (human source of truth)
+
+`AGENTS.md` "Repo Structure" gains a subsection distinguishing **persisted/
+durable** doc folders from **intermediate/working** folders:
 
 ```
-docs/PRD.md, docs/adr/, Documentation/   # persisted — durable knowledge
-docs/superpowers/, claudedocs/, docs/working/  # intermediate — never reach base
+docs/adr/, docs/PRD.md, Documentation/          # persisted — durable knowledge
+docs/superpowers/, claudedocs/, docs/working/   # intermediate — never reach base
 ```
 
-`AGENTS.md` is the human source of truth; `.spec-cleanup.yml` is its
-machine-readable mirror. A consistency check (agent-harness "doc-drift" style)
-warns when the two diverge.
+This is human-facing documentation. `.spec-cleanup.yml` remains the single
+machine-readable source the Guard reads. **No automated AGENTS.md↔config
+consistency/drift check in v1** — it duplicates a source to then police it;
+deferred until the two are shown to drift in practice.
 
-## 4. Data flow / state resolution
+## 4. Resolution paths
 
-The gate is clean only when **no** intermediate artifact remains in **any** of
-the three states. Resolution paths:
+The gate is clean only when **no** intermediate artifact remains in **any** of the
+three states.
 
-1. **Convert** (default) — Capture proposes docs → human accepts → docs committed
-   → raw removed.
-2. **Remove** — raw removed without conversion (mode `remove`, or human declines
-   conversion).
-3. **Acknowledge** — human asserts nothing durable; commit trailer recorded; raw
-   removed.
+1. **Convert** (default) — manifest+confirm → propose ADR → human accepts →
+   docs committed → verify → recoverable removal.
+2. **Remove** — manifest+confirm → recoverable removal (no conversion); used for
+   `mode: remove` or when the human declines conversion.
+3. **Acknowledge** — manifest+confirm → recoverable removal + trailer; the human
+   asserts nothing durable.
+
+Idempotency: Capture operates only on artifacts still present in one of the three
+states; already-removed/session paths are dropped; a re-run on a clean branch is a
+Guard no-op. ADR proposal must detect already-applied content (no duplicate ADR).
 
 ## 5. Error handling / edge cases
 
-- **No config** → built-in defaults (`docs/superpowers/**`), convert mode, no
-  capture targets → remove-with-ack.
-- **Capture low-confidence / empty** → no auto-write; surfaces confirm-removal.
-- **Reference project / empty `src/`** → no intermediate files → Guard is a no-op
+- **No config** → baked-in defaults (`docs/superpowers/**`), `convert`, `adr`
+  target absent → degrades to remove-with-acknowledgement.
+- **`yq` absent but config present** → Guard fails closed (does not under-enforce).
+- **Capture low-confidence / empty extraction** → no auto-write; surfaces
+  "nothing durable found, confirm removal."
+- **Capture target dir missing** (`docs/adr/` absent) → create it and seed ADR
+  numbering at `0001`; ADR ids use `NNNN-slug` derived from the next free number,
+  collisions on parallel branches resolved at rebase (renumber the later one).
+- **Reference project / empty `src/`** → no intermediate files → Guard no-op
   (avoids the "cosmetic stage" smell raised in the same chat).
 - **Binary / very large plans** → Guard only checks path presence; Capture reads
   text and skips binaries.
+- **CI context (no session)** → only the Guard runs; it enforces the configured
+  globs. Session-only ad-hoc paths are caught only after §3.4 registers them in
+  config — this residual gap is explicit, not silent.
 - **Already-clean branch** → Guard no-op, merge proceeds normally.
-- **CI context (no session)** → only the Guard runs; Capture is interactive-only.
 
-## 6. Adoption by team repos
+## 6. Scope
 
-The `ecom-orocommerce-docker` repo adopts the capability by adding its own
-`.spec-cleanup.yml` (orocommerce-specific globs + doc targets) — no forked logic.
-It composes with the existing `oro-qa-reviewer` agent rather than replacing it.
+**v1 (this PR's implementation plan):**
+- `spec-cleanup-guard.sh` (read-only, three-state, pinned pathspecs, `--selftest`,
+  `--dry-run`, fail-closed config).
+- `.spec-cleanup.yml` schema + baked defaults + `exclude:`.
+- Merge-gate checklist item + recipe in `pull-request-workflow.md`.
+- Capture step in `/pr-finish`: manifest+confirm, **ADR-only** conversion,
+  verify-before-remove, recoverable removal, acknowledge trailer.
+- Tests per §7.
 
-## 7. Testing
+**Deferred (follow-ups):** PRD update-in-place and user-doc capture targets;
+the off-by-default git `pre-commit` template and PreToolUse runtime block;
+session-known-path *auto-registration* UX polish; `block` mode (only if a
+concrete need surfaces); any AGENTS.md↔config drift check.
 
-Evals in `skills/git-workflow/evals/` plus a `checkpoints.yaml` entry:
+## 7. Testing (matched to each layer's real harness)
 
-- **E1** branch with `docs/superpowers/**` tracked → Guard fails, lists files by
-  state.
-- **E2** untracked intermediate file present → Guard fails (untracked state).
-- **E3** after convert + remove → Guard passes.
-- **E4** repo with no config → default Guard active on `docs/superpowers/**`.
-- **E5** acknowledge path → Guard passes with removal only + trailer present.
-- **E6** clean branch → Guard no-op.
-- **E7** `AGENTS.md` ↔ `.spec-cleanup.yml` divergence → consistency check warns.
+- **Guard shell self-test** — `skills/git-workflow/scripts/spec-cleanup-guard.sh
+  --selftest` (sibling-style to `verify-git-workflow.sh`), sets up git fixtures
+  and asserts exit codes:
+  - T1 tracked `docs/superpowers/**` present → non-zero, listed under tracked.
+  - T2 untracked intermediate file → non-zero, listed under untracked.
+  - T3 nested `docs/superpowers/a/b/c.md` → caught in all three states (pathspec).
+  - T4 no config → default guard active on `docs/superpowers/**`.
+  - T5 `exclude:` match → not flagged.
+  - T6 clean branch → exit 0 (no-op).
+  - T7 config present, `yq` simulated-absent → fail-closed non-zero.
+- **Agent-behavior evals** (`skills/git-workflow/evals/evals.json`, prompt +
+  content/tool_use assertions): agent invokes the Guard at `/pr-finish`; agent
+  proposes an ADR rather than committing raw specs to base.
+- **Checkpoint** (`skills/git-workflow/checkpoints.yaml`, repo-state): a
+  `contains`/`file_exists` check that an assessed repo declares intermediate
+  paths (`.spec-cleanup.yml` or the AGENTS.md layout subsection).
 
 ## 8. Delivery
 
 - Feature PR on `git-workflow-skill` (`feature/spec-cleanup-capability`).
 - No version bump / CHANGELOG entry in the feature PR (separate release flow).
 - Signed commits (`git commit -s`); DCO-enforced repo.
+- The `ecom-orocommerce-docker` repo adopts the capability via its own
+  `.spec-cleanup.yml` (orocommerce globs + ADR target); no forked logic; composes
+  with the existing `oro-qa-reviewer` agent.
 - This design doc lives under `docs/superpowers/specs/` as intentional
   dogfooding — the shipped capability would later capture-and-remove it.
+
+## Appendix — review provenance
+
+Revised against a 6-dimension adversarial review (2026-06-16): blockers fixed
+(untracked-`rm` irreversibility → recoverable git removal; glob over-match → anchored
+defaults + `exclude:`; `hooks/` vs `Build/hooks/` conflation). High/medium fixes:
+pinned git pathspec mechanism, `yq` fail-closed, verify-before-remove, dry-run
+manifest, read-only Guard invariant, skill-scoped script location, merge-gate
+recipe wiring, `/pr-finish` insertion point, tests split across self-test/evals/
+checkpoint. Scope cuts (confirmed findings): dropped `block` mode, AGENTS.md↔config
+drift check, and session-introspection-as-deletion-driver; sequenced ADR-first with
+PRD/user-doc deferred.

--- a/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-16-spec-cleanup-design.md
@@ -30,7 +30,8 @@ always recoverable (it goes through git history, never bare `rm`).
 
 ## 2. Goals / Non-Goals
 
-**Goals**
+### Goals
+
 - Block the base branch from receiving tracked intermediate artifacts.
 - Detect artifacts in **all three states**: committed/tracked, staged, and
   untracked working-tree files.
@@ -41,7 +42,8 @@ always recoverable (it goes through git history, never bare `rm`).
 - Ship usable defaults; let repos extend via `.spec-cleanup.yml`; declare the
   folder taxonomy in `AGENTS.md`.
 
-**Non-Goals**
+### Non-Goals
+
 - Auto-discovering "every intermediate file everywhere" by heuristic. Enforced
   detection is anchored to declared globs (§3.2). Session context is used only to
   *discover and register* stray artifacts (§3.4), never as a silent deletion

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: git-workflow
 description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, resolving PR review comments, merging PRs (including CI verification, auto-merge queues, and post-merge cleanup), managing PR review threads, merging PRs with signed commits, handling merge conflicts, creating releases, integrating Git with CI/CD, setting up git hooks (lefthook, captainhook, husky, pre-commit), or debugging hook-install failures in git worktrees."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
-compatibility: "Requires git, gh CLI."
+compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
   version: "1.17.0"
@@ -19,12 +19,12 @@ Expert patterns for Git: branching, commits, collaboration, CI/CD.
 1. **No direct push to main** — always open a PR.
 2. **No merge before all threads resolved** — see `references/pull-request-workflow.md`.
 3. **No squash unless asked** — preserves atomic commits, signatures, bisection.
-4. **No "tested/verified/working" without pasted command output** — if you cannot run the check, say so.
+4. **No "tested/verified/working" without pasted command output** — else say so.
 5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree, verified by `pwd`.
 6. **Force-push only with `--force-with-lease`** — never plain `--force`.
 7. **Commit before rebase** — `add → commit → fetch → rebase → push`. Dirty tree aborts rebase.
 
-See `references/pull-request-workflow.md` for merge-gate, atomic-commit, and SHA-citation patterns.
+See `references/pull-request-workflow.md` for merge-gate and atomic-commit patterns.
 
 ## Reference Files
 
@@ -75,7 +75,7 @@ Install: `lefthook install` | `composer install` | `npm install` | `pre-commit i
 
 ## Critical Release Rules
 
-1. **Immutable releases**: Deleted releases permanently block tag reuse; bump version instead.
+1. **Immutable releases**: deleted releases block tag reuse; bump version.
 2. **Multi-branch releases**: Use `--latest=false` from non-default branches.
 3. **Pre-release**: Version bumped, CI green, CHANGELOG updated, `git pull` BEFORE `gh release create`.
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -17,12 +17,12 @@ Expert patterns for Git: branching, commits, collaboration, CI/CD.
 ## Critical Rules (Non-Negotiable)
 
 1. **No direct push to main** — always open a PR.
-2. **No merge before all threads resolved** — run the merge gate in `references/pull-request-workflow.md`.
-3. **No squash unless asked** — atomic commits preserved; keeps GPG signatures and bisection.
+2. **No merge before all threads resolved** — see `references/pull-request-workflow.md`.
+3. **No squash unless asked** — preserves atomic commits, signatures, bisection.
 4. **No "tested/verified/working" without pasted command output** — if you cannot run the check, say so.
-5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree. Verify `pwd` first.
+5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree, verified by `pwd`.
 6. **Force-push only with `--force-with-lease`** — never plain `--force`.
-7. **Commit before rebase** — `add → commit → fetch → rebase → push`. Rebase aborts on a dirty tree; the push then rejects as non-fast-forward.
+7. **Commit before rebase** — `add → commit → fetch → rebase → push`. Dirty tree aborts rebase.
 
 See `references/pull-request-workflow.md` for merge-gate, atomic-commit, and SHA-citation patterns.
 
@@ -42,6 +42,7 @@ Load references on demand:
 | `references/claude-code-hooks.md` | Claude Code `settings.json` hooks — merge gate, cache-path rejection, auto-lint |
 | `references/code-quality-tools.md` | shellcheck, shfmt, git-absorb, difftastic |
 | `references/merge-gate-watcher.md` | Merge-driver loop, hard/soft check taxonomy, rerun stale-SHA, review-bot rounds |
+| `references/spec-cleanup.md` | Keep planning artifacts off the base branch; guard + capture-to-ADR |
 
 ## Conventional Commits
 

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -134,6 +134,17 @@ mechanical:
     severity: warning
     desc: "Main branch should not accumulate >20 unreleased commits since last tag"
 
+  # === INTERMEDIATE PLANNING ARTIFACTS ===
+  - id: GW-16
+    type: command
+    pattern: 'test -z "$(git ls-files -- docs/superpowers/ claudedocs/ docs/working/ 2>/dev/null)"'
+    severity: warning
+    desc: >-
+      Intermediate planning artifacts (superpowers specs/plans, claudedocs,
+      working notes) should not be tracked on the base branch — convert durable
+      decisions to an ADR and remove the raw files. See
+      references/spec-cleanup.md and spec-cleanup-guard.sh.
+
 llm_reviews:
   # === CONVENTIONAL COMMITS ===
   - id: GW-20

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -345,5 +345,37 @@
         "pattern": "(?i)(exit.{0,12}(code|status|0|zero)|CLEAN (does not|doesn.t).{0,40}(unresolved|thread|conversation)|unresolved (review )?(thread|conversation))"
       }
     ]
+  },
+  {
+    "name": "spec_cleanup_guard_before_merge",
+    "prompt": "I'm finishing a PR with /pr-finish. My feature branch committed the superpowers plan and spec under docs/superpowers/ while I was working. What should happen before this merges into the base branch?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)(spec.?cleanup|intermediate|working).{0,40}(artifact|spec|plan|file)|docs/superpowers"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(not (reach|land|merge)|keep .{0,20}out of|must not).{0,40}(base|main|develop)|(remove|delete|clean).{0,40}before.{0,20}merge"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(ADR|capture|convert|durable doc|documentation).{0,40}(then|before).{0,40}(remove|delete|clean)|guard"
+      }
+    ]
+  },
+  {
+    "name": "spec_cleanup_recoverable_removal",
+    "prompt": "My branch has an untracked docs/superpowers/plan.md I no longer need before merging. How do I get rid of it safely?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)(never|don.t|do not|avoid).{0,30}(bare )?(rm|delete).{0,30}untracked|untracked.{0,40}(irrecoverable|not in git|cannot.{0,10}recover|unrecoverable)"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(stage|git add|commit).{0,60}(then|before).{0,20}(git rm|remove|delete)|recoverable.{0,30}(removal|history)|enters? .{0,10}history"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -765,6 +765,7 @@ Before merging any PR, run this gate. If any check fails, stop and fix the under
 - [ ] **No CI annotations** — check job annotations, not just pass/fail (see below)
 - [ ] **Signed commits** — every commit in the PR is signed (see "Signing and DCO Failures" below if blocked)
 - [ ] **DCO sign-off** — every commit has a `Signed-off-by:` trailer matching `git config user.{name,email}` (required when the `probot/dco` check is enabled)
+- [ ] **No intermediate planning artifacts** — `bash skills/git-workflow/scripts/spec-cleanup-guard.sh` exits 0; superpowers specs/plans (`docs/superpowers/**`) and other scratch planning files must not reach the base branch (see "Spec-Cleanup Guard" below and `references/spec-cleanup.md`)
 
 ### Auto-Merge / Merge-Queue Arming Gate
 
@@ -903,6 +904,21 @@ gh api "repos/{owner}/{repo}/commits/SHA/check-runs" \
 For automated enforcement at tool-invocation time, see the `merge-gate.sh` hook recipe in `references/claude-code-hooks.md`. The hook enforces the **runtime-checkable subset** — `reviewDecision`, `mergeStateStatus`, and unresolved thread count — which covers the most common block reasons. Signed-commits and CI-annotations checks are not enforced by the hook (annotations in particular require the commit-level API call above); rely on the repo's branch-protection rules and local pre-commit hook for those.
 
 > **Important:** CI checks can PASS while emitting warning annotations (e.g., actionlint/shellcheck via reviewdog, CodeQL deprecation notices). These are invisible in the PR summary view but visible in the job detail "Annotations" section. Always check for annotations before declaring a PR clean.
+
+### Spec-Cleanup Guard
+
+Intermediate planning artifacts (superpowers specs/plans, ad-hoc `PLAN.md`,
+planning-tool output) must not ride into the base branch. The guard is
+deterministic and **read-only** — it detects and reports, never deletes.
+
+```bash
+# Exit 0 = clean; exit 1 = artifacts found (resolve before merge); exit 2 = config error.
+bash skills/git-workflow/scripts/spec-cleanup-guard.sh
+```
+
+If it exits 1, resolve via the `/pr-finish` spec-cleanup step (convert to an ADR /
+remove / acknowledge) so the branch is clean, then re-run. Full capability —
+config, three-state detection, Capture flow — is in `references/spec-cleanup.md`.
 
 ### Rulesets: the gate `gh pr view` doesn't show
 

--- a/skills/git-workflow/references/spec-cleanup.md
+++ b/skills/git-workflow/references/spec-cleanup.md
@@ -36,7 +36,8 @@ Config globs are normalized to **git pathspecs** (these are NOT shell globs):
 a directory glob `docs/superpowers/**` → directory pathspec `docs/superpowers/`
 (recurses); a suffix glob → `:(glob)docs/superpowers/**/*.plan.md` (anchored —
 a bare `**/*.plan.md` is forbidden because it sweeps in real files like
-`src/foo.plan.md`). `exclude:` entries become `:(exclude)` pathspecs.
+`src/foo.plan.md`). `exclude:` entries become `:(exclude)` pathspecs (or
+`:(exclude,glob)` when the pattern contains glob characters).
 
 ## Config — `.spec-cleanup.yml` (optional)
 
@@ -72,11 +73,14 @@ Runs in-session so the branch is clean before the gate. Sequence:
    intended paths (`git show --stat HEAD`) and the tree no longer reports them
    uncommitted. On any failure (blocked hook, signing failure, empty diff),
    **abort removal** and surface the error.
-4. **Recoverable removal.** Stage any untracked raw artifacts so they enter
-   history, then commit their deletion as `chore: remove working specs/plans
-   (captured in <ADR>)`. Because we never squash (repo rule), the raw content
-   stays recoverable from branch/merge history. **Bare `rm` of untracked content
-   is forbidden** — every removal is a git deletion of a tracked file.
+4. **Recoverable removal.** Stage **only the manifested artifact paths**
+   (`git add -- <path>`, never `git add -A/-u`, so unrelated working-tree changes
+   are not absorbed) so they enter history, then commit their deletion as
+   `chore: remove working specs/plans (captured in <ADR>)`. Recoverability holds
+   **only** for merge/rebase-merged PRs (never squashed); in a squash-merge repo
+   the captured ADR is the sole durable record — confirm it landed first. **Bare
+   `rm` of untracked content is forbidden** — every removal is a git deletion of a
+   tracked file.
 5. **Acknowledge path.** If nothing is durable (or `mode: remove`), skip step 2;
    still manifest+confirm and removal, and record a `Spec-Cleanup: acknowledged`
    trailer on the removal commit listing the removed paths. The acknowledging
@@ -107,6 +111,8 @@ that residual gap is closed only once discovery registers them in config.
 
 Other repos adopt by shipping their own `.spec-cleanup.yml` (own globs + ADR
 target). No forked logic; composes with existing QA agents (e.g.
-`oro-qa-reviewer`). Note: the `git-workflow-skill` repo itself ships only
-`.spec-cleanup.yml.example`, not an active config, so the Guard does not flag its
-own dogfooded design spec under `docs/superpowers/specs/`.
+`oro-qa-reviewer`). Note: the `git-workflow-skill` repo ships only
+`.spec-cleanup.yml.example` (no active config), so the Guard is not wired into its
+own merge gate/CI. Run manually with the baked-in defaults it *does* flag the
+dogfooded design spec under `docs/superpowers/specs/` — the intended
+self-demonstration (design §8).

--- a/skills/git-workflow/references/spec-cleanup.md
+++ b/skills/git-workflow/references/spec-cleanup.md
@@ -1,0 +1,112 @@
+# Spec-Cleanup — Keep Intermediate Planning Artifacts Out of the Base Branch
+
+Dev-time planning artifacts — superpowers specs/plans (`docs/superpowers/**`),
+ad-hoc `PLAN.md` scratch files, output from other planning tools — are throwaway
+working notes. When they get committed to a feature branch they ride into the
+base branch on merge, rot there, and pollute history (the HMKG-2227 incident:
+~5000 lines of specs/plans dragged across branches via `develop`).
+
+This capability has two layers, wired into the merge gate and `/pr-finish`:
+
+- **Guard** — deterministic, **read-only**. Detects the artifacts and blocks the
+  gate. Safe to run in CI.
+- **Capture** — interactive, in-session. Distils durable knowledge into an ADR
+  (proposed as a reviewable diff), then removes the raw files **recoverably**.
+
+## Guard — `scripts/spec-cleanup-guard.sh`
+
+Read-only **invariant**: the Guard never deletes, stages, or modifies any file.
+It detects the *presence* of configured intermediate paths in three states and
+exits non-zero if any are found. It is branch-local (presence ⇒ fail), so there
+is no base-branch resolution to get wrong.
+
+| State | Mechanism |
+|-------|-----------|
+| tracked (committed) | `git ls-files` |
+| staged | `git diff --cached --name-only --diff-filter=AM` |
+| untracked | `git ls-files --others --exclude-standard` |
+
+```bash
+bash skills/git-workflow/scripts/spec-cleanup-guard.sh            # enforce: exit 1 on matches
+bash skills/git-workflow/scripts/spec-cleanup-guard.sh --dry-run  # manifest only, exit 0
+bash skills/git-workflow/scripts/spec-cleanup-guard.sh --selftest # internal fixtures
+```
+
+Config globs are normalized to **git pathspecs** (these are NOT shell globs):
+a directory glob `docs/superpowers/**` → directory pathspec `docs/superpowers/`
+(recurses); a suffix glob → `:(glob)docs/superpowers/**/*.plan.md` (anchored —
+a bare `**/*.plan.md` is forbidden because it sweeps in real files like
+`src/foo.plan.md`). `exclude:` entries become `:(exclude)` pathspecs.
+
+## Config — `.spec-cleanup.yml` (optional)
+
+Single machine-readable source of truth for paths. See
+`.spec-cleanup.yml.example`. Without a config the baked-in defaults apply
+(`docs/superpowers/**`, `claudedocs/**`, `docs/working/**`,
+`docs/superpowers/**/*.plan.md`). If the file **is** present but `yq`
+(mikefarah v4) is not installed, the Guard **fails closed** (exit 2) rather than
+silently under-enforcing.
+
+```yaml
+intermediate_paths:
+  - docs/superpowers/**
+exclude:
+  - docs/superpowers/specs/**/KEEP-*.md
+capture_targets:
+  adr: docs/adr/          # v1 target (append new file)
+mode: convert             # convert | remove
+```
+
+## Capture — the `/pr-finish` spec-cleanup step (before Rebase)
+
+Runs in-session so the branch is clean before the gate. Sequence:
+
+1. **Manifest + confirm.** Print every match grouped by tracked/staged/untracked.
+   The untracked subset is called out separately — it is the only class not
+   recoverable from git by default. Require explicit confirmation.
+2. **Convert (default).** A sub-agent reads the artifacts and **proposes an ADR
+   diff** into `capture_targets.adr`. Routing heuristic for v1: *a decision with
+   alternatives considered → ADR*. (PRD update-in-place and user-doc stubs are
+   deferred phase-2 targets.) Human reviews the diff; on accept, commit the docs.
+3. **Verify before removing.** Assert the docs commit exists and contains the
+   intended paths (`git show --stat HEAD`) and the tree no longer reports them
+   uncommitted. On any failure (blocked hook, signing failure, empty diff),
+   **abort removal** and surface the error.
+4. **Recoverable removal.** Stage any untracked raw artifacts so they enter
+   history, then commit their deletion as `chore: remove working specs/plans
+   (captured in <ADR>)`. Because we never squash (repo rule), the raw content
+   stays recoverable from branch/merge history. **Bare `rm` of untracked content
+   is forbidden** — every removal is a git deletion of a tracked file.
+5. **Acknowledge path.** If nothing is durable (or `mode: remove`), skip step 2;
+   still manifest+confirm and removal, and record a `Spec-Cleanup: acknowledged`
+   trailer on the removal commit listing the removed paths. The acknowledging
+   actor is whoever runs `/pr-finish`; the trailer commit is signed/DCO-compliant.
+
+**Mode precedence:** `mode` is the default offered; a human may escalate to a
+stricter outcome (decline conversion → remove) but the tooling never silently
+loosens.
+
+**Discovery vs enforcement:** the Guard (and CI) enforce only the declared
+globs. In-session, Capture may additionally surface session-known artifacts that
+match no glob (ad-hoc `PLAN.md`, other-tool output) and propose **adding them to
+`.spec-cleanup.yml`** so the deterministic Guard catches them thereafter — it
+never silently deletes a non-globbed path. CI cannot see session-only paths;
+that residual gap is closed only once discovery registers them in config.
+
+## Wiring
+
+- **Merge gate** — a Pre-Merge Checklist item + command recipe in
+  `references/pull-request-workflow.md` runs the Guard and blocks on non-zero.
+- **Optional runtime block** — extend the `merge-gate.sh` PreToolUse hook recipe
+  in `references/claude-code-hooks.md`, or add an **off-by-default** git
+  `pre-commit` template under `Build/hooks/` (a *git* hook — distinct from the
+  Claude-hook config in `hooks/hooks.json`). Off by default because committing
+  working notes mid-branch is fine; only reaching the base branch is not.
+
+## Adoption
+
+Other repos adopt by shipping their own `.spec-cleanup.yml` (own globs + ADR
+target). No forked logic; composes with existing QA agents (e.g.
+`oro-qa-reviewer`). Note: the `git-workflow-skill` repo itself ships only
+`.spec-cleanup.yml.example`, not an active config, so the Guard does not flag its
+own dogfooded design spec under `docs/superpowers/specs/`.

--- a/skills/git-workflow/scripts/spec-cleanup-guard.sh
+++ b/skills/git-workflow/scripts/spec-cleanup-guard.sh
@@ -75,6 +75,14 @@ load_config() {
     PATHS=("${DEFAULT_PATHS[@]}")
     EXCLUDES=("${DEFAULT_EXCLUDES[@]+"${DEFAULT_EXCLUDES[@]}"}")
   fi
+  # Reject unanchored leading-glob patterns (e.g. **/*.plan.md, *.md): they match
+  # arbitrary project files. Anchor under a directory (docs/superpowers/**/*.plan.md).
+  local g
+  for g in "${PATHS[@]}"; do
+    if [[ "$g" == '*'* ]]; then
+      die "unanchored glob '$g' in intermediate_paths — anchor it under a directory (e.g. docs/superpowers/**/*.plan.md) so it cannot match unrelated files."
+    fi
+  done
 }
 
 build_pathspecs() {
@@ -86,9 +94,9 @@ build_pathspecs() {
 
 # Populate TRACKED / STAGED / UNTRACKED arrays.
 detect() {
-  mapfile -t TRACKED   < <(git ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
-  mapfile -t STAGED    < <(git diff --cached --name-only --diff-filter=AM -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
-  mapfile -t UNTRACKED < <(git ls-files --others --exclude-standard -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t TRACKED   < <(git -c core.quotePath=false ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t STAGED    < <(git -c core.quotePath=false diff --cached --name-only --diff-filter=AM -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t UNTRACKED < <(git -c core.quotePath=false ls-files --others --exclude-standard -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
 }
 
 print_group() {
@@ -101,6 +109,9 @@ print_group() {
 run() {
   local dry="$1"
   git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git work tree."
+  # Anchor config lookup + pathspecs at the repo root so the gate cannot silently
+  # pass when invoked from a subdirectory (e.g. a hook or CI step with a different CWD).
+  cd "$(git rev-parse --show-toplevel)" || die "cannot cd to repo root."
   load_config
   build_pathspecs
   detect
@@ -145,6 +156,8 @@ selftest() {
     echo c > docs/superpowers/specs/a/b/c.md   # nested, untracked
     st_assert "T2/T3 nested untracked -> 1" 1 "$(st_rc bash "$self")"
     st_assert "T3 nested caught also in --dry-run (rc 0)" 0 "$(st_rc bash "$self" --dry-run)"
+    mkdir -p sub/deeper
+    st_assert "GC-1 caught when run from subdirectory -> 1" 1 "$(cd sub/deeper && st_rc bash "$self")"
 
     eval "$GIT_Q add docs/superpowers/specs/a/b/c.md"      # now staged
     st_assert "T_staged staged intermediate -> 1" 1 "$(st_rc bash "$self")"
@@ -167,6 +180,8 @@ selftest() {
       st_assert "T5b non-excluded under config -> 1" 1 "$(st_rc bash "$self")"
       st_assert "T7 config present + no yq -> 2 (fail closed)" 2 \
         "$(SPEC_CLEANUP_FAKE_NO_YQ=1 st_rc bash "$self")"
+      printf 'intermediate_paths:\n  - "**/*.plan.md"\n' > .spec-cleanup.yml
+      st_assert "GC-2 unanchored glob in config -> 2 (rejected)" 2 "$(st_rc bash "$self")"
       rm -f .spec-cleanup.yml docs/superpowers/flagme.md
       rm -rf docs/superpowers/keep
     else
@@ -179,7 +194,7 @@ selftest() {
 
 # ------------------------------ main ----------------------------
 case "${1:-}" in
-  --help|-h) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  --help|-h) awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; exit 0 ;;
   --selftest) selftest ;;
   --dry-run) run 1 ;;
   "") run 0 ;;

--- a/skills/git-workflow/scripts/spec-cleanup-guard.sh
+++ b/skills/git-workflow/scripts/spec-cleanup-guard.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# spec-cleanup-guard.sh — deterministic, READ-ONLY gate for intermediate
+# planning artifacts (superpowers specs/plans, scratch plans, planning-tool
+# output) that must not land in the base branch.
+#
+# Invariant: this script NEVER deletes, stages, or modifies any file. It detects
+# and reports. Only the interactive Capture step (/pr-finish) removes files.
+#
+# Detection is branch-local and state-based: it flags the PRESENCE of configured
+# intermediate paths in three states — committed/tracked, staged, untracked —
+# independent of any base branch (intermediate paths must never be tracked, so
+# presence => fail). This sidesteps base-branch resolution entirely.
+#
+# Exit codes: 0 clean · 1 intermediate artifacts found · 2 usage/config error.
+#
+# Usage:
+#   spec-cleanup-guard.sh            enforce: list matches, exit 1 if any
+#   spec-cleanup-guard.sh --dry-run  list matches, always exit 0 (manifest only)
+#   spec-cleanup-guard.sh --selftest run internal fixtures, exit 0/1
+#   spec-cleanup-guard.sh --help
+#
+# Config: .spec-cleanup.yml at repo root (optional). Reads intermediate_paths[]
+# and exclude[]. If the file is present but `yq` is unavailable the guard FAILS
+# CLOSED (exit 2) rather than silently under-enforcing. Without a config file the
+# baked-in defaults below apply.
+set -euo pipefail
+
+DEFAULT_PATHS=(
+  "docs/superpowers/**"
+  "claudedocs/**"
+  "docs/working/**"
+  "docs/superpowers/**/*.plan.md"
+)
+DEFAULT_EXCLUDES=()
+
+CONFIG_FILE=".spec-cleanup.yml"
+
+die() { printf 'spec-cleanup-guard: %s\n' "$*" >&2; exit 2; }
+
+# Normalize a config glob to a git pathspec.
+#   dir glob  "docs/superpowers/**"          -> "docs/superpowers/"   (recurses)
+#   suffix    "docs/superpowers/**/*.plan.md" -> ":(glob)docs/.../*.plan.md"
+#   plain     "docs/x.md"                     -> "docs/x.md"
+normalize_pathspec() {
+  local g="$1" base
+  if [[ "$g" == */\*\* ]]; then
+    base="${g%/\*\*}"
+    if [[ "$base" != *[\*\?\[]* ]]; then printf '%s/' "$base"; return; fi
+  fi
+  if [[ "$g" != *[\*\?\[]* ]]; then printf '%s' "$g"; return; fi
+  printf ':(glob)%s' "$g"
+}
+
+# Normalize an exclude glob to an exclude pathspec.
+normalize_exclude() {
+  local g="$1"
+  if [[ "$g" == *[\*\?\[]* ]]; then printf ':(exclude,glob)%s' "$g"
+  else printf ':(exclude)%s' "$g"; fi
+}
+
+load_config() {
+  PATHS=() EXCLUDES=()
+  if [[ -f "$CONFIG_FILE" ]]; then
+    if [[ "${SPEC_CLEANUP_FAKE_NO_YQ:-0}" == "1" ]] || ! command -v yq >/dev/null 2>&1; then
+      die "$CONFIG_FILE present but 'yq' is not installed; refusing to under-enforce (install yq)."
+    fi
+    local p
+    while IFS= read -r p; do [[ -n "$p" ]] && PATHS+=("$p"); done \
+      < <(yq '.intermediate_paths[]' "$CONFIG_FILE" 2>/dev/null || true)
+    while IFS= read -r p; do [[ -n "$p" && "$p" != "null" ]] && EXCLUDES+=("$p"); done \
+      < <(yq '.exclude[]' "$CONFIG_FILE" 2>/dev/null || true)
+    [[ ${#PATHS[@]} -gt 0 ]] || die "$CONFIG_FILE has no intermediate_paths."
+  else
+    PATHS=("${DEFAULT_PATHS[@]}")
+    EXCLUDES=("${DEFAULT_EXCLUDES[@]+"${DEFAULT_EXCLUDES[@]}"}")
+  fi
+}
+
+build_pathspecs() {
+  PATHSPECS=()
+  local g
+  for g in "${PATHS[@]}"; do PATHSPECS+=("$(normalize_pathspec "$g")"); done
+  for g in "${EXCLUDES[@]+"${EXCLUDES[@]}"}"; do PATHSPECS+=("$(normalize_exclude "$g")"); done
+}
+
+# Populate TRACKED / STAGED / UNTRACKED arrays.
+detect() {
+  mapfile -t TRACKED   < <(git ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t STAGED    < <(git diff --cached --name-only --diff-filter=AM -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t UNTRACKED < <(git ls-files --others --exclude-standard -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+}
+
+print_group() {
+  local title="$1"; shift
+  (( $# == 0 )) && return
+  printf '  %s:\n' "$title"
+  printf '    %s\n' "$@"
+}
+
+run() {
+  local dry="$1"
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git work tree."
+  load_config
+  build_pathspecs
+  detect
+  local n=$(( ${#TRACKED[@]} + ${#STAGED[@]} + ${#UNTRACKED[@]} ))
+  if (( n == 0 )); then
+    echo "spec-cleanup-guard: clean — no intermediate planning artifacts."
+    return 0
+  fi
+  echo "spec-cleanup-guard: found $n intermediate planning artifact(s) that must not reach the base branch:"
+  print_group "tracked (committed)" "${TRACKED[@]+"${TRACKED[@]}"}"
+  print_group "staged"              "${STAGED[@]+"${STAGED[@]}"}"
+  print_group "untracked"           "${UNTRACKED[@]+"${UNTRACKED[@]}"}"
+  echo "Resolve via /pr-finish: convert (propose ADR) · remove · acknowledge."
+  echo "Untracked files are listed so you can confirm before any removal."
+  [[ "$dry" == "1" ]] && return 0
+  return 1
+}
+
+# --------------------------- selftest ---------------------------
+GIT_Q='git -c commit.gpgsign=false -c user.email=t@example.com -c user.name=test'
+st_pass=0 st_fail=0
+st_assert() { # desc expected_rc actual_rc
+  if [[ "$2" == "$3" ]]; then st_pass=$((st_pass+1)); printf '  ok   %s (rc=%s)\n' "$1" "$3"
+  else st_fail=$((st_fail+1)); printf '  FAIL %s (want rc=%s, got %s)\n' "$1" "$2" "$3"; fi
+}
+st_rc() { local rc=0; "$@" >/dev/null 2>&1 || rc=$?; printf '%s' "$rc"; }
+
+selftest() {
+  local self; self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  local t; t="$(mktemp -d "${TMPDIR:-/tmp}/scg-selftest.XXXXXX")"
+  trap 'rm -rf "$t"' RETURN
+  ( cd "$t"
+    eval "$GIT_Q init -q"
+    mkdir -p docs/superpowers/specs/a/b src docs/working
+    echo readme > README.md
+    echo real   > src/real.plan.md            # real file, NON-intermediate path
+    eval "$GIT_Q add README.md src/real.plan.md"; eval "$GIT_Q commit -qm init"
+
+    echo "T4 no config — default guard:"
+    st_assert "T6 clean branch -> 0" 0 "$(st_rc bash "$self")"
+
+    echo c > docs/superpowers/specs/a/b/c.md   # nested, untracked
+    st_assert "T2/T3 nested untracked -> 1" 1 "$(st_rc bash "$self")"
+    st_assert "T3 nested caught also in --dry-run (rc 0)" 0 "$(st_rc bash "$self" --dry-run)"
+
+    eval "$GIT_Q add docs/superpowers/specs/a/b/c.md"      # now staged
+    st_assert "T_staged staged intermediate -> 1" 1 "$(st_rc bash "$self")"
+    eval "$GIT_Q commit -qm spec"                          # now tracked
+    st_assert "T1 tracked intermediate -> 1" 1 "$(st_rc bash "$self")"
+
+    eval "$GIT_Q rm -q docs/superpowers/specs/a/b/c.md"; eval "$GIT_Q commit -qm rm"
+    st_assert "T6b removed -> clean 0" 0 "$(st_rc bash "$self")"
+
+    echo "T_overmatch real src/*.plan.md must NOT be flagged by default:"
+    st_assert "default ignores src/real.plan.md -> 0" 0 "$(st_rc bash "$self")"
+
+    echo "T5 exclude + T7 yq-fail-closed (config present):"
+    if command -v yq >/dev/null 2>&1; then
+      printf 'intermediate_paths:\n  - docs/superpowers/**\nexclude:\n  - docs/superpowers/keep/**\n' > .spec-cleanup.yml
+      mkdir -p docs/superpowers/keep
+      echo k > docs/superpowers/keep/wanted.md     # untracked but excluded
+      st_assert "T5 excluded path -> clean 0" 0 "$(st_rc bash "$self")"
+      echo f > docs/superpowers/flagme.md
+      st_assert "T5b non-excluded under config -> 1" 1 "$(st_rc bash "$self")"
+      st_assert "T7 config present + no yq -> 2 (fail closed)" 2 \
+        "$(SPEC_CLEANUP_FAKE_NO_YQ=1 st_rc bash "$self")"
+      rm -f .spec-cleanup.yml docs/superpowers/flagme.md
+      rm -rf docs/superpowers/keep
+    else
+      echo "  skip T5/T7 (yq not installed)"
+    fi
+    echo "selftest: $st_pass passed, $st_fail failed"
+    [[ "$st_fail" == "0" ]]   # subshell exit status reflects failures
+  )
+}
+
+# ------------------------------ main ----------------------------
+case "${1:-}" in
+  --help|-h) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  --selftest) selftest ;;
+  --dry-run) run 1 ;;
+  "") run 0 ;;
+  *) die "unknown argument: $1 (try --help)";;
+esac

--- a/skills/git-workflow/scripts/spec-cleanup-guard.sh
+++ b/skills/git-workflow/scripts/spec-cleanup-guard.sh
@@ -92,11 +92,19 @@ build_pathspecs() {
   for g in "${EXCLUDES[@]+"${EXCLUDES[@]}"}"; do PATHSPECS+=("$(normalize_exclude "$g")"); done
 }
 
-# Populate TRACKED / STAGED / UNTRACKED arrays.
+# Populate TRACKED / STAGED / UNTRACKED arrays (each file in exactly one bucket).
 detect() {
-  mapfile -t TRACKED   < <(git -c core.quotePath=false ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
-  mapfile -t STAGED    < <(git -c core.quotePath=false diff --cached --name-only --diff-filter=AM -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  mapfile -t STAGED    < <(git -c core.quotePath=false diff --cached --name-only --diff-filter=ACMR -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
   mapfile -t UNTRACKED < <(git -c core.quotePath=false ls-files --others --exclude-standard -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  # Committed-tracked = index entries matching, minus anything already reported as a
+  # staged change, so a newly-staged file is not double-listed as "committed".
+  # ls-files (not ls-tree) is required here: ls-tree rejects the :(glob)/:(exclude)
+  # pathspec magic the guard relies on.
+  if ((${#STAGED[@]})); then
+    mapfile -t TRACKED < <(git -c core.quotePath=false ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u | grep -vxF "$(printf '%s\n' "${STAGED[@]}")" || true)
+  else
+    mapfile -t TRACKED < <(git -c core.quotePath=false ls-files -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
+  fi
 }
 
 print_group() {
@@ -131,7 +139,7 @@ run() {
 }
 
 # --------------------------- selftest ---------------------------
-GIT_Q='git -c commit.gpgsign=false -c user.email=t@example.com -c user.name=test'
+git_q() { git -c commit.gpgsign=false -c user.email=t@example.com -c user.name=test "$@"; }
 st_pass=0 st_fail=0
 st_assert() { # desc expected_rc actual_rc
   if [[ "$2" == "$3" ]]; then st_pass=$((st_pass+1)); printf '  ok   %s (rc=%s)\n' "$1" "$3"
@@ -144,11 +152,11 @@ selftest() {
   local t; t="$(mktemp -d "${TMPDIR:-/tmp}/scg-selftest.XXXXXX")"
   trap 'rm -rf "$t"' RETURN
   ( cd "$t"
-    eval "$GIT_Q init -q"
+    git_q init -q
     mkdir -p docs/superpowers/specs/a/b src docs/working
     echo readme > README.md
     echo real   > src/real.plan.md            # real file, NON-intermediate path
-    eval "$GIT_Q add README.md src/real.plan.md"; eval "$GIT_Q commit -qm init"
+    git_q add README.md src/real.plan.md; git_q commit -qm init
 
     echo "T4 no config — default guard:"
     st_assert "T6 clean branch -> 0" 0 "$(st_rc bash "$self")"
@@ -159,12 +167,19 @@ selftest() {
     mkdir -p sub/deeper
     st_assert "GC-1 caught when run from subdirectory -> 1" 1 "$(cd sub/deeper && st_rc bash "$self")"
 
-    eval "$GIT_Q add docs/superpowers/specs/a/b/c.md"      # now staged
+    git_q add docs/superpowers/specs/a/b/c.md             # now staged
     st_assert "T_staged staged intermediate -> 1" 1 "$(st_rc bash "$self")"
-    eval "$GIT_Q commit -qm spec"                          # now tracked
+    # A newly-staged file must appear ONLY under "staged", never "tracked (committed)".
+    staged_out="$(bash "$self" 2>/dev/null || true)"
+    if printf '%s' "$staged_out" | grep -q 'staged:' && ! printf '%s' "$staged_out" | grep -q 'tracked (committed):'; then
+      st_assert "staged file not double-listed as tracked" 0 0
+    else
+      st_assert "staged file not double-listed as tracked" 0 1
+    fi
+    git_q commit -qm spec                                  # now tracked
     st_assert "T1 tracked intermediate -> 1" 1 "$(st_rc bash "$self")"
 
-    eval "$GIT_Q rm -q docs/superpowers/specs/a/b/c.md"; eval "$GIT_Q commit -qm rm"
+    git_q rm -q docs/superpowers/specs/a/b/c.md; git_q commit -qm rm
     st_assert "T6b removed -> clean 0" 0 "$(st_rc bash "$self")"
 
     echo "T_overmatch real src/*.plan.md must NOT be flagged by default:"


### PR DESCRIPTION
## Summary

Adds a **spec-cleanup** capability to the git-workflow skill: keep intermediate
planning artifacts (superpowers specs/plans under `docs/superpowers/**`, ad-hoc
`PLAN.md`, planning-tool output) out of the base branch, and capture durable
decisions into an ADR before the raw files are removed.

Origin: the #team-ecom discussion on 2026-06-15, where ~5000 lines of
superpowers specs/plans rode a feature branch into the base branch via `develop`
(HMKG-2227). Folded into git-workflow-skill per the team's `/pr-finish` direction.

## Design — two layers, one capability

- **Guard** (`skills/git-workflow/scripts/spec-cleanup-guard.sh`) — deterministic,
  **read-only**. Detects intermediate artifacts in three states (tracked / staged /
  untracked) via pinned git pathspecs; `yq` fail-closed; `--dry-run`, `--selftest`.
  Never deletes, stages, or modifies — safe to run at the merge gate and in CI.
- **Capture** — interactive `/pr-finish` step (before rebase). Proposes an ADR diff
  for review, verifies the capture commit landed, then removes raw files
  **recoverably** through git history (never bare-`rm`). Default `convert`,
  fallback `remove`/acknowledge.

## Scope (v1)

- Read-only guard with three-state detection, pinned pathspecs, `--selftest`,
  `--dry-run`, fail-closed config.
- `.spec-cleanup.yml` schema + `.spec-cleanup.yml.example` (baked-in defaults +
  `exclude:`).
- Merge-gate checklist item + recipe in `references/pull-request-workflow.md`.
- `/pr-finish` capture-before-rebase step; **ADR-only** conversion.
- AGENTS.md doc-folder taxonomy, 2 agent-behavior evals, checkpoint GW-16,
  `references/spec-cleanup.md`.

**Deferred (follow-ups):** PRD update-in-place and user-doc capture targets;
off-by-default git pre-commit template / PreToolUse runtime block; `block` mode;
AGENTS.md↔config drift check.

## How it was built

Two adversarial review passes (multi-dimension, each finding independently
verified) gated the work:

- **Spec review** → 3 blockers fixed before any code (recoverable git removal vs
  bare `rm`; anchored globs + `exclude:`; `hooks/` vs `Build/hooks/` conflation).
- **Implementation review** → 1 high + 1 medium + 7 low, all confirmed and fixed
  (subdir false-negative; `yq` compatibility; guard rejects its own forbidden
  unanchored globs; `--help` source leak; safety/precision wording).

## Test plan

- `bash skills/git-workflow/scripts/spec-cleanup-guard.sh --selftest` → 12/12
  (clean/dirty/staged/untracked/nested/subdir/exclude/fail-closed/reject-unanchored).
- `shellcheck` clean; `bash Build/Scripts/validate-skill.sh` passes (SKILL.md under
  the 500-word cap); markdownlint + yamllint + JSON checks pass.

No version bump / CHANGELOG entry (separate release flow). The design spec under
`docs/superpowers/specs/` is intentional dogfooding — the guard flags it by
design; the repo ships no active config, so it is not wired into its own gate.
