### PR TITLE
fix(merge-gate): reviewThreads is not a gh pr view --json field; use GraphQL

### DIFF
--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -77,7 +77,7 @@ MSS=$(echo "$INFO" | jq -r '.mergeStateStatus // "null"')
 URL=$(echo "$INFO" | jq -r '.url // ""')
 [[ "$URL" =~ github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]] || exit 0
 UNRES=$(gh api graphql -f query="{repository(owner:\"${BASH_REMATCH[1]}\",name:\"${BASH_REMATCH[2]}\"){pullRequest(number:${BASH_REMATCH[3]}){reviewThreads(first:100){nodes{isResolved}}}}}" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved==false)] | length' 2>/dev/null) || UNRES=0
+  --jq '[.data.repository.pullRequest?.reviewThreads?.nodes[]? | select(.isResolved==false)] | length' 2>/dev/null) || UNRES=0
 
 # Gate on unresolved threads + merge state only. Deliberately NOT on
 # reviewDecision: repos with no required-approval rule report reviewDecision ""

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -66,20 +66,32 @@ fi
 # Could not parse a PR id — let the call through rather than false-positive block.
 [[ -z "$PR" ]] && exit 0
 
-STATE=$(gh pr view "$PR" "${REPO_FLAG[@]}" \
-  --json reviewDecision,mergeStateStatus,reviewThreads 2>/dev/null) || exit 0
-UNRES=$(echo "$STATE" | jq '[.reviewThreads.nodes[]? | select(.isResolved==false)] | length')
-DEC=$(echo "$STATE" | jq -r '.reviewDecision // "null"')
-MSS=$(echo "$STATE" | jq -r '.mergeStateStatus // "null"')
+# NB: `reviewThreads` is NOT a valid `gh pr view --json` field — gh errors
+# "Unknown JSON field: reviewThreads" (its whitelist has reviews /
+# reviewRequests / reviewDecision, not reviewThreads). Fetch mergeStateStatus +
+# url via `gh pr view`, then get thread resolution via GraphQL (owner / repo /
+# number parsed from the url). Passing reviewThreads to --json makes the whole
+# call fail → `|| exit 0` → the gate silently allows every merge.
+INFO=$(gh pr view "$PR" "${REPO_FLAG[@]}" --json mergeStateStatus,url 2>/dev/null) || exit 0
+MSS=$(echo "$INFO" | jq -r '.mergeStateStatus // "null"')
+URL=$(echo "$INFO" | jq -r '.url // ""')
+[[ "$URL" =~ github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]] || exit 0
+UNRES=$(gh api graphql -f query="{repository(owner:\"${BASH_REMATCH[1]}\",name:\"${BASH_REMATCH[2]}\"){pullRequest(number:${BASH_REMATCH[3]}){reviewThreads(first:100){nodes{isResolved}}}}}" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved==false)] | length' 2>/dev/null) || UNRES=0
 
-if [[ "$UNRES" -gt 0 || "$DEC" != "APPROVED" || "$MSS" != "CLEAN" ]]; then
+# Gate on unresolved threads + merge state only. Deliberately NOT on
+# reviewDecision: repos with no required-approval rule report reviewDecision ""
+# and merge fine when CLEAN, and mergeStateStatus==CLEAN already encodes the
+# required-approval gate — so gating on reviewDecision!=APPROVED would
+# false-positive-block every such repo.
+if [[ "${UNRES:-0}" -gt 0 || "$MSS" != "CLEAN" ]]; then
   jq -cn \
-    --arg r "merge-gate fail: unresolved=$UNRES, review=$DEC, mergeState=$MSS" \
+    --arg r "merge-gate: unresolved-threads=$UNRES, mergeState=$MSS — resolve threads / clear the block before merging" \
     '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
 fi
 ```
 
-The hook denies `gh pr merge` when any of: review threads unresolved, `reviewDecision != APPROVED`, or `mergeStateStatus != CLEAN`. It parses the three PR-reference forms `gh pr merge` accepts (plain number, full URL, `owner/repo#N`); if parsing fails, the hook allows the call rather than producing false-positive denies.
+The hook denies `gh pr merge` when review threads are unresolved or `mergeStateStatus != CLEAN`. It parses the three PR-reference forms `gh pr merge` accepts (plain number, full URL, `owner/repo#N`); if parsing fails, the hook allows the call rather than producing false-positive denies.
 
 ## Recipe 2: Reject Edits to Installed Cache Paths
 
@@ -191,7 +203,7 @@ The settings watcher only picks up new hook files if `.claude/` existed at sessi
 | Anti-pattern | Why wrong | Fix |
 |--------------|-----------|-----|
 | Using `xargs` on stdin JSON | xargs splits on spaces; breaks paths with spaces | `{ read -r F; ... "$F"; }` pattern |
-| Forgetting `2>/dev/null || true` on PostToolUse | Hook failure pollutes transcript | Wrap non-blocking hooks |
-| `Write|Edit` matcher without file-path extraction | Hook runs on wrong files | `jq -r '.tool_input.file_path'` |
+| Forgetting `2>/dev/null \|\| true` on PostToolUse | Hook failure pollutes transcript | Wrap non-blocking hooks |
+| `Write\|Edit` matcher without file-path extraction | Hook runs on wrong files | `jq -r '.tool_input.file_path'` |
 | Blocking hooks that hit flaky services | One GitHub-API outage blocks all merges | Soft-fail: warn instead of deny for infra-dependent gates |
 | Per-hook large shell scripts inline in JSON | Unreadable, un-testable | Keep inline ≤3 lines; call external script for more |

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -859,17 +859,28 @@ If `unknown_key`: go to *github.com → Settings → SSH and GPG keys*, find you
 ### Merge-Gate Command
 
 ```bash
-# Primary gate — single gh pr view that returns every PR-level input.
-# --json takes a comma-separated field list with no spaces, so keep the
-# whole list on one line.
-gh pr view NUMBER --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup,reviewThreads
+# The gate is TWO queries. `reviewThreads` is NOT a valid `gh pr view --json`
+# field — gh errors "Unknown JSON field: reviewThreads" (its whitelist has
+# reviews / reviewRequests / reviewDecision, not reviewThreads), and passing it
+# fails the WHOLE call. Thread resolution is only available via GraphQL.
+#
+# (1) PR-level fields via gh pr view (--json takes a no-spaces comma list):
+gh pr view NUMBER --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup
+
+# (2) unresolved-thread count via GraphQL (must be 0):
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:NUMBER){
+  reviewThreads(first:100){nodes{isResolved}}}}}' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length'
 
 # Merge-ready requires ALL of:
-#   reviewDecision                            == "APPROVED"
+#   reviewDecision                            == "APPROVED" OR "" (empty = no
+#                                                human-approval rule; CLEAN then
+#                                                already encodes the gate — do
+#                                                NOT treat "" as a blocker)
 #   mergeStateStatus                          == "CLEAN"
 #   mergeable                                 == "MERGEABLE"
 #   every statusCheckRollup[].conclusion      == "SUCCESS"
-#   every reviewThreads[].isResolved          == true   # gh flattens the GraphQL edges/nodes
+#   unresolved-thread count (query 2)         == 0
 ```
 
 **The gate and the merge are two separate invocations.** Run the gate query,
@@ -883,12 +894,13 @@ threads — GitHub only couples the two when the "require conversation
 resolution" branch-protection rule is enabled, which most repos don't turn on.
 
 ```bash
-# ❌ Wrong — merge already executed by the time "unresolved: 3" is visible
-gh pr view 42 --json mergeStateStatus,reviewThreads && gh pr merge 42 --merge
+# ❌ Wrong — merge already executed by the time the gate output is visible
+gh pr view 42 --json mergeStateStatus && gh pr merge 42 --merge
 
-# ✅ Right — two invocations, with an explicit read of the gate output between
-gh pr view 42 --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup,reviewThreads
-# READ the output: all threads resolved? all checks green? Only then, as a new command:
+# ✅ Right — run the gate queries, READ the output, then merge as a new command
+gh pr view 42 --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:42){reviewThreads(first:100){nodes{isResolved}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+# READ both: all threads resolved (count 0)? all checks green? Only then:
 gh pr merge 42 --merge
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -870,7 +870,7 @@ gh pr view NUMBER --json reviewDecision,mergeStateStatus,mergeable,statusCheckRo
 # (2) unresolved-thread count via GraphQL (must be 0):
 gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:NUMBER){
   reviewThreads(first:100){nodes{isResolved}}}}}' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length'
+  --jq '[.data.repository.pullRequest?.reviewThreads?.nodes[]? | select(.isResolved==false)] | length'
 
 # Merge-ready requires ALL of:
 #   reviewDecision                            == "APPROVED" OR "" (empty = no
@@ -899,7 +899,7 @@ gh pr view 42 --json mergeStateStatus && gh pr merge 42 --merge
 
 # ✅ Right — run the gate queries, READ the output, then merge as a new command
 gh pr view 42 --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup
-gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:42){reviewThreads(first:100){nodes{isResolved}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){pullRequest(number:42){reviewThreads(first:100){nodes{isResolved}}}}}' --jq '[.data.repository.pullRequest?.reviewThreads?.nodes[]?|select(.isResolved==false)]|length'
 # READ both: all threads resolved (count 0)? all checks green? Only then:
 gh pr merge 42 --merge
 ```


### PR DESCRIPTION
## Problem

Both the merge-gate **hook recipe** (`references/claude-code-hooks.md`) and the merge-gate **command** (`references/pull-request-workflow.md`) pass `reviewThreads` to `gh pr view --json`. That field doesn't exist:

```
$ gh pr view N --json reviewThreads
Unknown JSON field: "reviewThreads"
Available fields: ... reviews, reviewRequests, reviewDecision, latestReviews ...
```

So the whole call fails. In the **hook** that's fatal: `… 2>/dev/null) || exit 0` fires and the gate **silently allows every merge** — the exact thing it exists to prevent. In the documented command it just errors out. Thread-resolution state is only available via GraphQL.

## Fix

- **Gate command** → two queries: PR-level fields via `gh pr view --json reviewDecision,mergeStateStatus,mergeable,statusCheckRollup`, and unresolved-thread count via `gh api graphql … reviewThreads`. Wrong/right examples updated to match.
- **Hook recipe** → fetch `mergeStateStatus,url`, parse owner/repo/number from the url, query threads via GraphQL.
- **Drop the `reviewDecision != APPROVED` condition.** Repos with no required-approval rule report `reviewDecision: ""` and merge fine when CLEAN; `mergeStateStatus == CLEAN` already encodes the required-approval gate. The old condition false-positive-blocked every such repo (most NR repos). Gate on unresolved threads + `mergeStateStatus != CLEAN`; criteria note now accepts `""`.
- Escape unescaped pipes in the Anti-Patterns table (MD056) so the docs lint.

## Verification

The corrected hook is running locally (`~/.claude/hooks/merge-gate.sh`) and was checked against live PRs: an open BLOCKED PR with unresolved threads → **deny**; a CLEAN PR with resolved threads → **allow**; non-merge commands → pass through.

https://claude.ai/code/session_015Myeo4imGJGskBMto9BVAm