### PR TITLE
docs: flake-vs-regression triage + git show cross-branch reads

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -843,6 +843,28 @@ Use `--diff-filter=ACMR` (not just `AM`) so renames and copies into a guarded
 path are caught. Verify pathspec support empirically before swapping one
 command for the other — the failure mode is silent, not loud.
 
+## Reading a File As It Is Committed on Another Branch
+
+To see what a file *actually contains on another branch or ref* — without
+switching to it — read it from the object store:
+
+```bash
+git show <branch>:<path>          # e.g. git show origin/main:src/App.tsx
+git show <tag>:<path>
+git show <sha>:<path>
+```
+
+Use this instead of trusting the working-tree copy right after a `git checkout`.
+A branch switch swaps every file on disk, so the on-disk copy (and any editor or
+harness "file was modified" notice fired by the switch) reflects the branch you
+landed on, not the one you were reasoning about — chasing that phantom "edit" is
+a real time sink. `git show <branch>:<path>` answers "what's committed there?"
+authoritatively; reserve the working tree for "what's staged/unsaved here now?".
+
+For a whole-tree comparison across branches without checkout, use
+`git diff <branchA> <branchB> -- <path>` (or `git diff <branchA>...<branchB>` for
+the merge-base–relative diff).
+
 ## Troubleshooting
 
 ### Common Issues

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -861,9 +861,9 @@ landed on, not the one you were reasoning about — chasing that phantom "edit" 
 a real time sink. `git show <branch>:<path>` answers "what's committed there?"
 authoritatively; reserve the working tree for "what's staged/unsaved here now?".
 
-For a whole-tree comparison across branches without checkout, use
-`git diff <branchA> <branchB> -- <path>` (or `git diff <branchA>...<branchB>` for
-the merge-base–relative diff).
+To compare a file across branches without checkout, use
+`git diff <branchA> <branchB> -- <path>` (or `git diff <branchA>...<branchB> -- <path>`
+for the merge-base–relative diff).
 
 ## Troubleshooting
 

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -12,6 +12,15 @@ Classify every failing check BEFORE reacting:
 | **Soft, self-healing** | `codecov/*` while sibling jobs still run (partial uploads) | Ignore while `pending > 0`; if persisting after completion: one full `gh run rerun <id>` |
 | **Soft, structural** | SonarCloud PR gate on refactor PRs | Introspect before deciding (below) |
 
+## One shard red in a sharded suite: flake vs. real regression
+
+When one of N test shards fails, read its **first** error before you reach for a rerun — whether the Hard-class failure above is a flake or a real bug turns on it:
+
+- **Infra flake** — the first error is a stack-boot / health-check line (`App failed to start within timeout`, DB-not-ready, a 5xx from the app root). Every assertion failure below it is collateral: there was no app to talk to. Only that one shard is red; the siblings pass. Reaction: one `gh run rerun <id> --failed` (a rebase + push also re-triggers a clean run).
+- **Real regression** — the *same* spec(s) fail **across all shards deterministically**, and the first error is an assertion (or an actionability timeout), not a boot line. A regression in shared code does not politely confine itself to one shard.
+
+Playwright tell: `locator.check` / `locator.click: Test timeout` is an **actionability** failure — the element never became visible / stable / hit-testable — usually a CSS or DOM change that broke a hit target. Treat it as a real regression to investigate even when it surfaces on a single shard, not as a flake to rerun. (Seen: a `.field-check-row` restyle moved a label out of the node a spec located by, so `getByText`-anchored `.check()` hung 30s — red on shard 1 only, looked exactly like a boot flake, was a real DOM regression.)
+
 ## Sonar gate introspection
 
 Never merge on a red Sonar gate without knowing *why* it is red:

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -17,7 +17,7 @@ Classify every failing check BEFORE reacting:
 When one of N test shards fails, read its **first** error before you reach for a rerun — whether the Hard-class failure above is a flake or a real bug turns on it:
 
 - **Infra flake** — the first error is a stack-boot / health-check line (`App failed to start within timeout`, DB-not-ready, a 5xx from the app root). Every assertion failure below it is collateral: there was no app to talk to. Only that one shard is red; the siblings pass. Reaction: one `gh run rerun <id> --failed` (a rebase + push also re-triggers a clean run).
-- **Real regression** — the *same* spec(s) fail **across all shards deterministically**, and the first error is an assertion (or an actionability timeout), not a boot line. A regression in shared code does not politely confine itself to one shard.
+- **Real regression** — *typically* the same spec(s) fail **across all shards deterministically**, and the first error is an assertion (or an actionability timeout), not a boot line. A regression in shared code does not politely confine itself to one shard. (The Playwright case below is the exception — a real regression that can surface on a single shard.)
 
 Playwright tell: `locator.check` / `locator.click: Test timeout` is an **actionability** failure — the element never became visible / stable / hit-testable — usually a CSS or DOM change that broke a hit target. Treat it as a real regression to investigate even when it surfaces on a single shard, not as a flake to rerun. (Seen: a `.field-check-row` restyle moved a label out of the node a spec located by, so `getByText`-anchored `.check()` hung 30s — red on shard 1 only, looked exactly like a boot flake, was a real DOM regression.)
 


### PR DESCRIPTION
## Summary

Two reference additions from a `/retro` session: how to tell a one-shard-red CI failure apart (flake vs. real regression), and reading a file as committed on another branch without checkout.

## Came from

`/retro` session on 2026-07-16 (timetracker release/deploy work).

- **Symptom:** A red `E2E (1/4)` was dismissed as a boot-flake twice; the second run was a real regression a `.field-check-row` restyle had introduced (a spec's `getByText`-anchored `.check()` hung 30s). Separately, a phantom "file was modified" reminder after a branch switch nearly sent me chasing a non-edit.
- **Cause:** No documented heuristic for flake-vs-regression on sharded suites; and trusting the working-tree copy right after `git checkout` instead of the object store.
- **Required behavior:** Read the shard's *first* error (boot line = collateral flake; same specs across all shards = real bug; `locator.check` timeout = actionability regression). Use `git show <branch>:<path>` to read committed state across branches.

## Change

- `merge-gate-watcher.md`: new "One shard red: flake vs. real regression" section.
- `advanced-git.md`: new "Reading a File As It Is Committed on Another Branch" section.

## Test plan

- [x] `Build/Scripts/validate-skill.sh` — 0 errors, 0 warnings
- [x] Commands verified (`git show <ref>:<path>`, `git diff A B -- path`, `gh run rerun <id> --failed`)
- [x] Both commits signed + DCO signed-off
