### PR TITLE
docs: verify signing without committing on main

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -507,7 +507,7 @@ If you must actually exercise the signing path, do it on a throwaway branch and 
 
 ```bash
 git switch -c tmp/sign-probe
-git commit --allow-empty -S -m probe && git log -1 --format='%G?'   # expect: G
+git commit --allow-empty -S -m "chore: signing probe" && git log -1 --format='%G?'   # conventional msg so a commit-msg hook won't reject it; expect: G
 git switch - && git branch -D tmp/sign-probe
 ```
 

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -491,6 +491,26 @@ gh api /repos/{owner}/{repo}/commits/HEAD --jq '.commit.verification | {verified
 
 **Never bypass signing** unless explicitly told to. `--no-gpg-sign` and `-c commit.gpgsign=false` disable commit signing; the result will fail branch-protection or policy checks that require signed commits later.
 
+**Verify signing capability without committing on `main`.** To check that signing
+actually works (right key, agent reachable), do **not** create a probe commit on the
+default branch — even an immediately-reset `git commit --allow-empty -S` on `main` is a
+transient commit on a protected branch and violates "no direct commits to main". Inspect
+configuration instead, no commit required:
+
+```bash
+git config commit.gpgsign     # expect: true
+git config gpg.format         # ssh (SSH signing) or empty (GPG)
+git config user.signingkey    # the key/path that will be used
+```
+
+If you must actually exercise the signing path, do it on a throwaway branch and discard it:
+
+```bash
+git switch -c tmp/sign-probe
+git commit --allow-empty -S -m probe && git log -1 --format='%G?'   # expect: G
+git switch - && git branch -D tmp/sign-probe
+```
+
 ## Atomic Commits
 
 Each commit should be a **single, self-contained logical change** that builds and passes tests independently.


### PR DESCRIPTION
## What

Adds a note to the "Signed Commits + DCO Sign-Off" section: how to verify signing capability **without** committing on `main`.

## Why

A `/retro` caught a probe commit — `git commit --allow-empty -S` on `main`, then `git reset` — used just to confirm signing works. Even though it was reset, it's a transient commit on the protected default branch, which the skill's own "no direct commits to main" rule forbids. The fix is to inspect `git config` (`commit.gpgsign` / `gpg.format` / `user.signingkey`), or probe on a throwaway branch and delete it.
