### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.17.0"
+  version: "1.18.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Release v1.18.0.

Bumps plugin.json + skill metadata version 1.17.0 → 1.18.0.

Content since v1.17.0:
- feat: timeline-event check for old-head review + CLEAN merge decisions (#66)
- feat: spec-cleanup capability + read-only spec-cleanup-guard.sh (#68)
- docs(merge-gate): gate query and merge as separate invocations (#67)
- docs(commit-conventions): verify signing without committing on main (#70)
- docs(ci): native CI watchers over hand-rolled poll loops (#71)