### PR TITLE
docs: bot-review failure notices, formatter-hook commit bounce, cross-PR branch detours

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -198,6 +198,40 @@ git apply "$PATCH"
 
 Then re-run the commit (the hook envs are now built, so it is fast).
 
+### Formatter hooks rewrite files — the first commit always bounces
+
+A hook that *reformats* rather than merely reports (`black`, `isort`,
+`ruff format`, `prettier`, `shfmt`, `end-of-file-fixer`) rewrites the staged
+file and then **fails the commit**, because what it wrote is not what you
+staged:
+
+```
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook
+reformatted tests/test_completion.py
+```
+
+The commit did **not** happen. The fix is `git add` the now-reformatted files
+and commit again — the second run passes because the file is already formatted.
+Budget two `commit` invocations, and never `--amend` here (see
+"Never amend a commit with pre-commit-hook failures" in
+`commit-conventions.md`): the first commit does not exist, so `--amend` would
+rewrite the *previous* one.
+
+To avoid the bounce entirely, run the formatter before committing — matching
+whatever the repo actually uses, which is not always the one you expect:
+
+```bash
+# read the hook ids the repo declares, then run those
+yq '.repos[].hooks[].id' .pre-commit-config.yaml
+pre-commit run black isort --files <changed files>   # or: ruff format . && ruff check .
+```
+
+Checking the config matters: a project can use `black`+`isort` where you assumed
+`ruff format`, and a habit built around only one of them still bounces on every
+commit in the other.
+
 ### `--no-verify` only after confirming CI parity
 
 A local hook the CI pipeline does **not** run is not a real merge gate (see

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -72,6 +72,15 @@ Pitfalls baked in: `grep -c` exits 1 on zero matches (`|| true`); decide hard-fa
 
 **Review bots converge over multiple rounds.** Every push invalidates the review (ruleset `copilot_code_review` needs a fresh review on the latest head), so re-request after each push: `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Later rounds may flag UNCHANGED lines adjacent to the diff (latent legacy bugs) — triage each finding on its merits; expect 3–6 rounds on large refactor PRs, with finding severity decreasing per round. Re-arm the watcher after every push.
 
+**A bot review can be a failure notice, not a review — read the body, not the state.** `copilot-pull-request-reviewer` posts its quota and capacity failures as an ordinary `COMMENTED` review whose body is `Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.` Every state-based check reads that as a satisfied gate: `reviews` is non-empty, `reviewThreads` is `0`, inline `comments` is `0`, and `mergeStateStatus` is `CLEAN` — indistinguishable from a clean review that found nothing. Before treating a bot review as landed, read the body:
+
+```bash
+gh pr view $PR --repo $R --json reviews \
+  --jq '.reviews[] | select(.author.login|test("copilot")) | .body'
+```
+
+Treat `unable to review` as **no review** and re-request; if the re-request returns the same notice the quota is still exhausted, and merging means merging unreviewed. Check the repo's recent merged PRs the same way before concluding that a bot review is the local norm — a quota outage can span every PR in a window, so "the last three merged PRs also show COMMENTED" is not evidence they were reviewed.
+
 **On a docs/prose PR the loop does not decay — it must be actively terminated.** The bot re-reads the whole changed file each round and keeps surfacing a *new cosmetic* nit (wording, an illustrative example value, a spelling), so pushing a fix just triggers another round almost indefinitely. To converge: once a finding is purely cosmetic and defensible, **reply on the thread and resolve it *without* a new commit** — no push means no re-review means no new nit. Reserve fresh pushes for substantive findings; batch several real fixes into one push rather than one-per-thread.
 
 ## Auto-merge armed + CLEAN but never enqueued: disable/re-enable to nudge

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -18,6 +18,32 @@ gh repo view OWNER/REPO --json defaultBranchRef --jq '.defaultBranchRef.name'
 Assuming the wrong name silently pushes to (or creates) the wrong branch, or
 targets a PR at a branch that isn't the integration branch.
 
+## After a Detour to Another PR, Switch Back — and Verify
+
+Working two PRs at once, a fix for PR B often means checking out B's branch
+mid-task. Nothing switches you back afterwards, and the next edits land on B
+while you believe you are on A. Because `git status` looks normal — modified
+tracked files, no conflict — the mistake surfaces only later, e.g. when a value
+you "already added" reads back as absent.
+
+Re-assert the branch before resuming edits, and again before staging:
+
+```bash
+git branch --show-current    # cheap; run it after ANY cross-PR detour
+```
+
+If edits did land on the wrong branch, move them rather than redoing them:
+
+```bash
+git stash push -m "misplaced work" -- <paths>   # path-scoped: leaves the branch's own work alone
+git checkout <intended-branch>
+git stash pop
+```
+
+Prefer a separate worktree per PR (`references/advanced-git.md`) when the two
+are worked in parallel — then no checkout is shared and the detour cannot
+misplace anything.
+
 ## Prefer the `gh` CLI / GitHub MCP Over Raw API or Web UI
 
 For GitHub operations (PRs, issues, reviews, releases), reach for `gh` or the


### PR DESCRIPTION
Three guidance gaps surfaced while driving two feature PRs to merge in one session.

## 1. A bot review can be a failure notice, not a review (`merge-gate-watcher.md`)

`copilot-pull-request-reviewer` posts quota failures as an ordinary `COMMENTED`
review whose body is *"Copilot was unable to review this pull request because the
user who requested the review has reached their quota limit."*

Every state-based gate check reads that as satisfied — `reviews` non-empty,
`reviewThreads` 0, inline `comments` 0, `mergeStateStatus` CLEAN — indistinguishable
from a clean review that found nothing. The skill already covers re-requesting after
each push, but not verifying the review *landed*.

Also warns against inferring local norm from prior merged PRs: a quota outage spans
every PR in a window, so "the last three merged PRs also show COMMENTED" is not
evidence they were reviewed.

## 2. Formatter hooks bounce the first commit (`git-hooks-setup.md`)

A reformatting hook (`black`, `isort`, `ruff format`, `prettier`, `shfmt`) rewrites
the staged file and then fails the commit — the commit never lands and the files must
be re-added and committed again. This happened on four consecutive commits in one
session. Existing guidance covers hook-env build time and `--no-verify` CI parity, but
not this. Also points at reading the repo's declared hook ids first: a habit built
around `ruff format` still bounces on every commit in a `black`/`isort` project.

## 3. Re-assert the branch after a detour to another PR (`pull-request-workflow.md`)

Fixing a second PR mid-task means checking out its branch; nothing switches back, so
later edits land on the wrong branch while `git status` looks completely normal. In
the session this misplaced 39 file edits, found only when a value that had just been
written read back as absent. Documents `git branch --show-current` after any cross-PR
detour, path-scoped `git stash push -- <paths>` to move the work rather than redo it,
and preferring one worktree per PR.

Came from /retro: yes
