### PR TITLE
docs(references): async review-bot polling + pre-commit recovery learnings

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -166,3 +166,35 @@ controlled-bypass note above.) CI is authoritative for these repos (see "Hooks
 Are Fast Feedback — CI Is the Gate"), so a scoped bypass here is safe. Also: in a
 fresh worktree, `Read` a file before `Write`/`Edit` — there is no cached state
 for a path the tooling has not seen yet.
+
+### pre-commit first run: slow env build, lost stash on interrupt
+
+The **first** commit that triggers `pre-commit` builds a fresh virtualenv for
+every hook repo (ruff, markdownlint, shellcheck, …). That can take minutes, and
+it is easy to interrupt or time out that commit before it finishes.
+
+`pre-commit` stashes your **unstaged** changes for the duration of the run, then
+restores them at the end. If the run is killed mid-way, that restore may not
+happen — the unstaged edits silently vanish from the working tree. So **always
+`git status` after an interrupted commit**, and if files reverted, reapply the
+stash patch pre-commit left behind:
+
+```bash
+ls -t ~/.cache/pre-commit/patch*         # newest is patch<epoch>-<pid>
+git apply ~/.cache/pre-commit/patch<N>-<pid>
+```
+
+Then re-run the commit (the hook envs are now built, so it is fast).
+
+### `--no-verify` only after confirming CI parity
+
+A local hook the CI pipeline does **not** run is not a real merge gate (see
+"Hooks Are Fast Feedback — CI Is the Gate"). If such a hook (say a repo-only
+`black`, `isort`, or `shellcheck`) reports the tree dirty and running its
+formatter would rewrite **hundreds of unrelated lines**, bypassing it with
+`--no-verify` is defensible — but only *after* you have read the CI workflow and
+confirmed it does not enforce that check. Concretely: verify the pipeline's
+`flake8` uses a narrow `--select`, that there is no `shellcheck`/`black` job,
+etc. A hook enforced only locally is already silently unenforced — don't let it
+dictate a massive diff that has nothing to do with your change. If CI *does* run
+the check, it is a real gate: fix the finding instead of bypassing it.

--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -183,8 +183,8 @@ stash patch pre-commit left behind:
 # pre-commit's cache dir is configurable: PRE_COMMIT_HOME, else XDG_CACHE_HOME/pre-commit,
 # else ~/.cache/pre-commit (macOS/other platforms may differ).
 PCH="${PRE_COMMIT_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pre-commit}"
-ls -t "$PCH"/patch*                       # newest is patch<epoch>-<pid>
-git apply "$PCH"/patch<N>-<pid>
+PATCH=$(ls -t "$PCH"/patch* 2>/dev/null | head -1)   # newest patch<epoch>-<pid>
+git apply "$PATCH"
 ```
 
 Then re-run the commit (the hook envs are now built, so it is fast).

--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -180,8 +180,11 @@ happen — the unstaged edits silently vanish from the working tree. So **always
 stash patch pre-commit left behind:
 
 ```bash
-ls -t ~/.cache/pre-commit/patch*         # newest is patch<epoch>-<pid>
-git apply ~/.cache/pre-commit/patch<N>-<pid>
+# pre-commit's cache dir is configurable: PRE_COMMIT_HOME, else XDG_CACHE_HOME/pre-commit,
+# else ~/.cache/pre-commit (macOS/other platforms may differ).
+PCH="${PRE_COMMIT_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pre-commit}"
+ls -t "$PCH"/patch*                       # newest is patch<epoch>-<pid>
+git apply "$PCH"/patch<N>-<pid>
 ```
 
 Then re-run the commit (the hook envs are now built, so it is fast).

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -329,7 +329,7 @@ whose `commit_id` equals the PR head has landed:
 HEAD=$(gh pr view "$PR" --repo "$R" --json headRefOid --jq .headRefOid)
 # A Copilot review keyed to the current head must exist before you trust the count.
 SEEN=$(gh api "repos/$R/pulls/$PR/reviews" \
-  --jq "[.[]? | select(.user?.login? // \"\" | test(\"copilot\";\"i\")) | select((.commit_id? // \"\")[0:8]==\"${HEAD:0:8}\")] | length")
+  --jq "[.[]? | select(.user?.login? // \"\" | test(\"copilot\";\"i\")) | select((.commit_id? // \"\")==\"$HEAD\")] | length")
 [ "${SEEN:-0}" -ge 1 ] || { echo "bot has not re-reviewed head $HEAD yet — keep polling"; }
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -329,7 +329,7 @@ whose `commit_id` equals the PR head has landed:
 HEAD=$(gh pr view "$PR" --repo "$R" --json headRefOid --jq .headRefOid)
 # A Copilot review keyed to the current head must exist before you trust the count.
 SEEN=$(gh api "repos/$R/pulls/$PR/reviews" \
-  --jq "[.[] | select(.user.login|test(\"copilot\";\"i\")) | select(.commit_id[0:8]==\"${HEAD:0:8}\")] | length")
+  --jq "[.[]? | select(.user?.login? // \"\" | test(\"copilot\";\"i\")) | select((.commit_id? // \"\")[0:8]==\"${HEAD:0:8}\")] | length")
 [ "${SEEN:-0}" -ge 1 ] || { echo "bot has not re-reviewed head $HEAD yet — keep polling"; }
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -310,6 +310,33 @@ gh api graphql -f query='
 
 If that returns any rows, the PR is not merge-ready.
 
+### Wait for the async re-review before trusting `unresolved == 0`
+
+`unresolved == 0` is **not** merge-ready if you sampled it right after a push.
+GitHub Copilot (and Gemini, and similar bot reviewers) re-review the PR
+**asynchronously** — typically 1–2 minutes after each push — and each round can
+post entirely **new** review threads against the fresh head. Reasoning about
+merge-readiness on a zero count that predates the bot's re-review produces a
+premature "threads clear" call; the bot then lands more valid findings a minute
+later. In one session, sampling too early gave a false all-clear **twice**, and
+the bot posted five more legitimate findings on each following round.
+
+So don't check thread count first — **check that the bot has actually reviewed
+the current head SHA first**, then re-check threads. Poll until a bot review
+whose `commit_id` equals the PR head has landed:
+
+```bash
+HEAD=$(gh pr view "$PR" --repo "$R" --json headRefOid --jq .headRefOid)
+# A Copilot review keyed to the current head must exist before you trust the count.
+SEEN=$(gh api "repos/$R/pulls/$PR/reviews" \
+  --jq "[.[] | select(.user.login|test(\"copilot\";\"i\")) | select(.commit_id[0:8]==\"${HEAD:0:8}\")] | length")
+[ "${SEEN:-0}" -ge 1 ] || { echo "bot has not re-reviewed head $HEAD yet — keep polling"; }
+```
+
+Only once `SEEN >= 1` is the unresolved-threads query above meaningful. This is
+the same "review the latest head SHA" gate the [Merge-Gate Watcher](merge-gate-watcher.md)
+enforces — apply it here too, before ever declaring the review done.
+
 ## Merge Strategies
 
 ### Merge Commit


### PR DESCRIPTION
## Summary

Captures two PR-completion learnings from a real `/pr-finish` session where each bit us in practice.

### Learning A — wait for the async review bot before trusting `unresolved == 0`
Added to `references/pull-request-workflow.md` (in "Verifying thread state from GitHub, not memory").

GitHub Copilot (and Gemini) re-review a PR **asynchronously** — usually 1–2 minutes after each push — and can post entirely new review threads against the fresh head. Sampling the unresolved-thread count right after a push therefore reads a stale zero. In the session that prompted this, an early sample produced a premature "threads clear" merge-readiness call **twice**, and the bot then landed five more valid findings each round. The fix: poll until a bot review whose `commit_id` equals the PR head has landed, and only then re-check unresolved threads. Includes a concrete `gh api .../reviews` check and cross-references the Merge-Gate Watcher.

### Learning B — pre-commit first-run recovery + CI parity before `--no-verify`
Added to `references/git-hooks-setup.md` (two new Troubleshooting subsections).

1. **First-run recovery.** The first commit that triggers `pre-commit` builds a virtualenv per hook repo (slow). If that commit is interrupted, pre-commit's stash of your unstaged changes may not be restored and the edits silently revert. Always `git status` after an interrupted commit and reapply `~/.cache/pre-commit/patch<N>-<pid>`. (This actually happened while validating this very PR — the first `pre-commit run` timed out at 2 minutes building envs.)
2. **CI parity before bypass.** A local-only hook with no equivalent CI job is not a real merge gate. When such a hook reports the tree dirty and its formatter would rewrite hundreds of unrelated lines, `--no-verify` is defensible — but only after reading the CI workflow and confirming it does not enforce that check. Reinforces the existing "Hooks Are Fast Feedback — CI Is the Gate" principle with a concrete decision rule.

## Validation
- `Build/Scripts/validate-skill.sh` → 0 errors, 0 warnings
- `markdownlint-cli2` (repo config) on both files → 0 errors
- SKILL.md untouched (still 500 words, at the cap)
- Commit is signed and DCO signed-off

## Type of Change
- [x] Documentation update
