### PR TITLE
docs: GitHub-rendered prose wrapping + cross-worktree static analysis

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -522,6 +522,24 @@ After any merge, verify structural invariants on the **merged base** (e.g. that
 every cross-reference still resolves), not just on the branch — that is the only
 check that catches a regression introduced by the merge itself.
 
+### Cross-Worktree Static Analysis Gives False Positives
+
+Running a static analyzer (Rector, php-cs-fixer, PHPStan, ESLint) from ONE
+worktree against source files in ANOTHER resolves symbols through the *running*
+worktree's autoloader/vendor, not the branch under test. When the other branch
+changed a method signature, added an interface method, or renamed a symbol, the
+analyzer sees a mismatch that does not exist on that branch — e.g. Rector's
+`RemoveExtraParametersRector` "removing" arguments that match the branch's own
+wider signature, or a type-resolution rule firing (or staying silent) because a
+new interface method is absent from — or present only in — the running worktree.
+
+This bites hardest in bare+worktree layouts where only one worktree has a built
+`.Build/vendor` (or `node_modules`), so cross-worktree runs are the only local
+option. Treat each such finding as suspect: real, or an artifact of resolving
+against the wrong tree? CI runs each branch in isolation with its own install,
+so **CI is authoritative** — reproduce a doubtful finding by building deps inside
+the target worktree, or defer to CI, rather than "fixing" a phantom.
+
 ### Use Cases
 
 ```bash

--- a/skills/git-workflow/references/no-editorializing.md
+++ b/skills/git-workflow/references/no-editorializing.md
@@ -39,3 +39,22 @@ Two recurring failure modes:
 Use plain labels, not graded ones: "Breaking change", "Tests", "Limitations" —
 not "Tests (all green)" or "Breaking change (honest)". If a limitation's cause
 matters, it is already stated in the item.
+
+## Line wrapping — GitHub comment surfaces vs `.md` files
+
+Separate from tone: the artifacts above render through two different Markdown
+pipelines, and hard-wrapping prose is right in one and wrong in the other.
+
+- **`.md` files** (README, CHANGELOG, docs) render as CommonMark: a single
+  newline inside a paragraph collapses to a **space**, so hard-wrapping the
+  source at ~80 columns reflows invisibly on render. Match the file's existing
+  wrap.
+- **GitHub comment surfaces** — PR/MR descriptions, review comments, issue/ticket
+  bodies, and **release notes** — render with `breaks: true`: every single
+  newline becomes a `<br>`. Hard-wrapping there carries the breaks into the
+  rendered page as ragged mid-sentence line breaks. Write each paragraph and list
+  item as ONE long line; use blank lines only for real paragraph/item boundaries.
+
+Do not wrap a release body or PR/comment the way you wrap a `.md` file. Fix one
+already published with hard-wraps via `gh release edit <tag> --notes-file <file>`
+(release bodies stay editable) or by editing the PR/comment.


### PR DESCRIPTION
Two reference notes distilled from a session retrospective (t3x-nr-vault security-fix sweep + release).

**`no-editorializing.md`** — a formatting note (separate from tone): GitHub comment surfaces (PR/MR descriptions, review comments, issue bodies, release notes) render with `breaks: true` so a single newline becomes `<br>`, whereas `.md` files render as CommonMark where soft newlines collapse. Hard-wrapping a release/PR body the way you wrap a `.md` file shows ragged mid-sentence breaks on the rendered page.

**`advanced-git.md`** — running a static analyzer from one worktree against files in another resolves symbols via the running worktree's autoloader, not the branch under test, producing phantom findings (e.g. Rector `RemoveExtraParametersRector`) that don't reproduce in branch-isolated CI.

markdownlint-cli2: 0 issues.