### PR TITLE
style: satisfy latest ruff

### DIFF
--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -4,9 +4,9 @@ PreToolUse hook to validate git commands for best practices.
 Checks conventional commits, branch naming, and common mistakes.
 """
 
-import sys
-import re
 import json
+import re
+import sys
 
 # Conventional commit pattern
 CONVENTIONAL_COMMIT_PATTERN = (
@@ -139,7 +139,7 @@ def check_command(command: str) -> list[dict]:
 def main():
     try:
         input_data = sys.stdin.read()
-    except Exception:
+    except Exception:  # noqa: BLE001 - git hook entry point: any stdin read failure is a no-op
         return
 
     if not input_data:


### PR DESCRIPTION
The Lint workflow went red on main after a ruff release tightened its default rule set (the run was green on 2026-07-21, red on the next main push). These are the findings the newer ruff reports, fixed at the source:

- `I001` — top-level imports sorted (ruff `--fix`)
- `BLE001` — the `except Exception` around `sys.stdin.read()` is an intentional catch-all for a git-hook entry point, annotated with a justified `# noqa` rather than narrowed to a guessed exception set

Verified locally with the exact CI invocation: `ruff check .` → All checks passed; `ruff format --check .` clean.

Note: the root cause is that the shared `skill-repo-skill/validate.yml` runs `uvx ruff` unpinned, so ruff's rolling defaults can turn any skill repo's main red on the next push. Worth pinning ruff there fleet-wide — filed separately.