### PR TITLE
docs(hooks): warn that pre-commit autoupdate pins pre-releases

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -28,6 +28,15 @@ Then install based on what's found:
 - `.pre-commit-config.yaml` → `pre-commit install`
 - Nothing → suggest adding one based on project language
 
+## Updating Hook Versions (`pre-commit autoupdate`)
+
+`pre-commit autoupdate` bumps every hook's `rev` to the repo's **latest tag —
+including pre-releases**. It happily pins a beta (observed: isort
+`8.0.1 → 9.0.0b1`). After running it, review each bumped `rev` and pin any
+`aN`/`bN`/`rcN` back to the latest stable tag before committing. When a hook
+mirrors a locked dev dependency (black, isort), keep the hook `rev` aligned
+with the lockfile version instead of blindly taking the newest tag.
+
 ## Recommended Hooks by Stage
 
 ### pre-commit (fast, <5s)


### PR DESCRIPTION
## Summary

`pre-commit autoupdate` takes the latest tag including pre-releases — in a real run it bumped isort `8.0.1 → 9.0.0b1`. Adds a short section to `references/git-hooks-setup.md`: review bumped `rev`s for `aN`/`bN`/`rcN` and pin back to stable; keep hook revs aligned with locked dev-dependency versions.

Came from /retro: yes