### PR TITLE
docs(merge-gate): confirm post-merge jobs by commit SHA, not run list

### DIFF
--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -62,3 +62,17 @@ Pitfalls baked in: `grep -c` exits 1 on zero matches (`|| true`); decide hard-fa
 **`gh run rerun` reuses the original `GITHUB_SHA`.** For `pull_request` events that is the merge commit computed at first run — a rerun after a base-branch fix still tests against the broken base. Rerun is only for flakes; to pick up a repaired base, rebase the branch and push.
 
 **Review bots converge over multiple rounds.** Every push invalidates the review (ruleset `copilot_code_review` needs a fresh review on the latest head), so re-request after each push: `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Later rounds may flag UNCHANGED lines adjacent to the diff (latent legacy bugs) — triage each finding on its merits; expect 3–6 rounds on large refactor PRs, with finding severity decreasing per round. Re-arm the watcher after every push.
+
+## Post-merge: confirm merge-triggered jobs by commit SHA, not by run list
+
+After merge, the base branch (`main`) fires its own runs (CI, release, deploy). To confirm those, query the **commit's** checks keyed on the merge SHA — never filter `gh run list` by `headSha`:
+
+```bash
+SHA=$(gh pr view $PR --repo $R --json mergeCommit --jq '.mergeCommit.oid')
+gh api repos/$R/commits/$SHA/check-runs --jq '.check_runs[]|{name,status,conclusion}'
+gh api repos/$R/commits/$SHA/status      --jq '{state, total:(.statuses|length)}'   # legacy commit statuses (Sonar/codecov)
+```
+
+`gh run list --json … --jq 'select(.headSha=="'$SHA'")'` is unreliable here: the list window is small and time-ordered, so a still-running `main` job scrolls out behind unrelated activity and the filter returns empty — which then feeds a `gh run view ""` (HTTP 404) and tempts a hand-rolled `sleep`-poll loop that just times out. The check-runs/status API is authoritative and SHA-addressed. For PR-head checks, `gh pr checks $PR --watch` already blocks to completion — prefer it over any custom loop.
+
+**Pre-existing red ≠ your regression.** If a post-merge gate (e.g. SonarCloud "Quality Gate failed" on N Security Hotspots) is red, check the *prior* base commit before owning it: `gh api repos/$R/commits/<prev-sha>/check-runs --jq '.check_runs[]|select(.name=="<gate>")|.conclusion'`. Identical red on the parent + a diff that touched no relevant code = a pre-existing backlog to report, not a regression to fix.

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -68,11 +68,11 @@ Pitfalls baked in: `grep -c` exits 1 on zero matches (`|| true`); decide hard-fa
 After merge, the base branch (`main`) fires its own runs (CI, release, deploy). To confirm those, query the **commit's** checks keyed on the merge SHA — never filter `gh run list` by `headSha`:
 
 ```bash
-SHA=$(gh pr view $PR --repo $R --json mergeCommit --jq '.mergeCommit.oid')
-gh api repos/$R/commits/$SHA/check-runs --jq '.check_runs[]|{name,status,conclusion}'
+SHA=$(gh pr view $PR --repo $R --json mergeCommit --jq '.mergeCommit?.oid')
+gh api repos/$R/commits/$SHA/check-runs --jq '.check_runs[]?|{name,status,conclusion}'
 gh api repos/$R/commits/$SHA/status      --jq '{state, total:(.statuses|length)}'   # legacy commit statuses (Sonar/codecov)
 ```
 
 `gh run list --json … --jq 'select(.headSha=="'$SHA'")'` is unreliable here: the list window is small and time-ordered, so a still-running `main` job scrolls out behind unrelated activity and the filter returns empty — which then feeds a `gh run view ""` (HTTP 404) and tempts a hand-rolled `sleep`-poll loop that just times out. The check-runs/status API is authoritative and SHA-addressed. For PR-head checks, `gh pr checks $PR --watch` already blocks to completion — prefer it over any custom loop.
 
-**Pre-existing red ≠ your regression.** If a post-merge gate (e.g. SonarCloud "Quality Gate failed" on N Security Hotspots) is red, check the *prior* base commit before owning it: `gh api repos/$R/commits/<prev-sha>/check-runs --jq '.check_runs[]|select(.name=="<gate>")|.conclusion'`. Identical red on the parent + a diff that touched no relevant code = a pre-existing backlog to report, not a regression to fix.
+**Pre-existing red ≠ your regression.** If a post-merge gate (e.g. SonarCloud "Quality Gate failed" on N Security Hotspots) is red, check the *prior* base commit before owning it: `gh api repos/$R/commits/<prev-sha>/check-runs --jq '.check_runs[]?|select(.name=="<gate>")|.conclusion'`. Identical red on the parent + a diff that touched no relevant code = a pre-existing backlog to report, not a regression to fix.


### PR DESCRIPTION
## Summary

- Add a **"Post-merge: confirm merge-triggered jobs by commit SHA"** section to `references/merge-gate-watcher.md`.
- Documents using `gh api repos/$R/commits/$SHA/check-runs` (+ `/status`) — authoritative and SHA-addressed — instead of `gh run list --jq 'select(.headSha==SHA)'`, which is unreliable for post-merge base-branch runs (small, time-ordered list window → still-running jobs scroll out → empty filter → `gh run view ""` 404 → hand-rolled poll loop that times out).
- Adds the "prefer `gh pr checks --watch` over custom loops" rule and a "pre-existing red ≠ your regression" check against the parent commit (e.g. a SonarCloud hotspot gate already red on the base).

## Motivation

Hit exactly this during a `pr-finish` run: post-merge `main` CI watched via `gh run list | jq select(headSha)` returned empty, cascading into a 404 and a 2-minute timed-out poll loop. The check-runs API resolved it in one call. Complements the existing watcher loop (which is pre-merge) with the post-merge step that `pull-request-workflow.md` step 6 ("confirm merge-triggered async jobs") relies on.

## Validation

- `markdownlint-cli2`: 0 errors
- `pre-commit run --files …`: all applicable hooks Passed (version-parity skipped — reference-only change, no version bump needed)
