### PR TITLE
docs: delete branch/worktree only after confirmed merge, not on watcher exit

### DIFF
--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -78,3 +78,26 @@ gh api repos/$R/commits/$SHA/status      --jq '{state, total:(.statuses|length)}
 `gh run list --json … --jq 'select(.headSha=="'$SHA'")'` is unreliable here: the list window is small and time-ordered, so a still-running `main` job scrolls out behind unrelated activity and the filter returns empty — which then feeds a `gh run view ""` (HTTP 404) and tempts a hand-rolled `sleep`-poll loop that just times out. The check-runs/status API is authoritative and SHA-addressed. For PR-head checks, `gh pr checks $PR --watch` already blocks to completion — prefer it over any custom loop.
 
 **Pre-existing red ≠ your regression.** If a post-merge gate (e.g. SonarCloud "Quality Gate failed" on N Security Hotspots) is red, check the *prior* base commit before owning it: `gh api repos/$R/commits/<prev-sha>/check-runs --jq '.check_runs[]?|select(.name=="<gate>")|.conclusion'`. Identical red on the parent + a diff that touched no relevant code = a pre-existing backlog to report, not a regression to fix.
+
+## Delete the branch/worktree only after the merge is CONFIRMED, never on watcher exit
+
+A merge-gate watcher loop can exit for reasons that are **not** "merged": the
+PR went `BLOCKED`, an auto-merge was cancelled, or the loop's own condition
+tripped on unresolved review threads. Deleting the local branch (or removing the
+worktree) the moment the watcher returns — before reading the PR's actual
+state — throws away work that is not yet on `main`.
+
+Gate the cleanup on the merge itself, not on the loop returning:
+
+```bash
+STATE=$(gh pr view $PR --repo $R --json state --jq .state)
+[ "$STATE" = "MERGED" ] || { echo "not merged ($STATE) — keep the branch"; exit 0; }
+git -C .bare worktree remove <dir>
+git -C .bare branch -D <branch>
+```
+
+If the branch was already deleted prematurely, it is usually recoverable from
+the remote (`git fetch origin` then re-add the worktree tracking
+`origin/<branch>`) — but only while the remote ref still exists (a merged PR's
+branch is often auto-deleted). The discipline is cheaper than the recovery:
+**confirm `state == MERGED` before any destructive cleanup.**


### PR DESCRIPTION
A merge-gate watcher loop can exit for reasons that are **not** 'merged' — the PR went `BLOCKED`, auto-merge was cancelled, or the loop tripped on unresolved review threads. Deleting the local branch/worktree the moment the watcher returns (before checking the PR's actual state) throws away work not yet on `main`.

Adds a short section to `merge-gate-watcher.md`: gate cleanup on `state == MERGED`, not on the loop returning; recovery from a premature delete is possible from the remote only while the ref still exists (merged PRs often auto-delete their branch).

Surfaced twice in one session (t3x-nr-llm). Content-only; no SKILL.md version bump.