### PR TITLE
docs(pr-workflow): add the GitLab merge-request equivalent of the merge gate

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1344,8 +1344,9 @@ glab api "projects/$P/merge_requests/$M/discussions" \
   --jq '[.[] | select(.individual_note|not)
          | {id, resolved: .notes[0].resolved, author: .notes[0].author.username}]'
 
-# (4) what protects the target branch (GitLab's answer to rulesets)
-glab api "projects/$P/protected_branches/main"
+# (4) what protects the target branch (GitLab's answer to rulesets).
+#     Use the target_branch from (1) — it is not always the default branch.
+glab api "projects/$P/protected_branches/<target-branch>"
 
 # (5) pipeline on the MR head SHA
 glab ci status --branch <source-branch>
@@ -1409,8 +1410,8 @@ procedure calls for a rebase, drive it locally and fetch the base explicitly
 then fails with "stale info"):
 
 ```bash
-git fetch origin main:refs/remotes/origin/main
-git rebase origin/main
+git fetch origin <target-branch>:refs/remotes/origin/<target-branch>
+git rebase origin/<target-branch>
 git push --force-with-lease origin <source-branch>
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1312,6 +1312,111 @@ git push origin main
 echo "PR #$PR_NUMBER merged via fast-forward"
 ```
 
+## GitLab: the same gate with `glab` (merge requests)
+
+Everything above assumes GitHub. GitLab has the same concepts under different
+field names, a different CLI and a different thread model — translate it, don't
+improvise mid-run. Export `GITLAB_HOST` (or pass `--hostname`) for self-managed
+instances.
+
+### One-block preflight
+
+The GitLab analogue of the `gh pr view` + rulesets + `reviewThreads` block.
+Run it once, up front, and re-run only after a state-changing push:
+
+```bash
+export GITLAB_HOST=git.example.com
+P=<group>%2F<project>          # URL-encoded path, or the numeric project id
+M=<mr_iid>
+
+# (1) MR state and WHY it is blocked. detailed_merge_status names the blocker;
+#     merge_status alone does not.
+glab api "projects/$P/merge_requests/$M" \
+  --jq '{state,draft,merge_status,detailed_merge_status,has_conflicts,
+         blocking_discussions_resolved,user_notes_count,sha,target_branch,title}'
+
+# (2) approval rule and who approved (approvals_required null = no rule)
+glab api "projects/$P/merge_requests/$M/approvals" \
+  --jq '{approvals_required,approved_by:[.approved_by[].user.username]}'
+
+# (3) threads. individual_note==true is a plain comment, not a thread.
+glab api "projects/$P/merge_requests/$M/discussions" \
+  --jq '[.[] | select(.individual_note|not)
+         | {id, resolved: .notes[0].resolved, author: .notes[0].author.username}]'
+
+# (4) what protects the target branch (GitLab's answer to rulesets)
+glab api "projects/$P/protected_branches/main"
+
+# (5) pipeline on the MR head SHA
+glab ci status --branch <source-branch>
+
+# (6) how this project merges — so you do not squash by accident
+glab api "projects/$P" --jq '{merge_method,squash_option,
+  only_allow_merge_if_pipeline_succeeds,remove_source_branch_after_merge}'
+```
+
+### Field mapping
+
+| GitHub | GitLab |
+|---|---|
+| `mergeStateStatus` (`BLOCKED` / `CLEAN`) | `detailed_merge_status` (`draft_status`, `not_approved`, `discussions_not_resolved`, `ci_must_pass`, `mergeable`, …) |
+| `mergeable` | `merge_status` + `has_conflicts` |
+| `reviewDecision` | `approvals_required` + `approved_by` (`/approvals`) |
+| GraphQL `reviewThreads[].isResolved` | `/discussions` → `notes[0].resolved`; aggregate flag `blocking_discussions_resolved` |
+| `resolveReviewThread` mutation | `PUT /merge_requests/:iid/discussions/:id?resolved=true` |
+| Rulesets (`/rules/branches/main`) | `/protected_branches/:name` + approval rules |
+| `statusCheckRollup` | `glab ci status` / `/pipelines` |
+| Draft PR | `draft: true` → `glab mr update <iid> --ready` |
+
+`detailed_merge_status: draft_status` means the **only** blocker is the draft
+flag. That is the most common "the MR refuses to merge and nothing looks wrong"
+case — check it before hunting for approvals or failing jobs.
+
+### Replying to and resolving a thread
+
+Reply *into* the thread, never as a new top-level comment, then resolve and
+verify — the same discipline as the GitHub GraphQL flow:
+
+```bash
+glab api -X POST "projects/$P/merge_requests/$M/discussions/<discussion_id>/notes" \
+  -f body="Fixed in <sha>. <what changed and why>"
+
+glab api -X PUT "projects/$P/merge_requests/$M/discussions/<discussion_id>?resolved=true"
+
+# verify — the aggregate flag must be true before merging
+glab api "projects/$P/merge_requests/$M" --jq .blocking_discussions_resolved
+```
+
+### Merge
+
+```bash
+# Check merge_method FIRST (preflight 6): "merge" -> merge commit,
+# "ff" -> fast-forward only, "rebase_merge" -> semi-linear.
+# Never pass --squash unless the user asked for it.
+glab mr merge "$M" --remove-source-branch --yes
+```
+
+`glab mr merge` waits for the pipeline and refuses while it is still running, so
+a green pipeline is a precondition of the command rather than something to
+re-check afterwards.
+
+### Rebase when the MR is behind
+
+GitLab will happily report `mergeable` while the branch is behind the target —
+being behind is not a blocker there, unlike a GitHub merge queue. If the
+procedure calls for a rebase, drive it locally and fetch the base explicitly
+(bare-repo worktrees often lack `remote.origin.fetch`, and `--force-with-lease`
+then fails with "stale info"):
+
+```bash
+git fetch origin main:refs/remotes/origin/main
+git rebase origin/main
+git push --force-with-lease origin <source-branch>
+```
+
+Re-run the preflight afterwards: the rebase produces a new head SHA, so the
+pipeline result you looked at no longer applies.
+
 ## Full PR Lifecycle Checklist
 
 Complete end-to-end workflow for merging a PR, from CI verification through post-merge cleanup.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1322,7 +1322,9 @@ instances.
 ### One-block preflight
 
 The GitLab analogue of the `gh pr view` + rulesets + `reviewThreads` block.
-Run it once, up front, and re-run only after a state-changing push:
+Run it once, up front, and re-run only after a state-changing push. Note that
+`glab api` has no `--jq` flag (verified on glab 1.95.0) — unlike `gh api`, pipe
+its output to `jq`:
 
 ```bash
 export GITLAB_HOST=git.example.com
@@ -1332,16 +1334,16 @@ M=<mr_iid>
 # (1) MR state and WHY it is blocked. detailed_merge_status names the blocker;
 #     merge_status alone does not.
 glab api "projects/$P/merge_requests/$M" \
-  --jq '{state,draft,merge_status,detailed_merge_status,has_conflicts,
+  | jq '{state,draft,merge_status,detailed_merge_status,has_conflicts,
          blocking_discussions_resolved,user_notes_count,sha,target_branch,title}'
 
 # (2) approval rule and who approved (approvals_required null = no rule)
 glab api "projects/$P/merge_requests/$M/approvals" \
-  --jq '{approvals_required,approved_by:[.approved_by[].user.username]}'
+  | jq '{approvals_required,approved_by:[.approved_by[].user.username]}'
 
 # (3) threads. individual_note==true is a plain comment, not a thread.
 glab api "projects/$P/merge_requests/$M/discussions" \
-  --jq '[.[] | select(.individual_note|not)
+  | jq '[.[] | select(.individual_note|not)
          | {id, resolved: .notes[0].resolved, author: .notes[0].author.username}]'
 
 # (4) what protects the target branch (GitLab's answer to rulesets).
@@ -1352,7 +1354,7 @@ glab api "projects/$P/protected_branches/<target-branch>"
 glab ci status --branch <source-branch>
 
 # (6) how this project merges — so you do not squash by accident
-glab api "projects/$P" --jq '{merge_method,squash_option,
+glab api "projects/$P" | jq '{merge_method,squash_option,
   only_allow_merge_if_pipeline_succeeds,remove_source_branch_after_merge}'
 ```
 
@@ -1385,7 +1387,7 @@ glab api -X POST "projects/$P/merge_requests/$M/discussions/<discussion_id>/note
 glab api -X PUT "projects/$P/merge_requests/$M/discussions/<discussion_id>?resolved=true"
 
 # verify — the aggregate flag must be true before merging
-glab api "projects/$P/merge_requests/$M" --jq .blocking_discussions_resolved
+glab api "projects/$P/merge_requests/$M" | jq .blocking_discussions_resolved
 ```
 
 ### Merge


### PR DESCRIPTION
`references/pull-request-workflow.md` assumed GitHub throughout. Driving a GitLab MR to merge therefore meant translating every preflight command to `glab` semantics by hand — twice in one session, against a self-managed instance. This adds the GitLab counterpart so the procedure is usable as written.

## What is added

- **One-block preflight** — the GitLab analogue of the `gh pr view` + rulesets + `reviewThreads` block: `detailed_merge_status`, `/approvals`, `/discussions`, `/protected_branches`, `glab ci status`, and the project's `merge_method`.
- **Field mapping table** — `mergeStateStatus`→`detailed_merge_status`, `reviewDecision`→`approvals_required`/`approved_by`, GraphQL `reviewThreads`→`/discussions` + `blocking_discussions_resolved`, rulesets→`/protected_branches`, `statusCheckRollup`→`glab ci status`, draft→`glab mr update --ready`.
- **Reply-into-thread + resolve + verify** — same discipline as the GitHub GraphQL flow, never a new top-level comment.
- **Merge** — with the `merge_method` check first, so squash is not selected by accident.
- **Rebase path** — with an explicit base fetch, because bare-repo worktrees frequently lack `remote.origin.fetch` and `--force-with-lease` then fails with "stale info".

## Two traps that cost real time

- `detailed_merge_status: draft_status` means the **draft flag is the only blocker** — the classic "the MR refuses to merge and nothing looks wrong" case, worth checking before hunting approvals or failing jobs.
- GitLab reports `mergeable` **while the branch is behind the target**; unlike a GitHub merge queue, being behind is not surfaced as a blocker and has to be checked separately.

## Notes

`SKILL.md` is deliberately untouched — it sits at exactly the 500-word cap that `validate` enforces, and its existing reference row ("PR merge, merge gate") already routes here.

`scripts/verify-harness.sh`: Level 3 COMPLETE, 0 errors, 0 warnings. Docs-only, no behaviour change.