### PR TITLE
chore(release): v1.18.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.18.6"
+  version: "1.18.7"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Prepare release v1.18.7 (patch: docs since v1.18.6). Version bump only: plugin.json + SKILL.md (2 files).