### PR TITLE
chore(release): v1.18.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.18.4"
+  version: "1.18.5"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Release v1.18.5 (patch). Changes since v1.18.4:

- docs(skill): drop release-authoring scope, add triage, sync reference table
- docs(pr-workflow): remove branching-strategies textbook, keep retro rules
- docs(commit-conventions): cut generic tutorial, keep retro-born sections
- docs(ci-cd): cut generic CI templates, keep CLI-watching and mirror rules
- docs(releases): point github-releases reference at github-release skill
- docs(advanced-git): add --onto replay-tip rebase for stale branches
- docs(references): async review-bot and pre-commit recovery learnings; full-SHA review match; derived pre-commit cache dir; hardened copilot-review jq; runnable pre-commit patch recovery; worktree path resolution and unpiped gating commands
- docs: GraphQL pagination for many review threads
- docs: delete branch/worktree only after confirmed merge, not on watcher exit
- docs: fix dangling and stale references after textbook-layer removal