### PR TITLE
docs(references): worktree path resolution, unpiped gates, thread pagination

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -299,6 +299,25 @@ git worktree remove ../project-feature
 git worktree prune
 ```
 
+### Bare-Repo Layouts: Relative Paths Resolve from the Repo, Not Your Shell
+
+With the bare-clone convention (`project/.bare` + one directory per branch),
+`git -C .bare worktree add <path>` resolves a **relative** `<path>` from *inside*
+`.bare` — `git -C` changes the process working directory first. From the project
+directory, `../<branch>` is therefore correct (a sibling of `.bare`), while
+`./<branch>` lands the worktree *inside* `.bare/` and `../<project>/<branch>`
+nests a stray copy one level deep:
+
+```bash
+cd /path/to/project           # contains .bare/
+git -C .bare worktree add ../feature-x origin/main   # -> /path/to/project/feature-x  OK
+git -C .bare worktree add ./feature-x  origin/main   # -> /path/to/project/.bare/feature-x  WRONG
+```
+
+When in doubt, pass an absolute path. Also check whether the target directory
+already holds a **plain clone** before nesting a `.bare` into it — mixing the two
+layouts in one directory leaves a repo checkout *and* a worktree tree side by side.
+
 ### Bare-Worktree Project Layout (Recommended)
 
 **One directory per branch; never switch branches in the same folder.**

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -299,24 +299,15 @@ git worktree remove ../project-feature
 git worktree prune
 ```
 
-### Bare-Repo Layouts: Relative Paths Resolve from the Repo, Not Your Shell
+### Bare-Repo Layouts
 
 With the bare-clone convention (`project/.bare` + one directory per branch),
-`git -C .bare worktree add <path>` resolves a **relative** `<path>` from *inside*
-`.bare` — `git -C` changes the process working directory first. From the project
-directory, `../<branch>` is therefore correct (a sibling of `.bare`), while
-`./<branch>` lands the worktree *inside* `.bare/` and `../<project>/<branch>`
-nests a stray copy one level deep:
+relative `worktree add` paths resolve from *inside* `.bare` — see the detailed
+path-resolution rules and recovery steps in the bare-repo section below.
 
-```bash
-cd /path/to/project           # contains .bare/
-git -C .bare worktree add ../feature-x origin/main   # -> /path/to/project/feature-x  OK
-git -C .bare worktree add ./feature-x  origin/main   # -> /path/to/project/.bare/feature-x  WRONG
-```
-
-When in doubt, pass an absolute path. Also check whether the target directory
-already holds a **plain clone** before nesting a `.bare` into it — mixing the two
-layouts in one directory leaves a repo checkout *and* a worktree tree side by side.
+Before nesting a `.bare` into an existing directory, check whether it already
+holds a **plain clone** — mixing the two layouts leaves a repo checkout *and* a
+worktree side by side in one directory.
 
 ### Bare-Worktree Project Layout (Recommended)
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -772,6 +772,41 @@ gh api graphql -f query='
   }' -f owner=OWNER -f repo=REPO -F pr=NUMBER
 ```
 
+### Handling Many Review Threads (Pagination)
+
+**Critical:** GitHub GraphQL API has a limit of 100 items per page. For PRs with many
+review comments (e.g., 127+ threads from automated reviewers), you MUST use pagination:
+
+```bash
+# Fetch ALL threads with pagination (handles >100 threads)
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes { body path }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner=OWNER -f repo=REPO -F pr=NUMBER
+
+# Then fetch next page using endCursor:
+# -f cursor="Y3Vyc29yOnYyOpHOABCD..."
+```
+
+**Real-world lesson (PR #575):** Automated reviewers can generate 100+ comment threads.
+Without pagination, only the first 100 threads are returned, leaving others unaddressed.
+
 ## Diagnosing CI Failures (Annotations First)
 
 > Failure first-step, not pre-merge gate. The Merge Gate below uses `annotations_count` as a *warnings present?* signal after success. This section is the inverse: when a workflow has *failed* and you don't yet know why, read the annotation text **first**, before any other diagnostic action.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -660,6 +660,18 @@ REMOTE_SHA=$(git ls-remote origin refs/heads/"$BR" | cut -f1)   # no fetch, no f
 
 Likewise verify staging of any path that might be gitignored with `git status --short` before committing — an empty commit pushes "successfully" yet changes nothing.
 
+The same trap applies to **every command whose exit code gates the next step**, not
+just `git push`: a verification build or test run piped through `tail`/`grep` reports
+the *pipe's* exit code. Real case: `docker build … 2>&1 | tail -2 && echo OK` printed
+`OK` for a **failed** build, and the broken branch was pushed before anyone noticed.
+Run gating commands unpiped — capture to a log file and check `$?`, then grep the log:
+
+```bash
+docker build . > build.log 2>&1; RC=$?
+echo "rc=$RC"; grep -E 'error|Good signature' build.log
+[ "$RC" -eq 0 ] || exit 1
+```
+
 ### `--force-with-lease` Rejected with "stale info"
 
 On PRs that bots touch (auto-approve, Renovate/Dependabot, a CI step that pushes), `git push --force-with-lease` can be rejected with `stale info` even when your local work is correct: a bot updated the remote branch since your last fetch, so the lease's expected ref (your `origin/<branch>` tracking ref) no longer matches and the push aborts. This is the safety check working — don't escalate to plain `--force`.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -661,15 +661,18 @@ REMOTE_SHA=$(git ls-remote origin refs/heads/"$BR" | cut -f1)   # no fetch, no f
 Likewise verify staging of any path that might be gitignored with `git status --short` before committing — an empty commit pushes "successfully" yet changes nothing.
 
 The same trap applies to **every command whose exit code gates the next step**, not
-just `git push`: a verification build or test run piped through `tail`/`grep` reports
-the *pipe's* exit code. Real case: `docker build … 2>&1 | tail -2 && echo OK` printed
-`OK` for a **failed** build, and the broken branch was pushed before anyone noticed.
-Run gating commands unpiped — capture to a log file and check `$?`, then grep the log:
+just `git push`: in POSIX shells a pipeline's status is that of its **last** command
+(`tail`, `grep`) unless `set -o pipefail` is active — and even with pipefail, a
+trailing `grep` that matches nothing fails a *green* build. Real case:
+`docker build … 2>&1 | tail -2 && echo OK` printed `OK` for a **failed** build, and
+the broken branch was pushed before anyone noticed. Gate on the command's own exit
+code; keep log inspection out of the gate:
 
 ```bash
-docker build . > build.log 2>&1; RC=$?
-echo "rc=$RC"; grep -E 'error|Good signature' build.log
-[ "$RC" -eq 0 ] || exit 1
+docker build . > build.log 2>&1
+rc=$?
+tail -20 build.log            # inspection only — never part of the gate
+[ "$rc" -eq 0 ] || exit 1
 ```
 
 ### `--force-with-lease` Rejected with "stale info"
@@ -790,7 +793,8 @@ gh api graphql -f query='
 review comments (e.g., 127+ threads from automated reviewers), you MUST use pagination:
 
 ```bash
-# Fetch ALL threads with pagination (handles >100 threads)
+# Fetch ONE page of up to 100 threads; repeat with the returned endCursor
+# until hasNextPage is false to cover all threads
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -812,7 +816,7 @@ gh api graphql -f query='
     }
   }' -f owner=OWNER -f repo=REPO -F pr=NUMBER
 
-# Then fetch next page using endCursor:
+# Loop until pageInfo.hasNextPage is false, passing each endCursor:
 # -f cursor="Y3Vyc29yOnYyOpHOABCD..."
 ```
 


### PR DESCRIPTION
Three additions from a retro of the NRS-4496 session:

- **advanced-git — bare-repo worktree paths:** `git -C .bare worktree add <relative>` resolves from inside `.bare`; two worktrees landed in the wrong place in one session (`./x` inside `.bare/`, `../<project>/x` nested a level deep). Documents the `../<branch>`/absolute-path rule and the plain-clone-vs-.bare mixing check.
- **pull-request-workflow — unpiped gating commands:** generalizes the existing piped-push warning to every command whose rc gates the next step; real case: `docker build … | tail -2 && echo OK` printed OK for a failed build, and the red branch was pushed. Log-file + `$?` pattern.
- **pull-request-workflow — thread pagination (rescued commit):** an unpushed local commit from 2026-02-01 (GraphQL `reviewThreads` pagination for 100+ threads, PR #575 lesson) was stranded on a stale branch; rebased onto current main and included here.