### PR TITLE
docs(pr-workflow): add a "Diagnosing mergeStateStatus: BLOCKED" decision aid

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -892,6 +892,20 @@ gh pr view 42 --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup
 gh pr merge 42 --merge
 ```
 
+#### Diagnosing `mergeStateStatus: BLOCKED`
+
+`BLOCKED` tells you the PR is not mergeable; it never tells you **why**. Derive the cause from the gate fields above — not from the branch-protection / ruleset inventory (`gh api repos/{repo}/rules/branches/{branch}` or `…/branches/{branch}/protection`). That inventory lists which rules *exist*, not which one is *currently failing*; reading "copilot_code_review is configured" and concluding "Copilot is blocking" is a classic false attribution. Walk the decisive evidence in this order:
+
+| Symptom in the gate output | Actual blocker |
+|---|---|
+| `reviewDecision: "REVIEW_REQUIRED"` | a required approving review is missing — request/await it |
+| `reviewDecision: ""` **and** still BLOCKED | **not** a review-approval block — keep looking (this is the field that disproves "a reviewer is blocking it") |
+| any `statusCheckRollup[].conclusion != "SUCCESS"` (incl. pending) | a required check — name *that* check, not a rule |
+| `reviewThreads[].isResolved == false` exists | unresolved conversations + the repo's `required_conversation_resolution` toggle — resolve the threads |
+| all the above clean, still BLOCKED | branch behind base (needs update), or merge-queue / required-deployment gate |
+
+When unsure which protection toggle couples to the symptom, read it directly: `gh api repos/{repo}/branches/{branch}/protection --jq '{conversation: .required_conversation_resolution, reviews: .required_pull_request_reviews, checks: .required_status_checks.contexts, strict: .required_status_checks.strict}'`. State the cause only once you can point at the field that proves it.
+
 The PR-level gate above covers review decision, merge state, required checks, and thread resolution in one response. A second check is needed for CI annotations (warnings — reviewdog / actionlint / CodeQL deprecations — that don't fail their check but still need addressing). These are a commit-level property, not a PR-level one:
 
 ```bash


### PR DESCRIPTION
## Summary

`mergeStateStatus: BLOCKED` says a PR isn't mergeable but never says **why**. The common failure mode — for agents and humans — is to read the branch-protection / ruleset *inventory* (`gh api repos/{repo}/rules/branches/{branch}`), see a rule exists, and attribute the block to it. That inventory lists which rules *exist*, not which one is *currently failing*.

This adds a short decision aid to the **Merge Gate** section of `pull-request-workflow.md` mapping each gate-field symptom to the actual blocker:

- `reviewDecision: "REVIEW_REQUIRED"` → missing required approval
- `reviewDecision: ""` **and** still BLOCKED → *not* a review block (the field that disproves "a reviewer is blocking it")
- failing/pending `statusCheckRollup` → name that check
- unresolved `reviewThreads` → conversation-resolution gate
- all clean, still BLOCKED → branch behind base / merge-queue / deployment gate

…plus the direct `…/branches/{branch}/protection` query to confirm which toggle couples to the symptom, and the rule: state the cause only once you can point at the field that proves it.

## Motivation

Real case from a release session: a PR was asserted to be "BLOCKED by the `copilot_code_review` ruleset" (twice) when the actual cause was `required_conversation_resolution` + 4 unresolved review threads — and `reviewDecision` was already empty, which had disproved a review-approval block. The gate command already returns all the needed fields; what was missing was the "derive the cause from these fields, not the rules list" step. This documents that.

Docs-only change to one reference file.
