### PR TITLE
docs(skill): add no-editorializing rule for written output

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -12,8 +12,6 @@ allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 
 # Git Workflow Skill
 
-Expert patterns for Git: branching, commits, collaboration, CI/CD.
-
 ## Critical Rules (Non-Negotiable)
 
 1. **No direct push to main** — always open a PR.
@@ -23,26 +21,28 @@ Expert patterns for Git: branching, commits, collaboration, CI/CD.
 5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree, verified by `pwd`.
 6. **Force-push only with `--force-with-lease`** — never plain `--force`.
 7. **Commit before rebase** — `add → commit → fetch → rebase → push`. Dirty tree aborts rebase.
+8. **No editorializing** — state what changed, not how good it is; no narrating expected results or self-praise. See `references/no-editorializing.md`.
 
 See `references/pull-request-workflow.md` for merge-gate and atomic-commit patterns.
 
 ## Reference Files
 
-Load references on demand:
+Load on demand:
 
 | Reference | Content Triggers |
 |-----------|-----------------|
-| `references/branching-strategies.md` | Branching model, Git Flow, GitHub Flow, trunk-based, branch protection |
-| `references/commit-conventions.md` | Commit messages, conventional commits, DCO sign-off, semantic versioning, commitlint |
-| `references/pull-request-workflow.md` | PR create/review/merge, thread resolution, merge strategies, CODEOWNERS, signed commits + rebase |
+| `references/branching-strategies.md` | Branching models, Git/GitHub Flow, trunk-based, protection |
+| `references/commit-conventions.md` | Conventional commits, DCO sign-off, semantic versioning, commitlint |
+| `references/pull-request-workflow.md` | PR create/review/merge, threads, strategies, CODEOWNERS, signed rebase |
 | `references/ci-cd-integration.md` | GitHub Actions, GitLab CI, semantic release, deployment |
-| `references/advanced-git.md` | Rebase, cherry-pick, bisect, stash, worktrees, reflog, submodules, recovery |
-| `references/github-releases.md` | Release management, immutable releases, `--latest=false`, multi-branch |
-| `references/git-hooks-setup.md` | Hook frameworks, detection, recommended hooks per stage |
+| `references/advanced-git.md` | Rebase, cherry-pick, bisect, stash, worktrees, reflog, recovery |
+| `references/github-releases.md` | Immutable releases, `--latest=false`, multi-branch |
+| `references/git-hooks-setup.md` | Hook frameworks, detection, hooks per stage |
 | `references/claude-code-hooks.md` | Claude Code `settings.json` hooks — merge gate, cache-path rejection, auto-lint |
 | `references/code-quality-tools.md` | shellcheck, shfmt, git-absorb, difftastic |
-| `references/merge-gate-watcher.md` | Merge-driver loop, hard/soft check taxonomy, rerun stale-SHA, review-bot rounds |
+| `references/merge-gate-watcher.md` | Merge-driver loop, check taxonomy, stale-SHA rerun, review-bot rounds |
 | `references/spec-cleanup.md` | Keep planning artifacts off the base branch; guard + capture-to-ADR |
+| `references/no-editorializing.md` | Writing without self-praise or narrating the expected |
 
 ## Conventional Commits
 
@@ -65,7 +65,7 @@ hotfix/1.2.1-security-patch
 
 ## Hook Detection
 
-Detect hooks before first commit:
+Detect hooks first:
 
 ```bash
 ls lefthook.yml .lefthook.yml captainhook.json .pre-commit-config.yaml .husky/pre-commit 2>/dev/null || echo "No hooks"

--- a/skills/git-workflow/references/no-editorializing.md
+++ b/skills/git-workflow/references/no-editorializing.md
@@ -1,4 +1,4 @@
-## No editorializing — inform, don't sell (tone, not wordlist)
+# No editorializing — inform, don't sell (tone, not wordlist)
 
 Applies to every written artifact: commit messages, PR/MR descriptions, review
 comments, issue/ticket text, chat — and code comments, docstrings,
@@ -9,7 +9,7 @@ banned-word list catches it, and the same word can be fine or not depending on
 whether it carries a fact. The failure is writing about *how good, clean, or
 careful the work is* instead of *what it does*. The reader has the diff and the
 artifact; anything that only flatters the work or reassures them adds nothing,
-and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+and to a reviewer it reads as salesmanship — it provokes a counter-reaction
 before they reach the substance.
 
 Apply three tests before a sentence stays:

--- a/skills/git-workflow/references/no-editorializing.md
+++ b/skills/git-workflow/references/no-editorializing.md
@@ -1,0 +1,41 @@
+## No editorializing — inform, don't sell (tone, not wordlist)
+
+Applies to every written artifact: commit messages, PR/MR descriptions, review
+comments, issue/ticket text, chat — and code comments, docstrings,
+documentation, README and changelog files.
+
+Editorializing is a matter of **tone and intent, not specific words** — no
+banned-word list catches it, and the same word can be fine or not depending on
+whether it carries a fact. The failure is writing about *how good, clean, or
+careful the work is* instead of *what it does*. The reader has the diff and the
+artifact; anything that only flatters the work or reassures them adds nothing,
+and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+before they reach the substance.
+
+Apply three tests before a sentence stays:
+
+1. **Deletion** — remove the phrase. Did the reader lose a fact? If not, cut it.
+2. **Subject** — is the sentence about the change, or about *you / your work*
+   (its quality, your diligence)? The latter goes.
+3. **Voice** — would a terse maintainer write this, or does it read like a
+   cover letter?
+
+Two recurring failure modes:
+
+- **Announcing the expected.** Passing tests, clean linters, "documented", "no
+  regressions", "works as expected" are the baseline — do not narrate them.
+  State a check's status only to flag an *exception* (something knowingly
+  failing or skipped). In a test/verification list, say what was *added or
+  covered*, not that it is green.
+
+- **Self-praise and reassurance.** Grading your own output ("clean", "robust",
+  "elegant", "foolproof", "tidy", "genuinely new", "production-ready"); framings
+  that reassure ("the honest breaking change", "deliberately scoped, not
+  hidden", "where it belongs"); and the diligence humble-brag ("I carefully…",
+  "I made sure to…", "thoroughly tested"). These describe the author, not the
+  change. Show the fact; drop the framing. (The words are only symptoms — judge
+  by the three tests above, not by the word.)
+
+Use plain labels, not graded ones: "Breaking change", "Tests", "Limitations" —
+not "Tests (all green)" or "Breaking change (honest)". If a limitation's cause
+matters, it is already stated in the item.


### PR DESCRIPTION
Adds Critical Rule 8 and `references/no-editorializing.md`: write what a change does, not how good or careful the work is. Covers commits, PR/MR text, reviews, comments, docs, README, changelog.

Two failure modes it names: narrating expected results (passing tests, clean lint, "no regressions") and self-praise/reassurance ("clean", "the honest breaking change", "deliberately scoped, not hidden"). Judged by tone via three tests (deletion / subject / voice), not a wordlist.

SKILL.md kept at the 500-word limit by tightening a few reference-table descriptions.