### PR TITLE
docs: force-fetch tags before topology reasoning; don't hard-wrap Markdown

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -802,3 +802,30 @@ git reset --hard HEAD@{1}
 git fsck --unreachable | grep commit | cut -d' ' -f3 | \
   xargs git log --merges --no-walk --grep=WIP
 ```
+
+### Tags & Remote-State Topology
+
+A plain `git fetch` auto-follows *new* tags on fetched commits, but it will not
+move a tag that was **force-updated** upstream, nor drop one deleted upstream —
+so local tag refs can silently point at stale commits. Before reasoning about tag
+relationships — which tag is newest, whether X is an ancestor of Y, whether two
+lines diverged — refresh the tags and treat the remote as authoritative. A stale
+local tag can invent a divergence that does not exist.
+
+```bash
+# Force-update moved tags and prune deleted ones (--prune-tags needs Git >= 2.17;
+# without it, drop the flag and re-fetch with --force)
+git fetch origin --prune --prune-tags --force
+
+# Nearest tag by commit ancestry (NOT the highest semver), plus a direct test
+git describe --tags <branch>
+git merge-base --is-ancestor <tag> <branch> && echo "reachable from branch"
+
+# Authoritative ahead/behind/merge-base straight from the host
+gh api repos/OWNER/REPO/compare/<base>...<head> \
+  --jq '{status, ahead_by, behind_by, merge_base: .merge_base_commit.sha}'
+```
+
+Verify against `origin` (or the compare API) before deleting a tag, choosing a
+release version, or concluding two lines forked — not against local refs.
+

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -133,6 +133,15 @@ Body may contain "quotes", & ampersands, `backticks` — all literal.
 EOF
 ```
 
+**Hard-wrap the commit *body* (~72 cols); don't hard-wrap prose whose wrapping
+you don't control.** The 72-column convention is for commit message bodies. For
+**PR/MR & issue descriptions, release notes, review comments, and chat**, write
+one line per paragraph (and per list item) and let the renderer soft-wrap — a
+hard break mid-paragraph there does nothing for the output. For **committed
+Markdown files**, follow the repo's existing convention: many hard-wrap prose
+docs for readable diffs, so match the surrounding files rather than mixing two
+styles in one tree.
+
 ### Footer
 
 ```bash


### PR DESCRIPTION
Two reference additions from real friction (source: a timetracker release session).

## advanced-git.md — Tags & remote-state topology

Tags don't update on a plain `git fetch` and can be force-moved upstream. Reasoning about tag relationships from stale local refs produced a bogus "the branches diverged" conclusion that nearly led to deleting a tag and mis-versioning a release. Adds: `git fetch --tags --prune --force` first, and use `gh api .../compare/A...B` (ahead/behind/merge_base) as the authoritative source before deleting a tag, choosing a version, or concluding a fork.

## commit-conventions.md — don't hard-wrap Markdown

Clarifies that the ~72-col wrap convention is for commit message **bodies only**. PR/issue/release descriptions and `.md` docs render as Markdown (soft-wrap) — hard breaks mid-paragraph there do nothing for the output and make the source painful to edit. One line per paragraph; only commit bodies and already-hard-wrapped files (`.rst`) get manual breaks.