### PR TITLE
docs: verify a dropped merge-queue entry via the issue timeline before re-arming

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -915,8 +915,8 @@ that stale read wastes a round-trip. The issue **timeline** is authoritative:
 
 ```bash
 gh api repos/{owner}/{repo}/issues/NUMBER/timeline --paginate \
-  --jq '[.[] | select(.event=="added_to_merge_queue" or .event=="removed_from_merge_queue"
-                    or .event=="merged" or .event=="closed") | "\(.created_at) \(.event)"][]'
+  --jq '.[]? | select(.event | IN("added_to_merge_queue", "removed_from_merge_queue",
+                                  "merged", "closed")) | "\(.created_at) \(.event)"'
 # removed_from_merge_queue immediately followed by merged  -> it landed; do nothing.
 # removed_from_merge_queue with NO merged event            -> real silent drop; re-arm.
 ```

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -907,6 +907,24 @@ gh api graphql -F id="$PRID" \
 # Branch is pushable again; fix threads, then re-arm through this gate.
 ```
 
+**Verify a "dropped" queue entry via the issue timeline before re-arming.**
+Right after a queue merge, `gh pr view --json state` can report `OPEN` and the
+queue listing can show the entry gone for several minutes — the exact signature
+of a silent drop, except the PR already merged. Re-arming (or re-diagnosing) on
+that stale read wastes a round-trip. The issue **timeline** is authoritative:
+
+```bash
+gh api repos/{owner}/{repo}/issues/NUMBER/timeline --paginate \
+  --jq '[.[] | select(.event=="added_to_merge_queue" or .event=="removed_from_merge_queue"
+                    or .event=="merged" or .event=="closed") | "\(.created_at) \(.event)"][]'
+# removed_from_merge_queue immediately followed by merged  -> it landed; do nothing.
+# removed_from_merge_queue with NO merged event            -> real silent drop; re-arm.
+```
+
+Also note: queue membership is GraphQL-only — `isInMergeQueue` /
+`mergeQueueEntry` are **not** `gh pr view --json` fields (the call errors);
+query `pullRequest { mergeQueueEntry { state position } }` via `gh api graphql`.
+
 ### Signing Readiness (Preflight — Before Committing)
 
 A signing failure surfaces only at the *merge gate* (BLOCKED on DCO / "verified signatures") — i.e. **after** all the work is staged, forcing a full re-sign cycle. Catch it up front: before a commit-heavy run (e.g. `/pr-finish`), confirm a signing key is actually available and that `git commit -S` will sign, rather than assuming it.


### PR DESCRIPTION
## What

Adds a paragraph + recipe to the *Recovery when armed too early* section of `references/pull-request-workflow.md`: right after a queue merge, `gh pr view --json state` can report `OPEN` and the queue listing can show the entry gone for several minutes — indistinguishable from the documented silent-drop failure mode, except the PR already merged. The issue timeline (`removed_from_merge_queue` followed by `merged`) is the authoritative discriminator. Also notes `isInMergeQueue`/`mergeQueueEntry` are GraphQL-only, not `gh pr view --json` fields.

## Why

Live case (netresearch/t3x-nr-llm PR #403, 2026-07-16): the stale read showed OPEN + empty queue while the timeline showed the merge had completed a minute earlier — the current guidance would have re-armed an already-merged PR.