### PR TITLE
Add field-tested git worktree/hooks/pathspec gotchas

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -394,6 +394,38 @@ done
 git -C /projects/<repo>/main fetch --prune origin
 ```
 
+### Sync the Base Before Branching (Stale-Base Trap)
+
+A per-branch worktree layout makes it easy to branch from a checkout that is
+weeks behind the remote. A feature branch's green pipeline only proves
+correctness **against its base** — if the base has moved, a clean auto-merge can
+combine your change with newer code in a way no pipeline ever tested, landing a
+regression on the default branch.
+
+Guard against it at both ends of the work:
+
+```bash
+# At the START of work in any worktree — a stale checkout is not proof
+# a file is missing. Sync the base, then branch from the fresh tip.
+git -C <worktree> status -sb
+git -C <worktree> pull --ff-only            # or fetch the base explicitly (see note)
+git -C <worktree> switch -c feature/x origin/main
+
+# BEFORE merging — rebase onto the current remote base so CI validates the
+# REAL merge result, not the branch against a stale base.
+git fetch origin
+git rebase origin/main
+```
+
+**Note for bare-repo layouts:** a bare clone often lacks
+`remote.origin.fetch`, so `git fetch origin` never updates `origin/<base>`.
+Fetch the base branch explicitly — `git fetch origin main:refs/remotes/origin/main`
+— or set the refspec once (see the bare-worktree setup above).
+
+After any merge, verify structural invariants on the **merged base** (e.g. that
+every cross-reference still resolves), not just on the branch — that is the only
+check that catches a regression introduced by the merge itself.
+
 ### Use Cases
 
 ```bash
@@ -690,6 +722,41 @@ git fsck
 # Repack
 git repack -a -d
 ```
+
+## Scripting Over Tracked Files
+
+### `git ls-files`, not `git ls-tree`, for glob pathspecs
+
+When a script matches tracked files by a configurable glob, use `git ls-files` —
+**not** `git ls-tree`. `ls-tree` rejects pathspec magic; the glob form dies:
+
+```bash
+git ls-tree -r HEAD -- ':(glob)docs/**/*.md'
+# fatal: pathspec magic not supported by this command: 'glob', 'exclude'
+```
+
+If that command is wrapped in `2>/dev/null` (common in guard scripts), the fatal
+error is swallowed and you get a **silently empty** result — a false negative
+that lets unguarded files through. `ls-files` honors `:(glob)` and
+`:(exclude,glob)`:
+
+```bash
+git ls-files -- ':(glob)docs/**/*.md' ':(exclude,glob)docs/_build/**'
+```
+
+**Caveat — `ls-files` lists the index (staged *and* committed).** A freshly
+staged file therefore shows up as "tracked". For a committed-only view (or to
+avoid double-counting a file you just staged), compute the staged set first and
+subtract it:
+
+```bash
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+git ls-files -- ':(glob)docs/**/*.md' | grep -vxF "$staged"
+```
+
+Use `--diff-filter=ACMR` (not just `AM`) so renames and copies into a guarded
+path are caught. Verify pathspec support empirically before swapping one
+command for the other — the failure mode is silent, not loud.
 
 ## Troubleshooting
 

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -408,7 +408,7 @@ Guard against it at both ends of the work:
 # At the START of work in any worktree — a stale checkout is not proof
 # a file is missing. Sync the base, then branch from the fresh tip.
 git -C <worktree> status -sb
-git -C <worktree> pull --ff-only            # or fetch the base explicitly (see note)
+git -C <worktree> fetch origin main         # update origin/main directly, don't touch the current branch
 git -C <worktree> switch -c feature/x origin/main
 
 # BEFORE merging — rebase onto the current remote base so CI validates the
@@ -751,7 +751,11 @@ subtract it:
 
 ```bash
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
-git ls-files -- ':(glob)docs/**/*.md' | grep -vxF "$staged"
+if [ -n "$staged" ]; then
+  git ls-files -- ':(glob)docs/**/*.md' | grep -vxF "$staged"
+else
+  git ls-files -- ':(glob)docs/**/*.md'
+fi
 ```
 
 Use `--diff-filter=ACMR` (not just `AM`) so renames and copies into a guarded

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -471,6 +471,15 @@ git config --global user.name "Firstname Lastname"
 git config --global user.email "you@example.com"
 ```
 
+**Commit locally to satisfy verified-signature branch protection — not via the host's Contents API.** Commits created through the GitHub Contents API (`PUT /repos/.../contents/...`), or any host-side write that supplies its own `committer`/`author`, come out **unsigned** (`verification.verified=false`, `reason: unsigned`) — the host does not web-flow-sign them. A repo that enforces verified signatures rejects the merge, and when admin enforcement is on you cannot bypass it. So when scripting commits across many repos, check the signature requirement up front alongside required checks and reviews:
+
+```bash
+gh api repos/{owner}/{repo}/branches/main/protection \
+  --jq '.required_signatures.enabled'   # also inspect rulesets
+```
+
+For any repo that enforces signatures, create the commit **locally** with signing configured (`git commit -S --signoff`) rather than through the API — a locally SSH/GPG-signed commit verifies on the host, an API-authored one does not.
+
 **SSH signing keys on GitHub: auth keys ≠ signing keys.** An SSH key registered under *Settings → SSH and GPG keys → Authentication Key* cannot verify commits. It must also be added as a *Signing Key* (same page, different Key type dropdown). GitHub reports unsigned-with-known-key commits as `reason: unknown_key` in the commits API — identical to an unregistered key. Check before the first push to a repo with verified-signature branch protection:
 
 ```bash

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -474,8 +474,8 @@ git config --global user.email "you@example.com"
 **Commit locally to satisfy verified-signature branch protection — not via the host's Contents API.** Commits created through the GitHub Contents API (`PUT /repos/.../contents/...`), or any host-side write that supplies its own `committer`/`author`, come out **unsigned** (`verification.verified=false`, `reason: unsigned`) — the host does not web-flow-sign them. A repo that enforces verified signatures rejects the merge, and when admin enforcement is on you cannot bypass it. So when scripting commits across many repos, check the signature requirement up front alongside required checks and reviews:
 
 ```bash
-gh api repos/{owner}/{repo}/branches/main/protection \
-  --jq '.required_signatures.enabled'   # also inspect rulesets
+gh api repos/"$R"/branches/main/protection \
+  --jq '.required_signatures?.enabled? // false'   # $R="owner/repo"; also inspect rulesets
 ```
 
 For any repo that enforces signatures, create the commit **locally** with signing configured (`git commit -S --signoff`) rather than through the API — a locally SSH/GPG-signed commit verifies on the host, an API-authored one does not.

--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -53,6 +53,38 @@ Then install based on what's found:
 - If hooks aren't installed, install them before first commit
 - If no hook framework exists, suggest adding one in the PR
 
+## Hooks Are Fast Feedback — CI Is the Gate
+
+Local hooks are per-checkout, individually bypassable, and **absent in fresh
+clones and in most secondary worktrees**. Treat them as fast feedback, not as an
+enforcement boundary. The actual gate must be CI: every substantive check a hook
+runs locally (format, lint, static analysis, tests, secret scan, commit-message
+validation) needs an equivalent job in the pipeline. A check that runs only in a
+local hook is silently unenforced for anyone who never installed it. When
+auditing a repo, confirm that parity — a missing local hook is only a real gap
+if CI doesn't cover the same check.
+
+This also means it is legitimate to deliberately leave a repo with **no** local
+hooks when the hook can't run reliably outside its container (e.g. a pre-commit
+that needs a Docker-only service) — provided CI runs the equivalent check.
+Forcing such a hook onto every checkout just turns it into a landmine.
+
+## Auditing Installed Hooks (`--git-path` cwd gotcha)
+
+To find where a checkout's hooks live, prefer the path git computes itself:
+
+```bash
+cd "$repo" && git rev-parse --git-path hooks
+```
+
+**Run it from inside the repo.** For a plain (non-worktree) clone,
+`git rev-parse --git-path hooks` returns a path **relative to the current
+directory** (`.git/hooks`). Resolve or `find` it from elsewhere and you look in
+the wrong place and false-report "no hooks installed". (Worktrees and a
+configured `core.hooksPath` return absolute paths, which masks the bug — so it
+only bites on ordinary clones.) `cd` into the repo first, or resolve the path
+against the repo root, before inspecting it.
+
 ## Troubleshooting
 
 ### CaptainHook + git worktrees (FAQ)


### PR DESCRIPTION
## What

Promotes four recurring, field-tested git lessons into the existing reference set. No new files; each note lands in the closest-fitting reference and matches the surrounding voice.

## Why

These gotchas keep recurring in day-to-day work and each one has cost real rework when forgotten. Capturing them in the skill's references makes the fix the default next time.

## Changes

| Lesson | Reference |
|--------|-----------|
| Commit locally (not via the host Contents API) to satisfy verified-signature branch protection; check `required_signatures` up front when scripting cross-repo commits | `commit-conventions.md` |
| Sync the base before branching and rebase before merge — a green branch pipeline on a stale base hides post-merge regressions; bare-repo missing-fetch-refspec trap | `advanced-git.md` (Worktrees) |
| Use `git ls-files` (honors `:(glob)`/`:(exclude)`), not `git ls-tree`, which rejects pathspec magic and fails *silently* under `2>/dev/null`; subtract the staged set for a committed-only view | `advanced-git.md` (Scripting) |
| Local hooks are fast feedback, CI is the real gate; the `git rev-parse --git-path hooks` cwd-relative gotcha when auditing installed hooks | `git-hooks-setup.md` |

## Notes

- The signing note here is the **Contents-API vs. local-commit** distinction — deliberately separate from the inherited-ssh-agent note in #76, and placed in a different part of the signing section to avoid conflict.
- `Build/Scripts/validate-skill.sh` passes; markdownlint and whitespace hooks pass on the changed files. SKILL.md untouched (word cap).

108 insertions, docs only.
