### PR TITLE
docs: bot-PR rule needs a deps-workflow check; separate env gaps from hook failures

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -152,6 +152,39 @@ against the repo root, before inspecting it.
   make the bypass the default; fix the hook environment or commit from the
   primary checkout when possible.
 
+### Distinguish "the hook is broken" from "the check failed"
+
+The bypass above is for a hook that cannot *run*. A hook that ran fine and
+reported a genuine failure is a different situation with the same exit code, and
+conflating them turns the sanctioned bypass into a habit.
+
+Third case, easy to misread as either: the hook ran, the check ran, and the
+check failed for a reason that lives in the **environment**, not the change.
+Tells:
+
+- `Doctrine\DBAL\Exception\DriverException: could not find driver` — the host
+  has no `pdo_mysql`; the container does.
+- `Container /path/var/cache/dev/App_KernelDevDebugContainer.xml does not exist`
+  — `phpstan-symfony` needs a warmed container: `php bin/console cache:warmup`
+  before the analysis, not a baseline entry.
+- A failure count that does not move when you revert your change.
+
+The fix is the **venue**, not the flag. Run the identical gate where the
+environment is complete — usually the project's own compose service:
+
+```bash
+docker compose run --rm app-e2e php -d memory_limit=1G bin/phpunit --testsuite unit --no-coverage
+```
+
+Only after that passes does the shim bypass apply, and say in the commit or the
+PR which gate ran where. Reaching for `--no-verify` on this class hides a
+result you could have had.
+
+Watch for a cold-start race when you script this: a suite started immediately
+after `docker compose up -d` can fail one or two DB-dependent tests while the
+database is still accepting connections. Re-run once against the warm stack
+before believing the failure.
+
 ### Fresh worktree: missing deps and stale `hooksPath`
 
 A freshly-created worktree often breaks pre-commit/pre-push hooks — and can even

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -968,6 +968,31 @@ gh api repos/{owner}/{repo}/issues/NUMBER/timeline --paginate \
 # removed_from_merge_queue with NO merged event            -> real silent drop; re-arm.
 ```
 
+### "Never merge Dependabot/Renovate by hand" presumes a deps workflow exists
+
+Leaving bot PRs alone is right *because* an auto-merge workflow lands them once
+they are green. Where no such workflow is installed, the rule has no mechanism
+behind it and simply strands the PRs. One repo in a sweep carried **12 open bot
+PRs** — including a `tar` security update sitting `CLEAN` and untouched for five
+weeks — because its `.github/workflows/` held only `ci.yml` and a publish
+workflow.
+
+Check for the mechanism before deferring to it:
+
+```bash
+gh api "repos/$R/contents/.github/workflows" --jq '.[].name'
+```
+
+- **A deps auto-merge workflow exists** → the rule applies. Do not merge by
+  hand; bring the PR green and let the workflow land it. If it is green and
+  still open, the workflow ran before the checks passed — re-run it rather than
+  merging (`gh run rerun <id>` on that workflow's run for the PR's head SHA).
+- **No such workflow** → the rule does not apply. Merging bot PRs by hand is not
+  forbidden, it is simply unautomated: report the stranded PRs and the missing
+  automation instead of leaving them to rot. Flag security updates and majors
+  separately — a `tar` advisory fix and a `jest` v30 major do not carry the same
+  risk and should not be swept together.
+
 Also note: queue membership is GraphQL-only — `isInMergeQueue` /
 `mergeQueueEntry` are **not** `gh pr view --json` fields (the call errors);
 query `pullRequest { mergeQueueEntry { state position } }` via `gh api graphql`.


### PR DESCRIPTION
From a `/retro` sweep of a dependency-maintenance session. Two findings, two commits.

## `pull-request-workflow.md` — the bot-PR hands-off rule presumes a deps workflow

"Never merge Dependabot/Renovate by hand" is correct *because* an auto-merge workflow lands them once green. Where no such workflow is installed, the rule has no mechanism behind it and simply strands the PRs.

One repo in this sweep carried **12 open bot PRs** — including a `tar` security update sitting `CLEAN` and untouched for five weeks — because its `.github/workflows/` held only `ci.yml` and a publish workflow. The rule was followed correctly and the outcome was worse than ignoring it.

Added after the *Auto-Merge / Merge-Queue Arming Gate* section: check for the mechanism first, then branch. Where the workflow exists and the PR is green but still open, it ran before the checks passed — re-run it rather than merging. Where it does not exist, report the stranded PRs and the missing automation, keeping security updates and majors apart rather than sweeping them together.

## `git-hooks-setup.md` — a third failure class

The existing *controlled bypass* guidance covers a hook that cannot **run** (missing shim in a worktree), including the `--no-verify` blind spot on `prepare-commit-msg` and the `core.hooksPath` remedy. That part needed nothing.

What was missing is the case that reads as either: the hook ran, the check ran, and the check failed for a reason living in the **environment** rather than the change. In this session the host lacked `pdo_mysql`, so two DB-dependent tests failed and blocked the commit; the same suite in the project's compose service reported 1938 tests / 4501 assertions OK.

Adds the tells — `could not find driver`, `phpstan-symfony` wanting a warmed container (`bin/console cache:warmup`, not a baseline entry), a failure count that does not move when the change is reverted — and states the fix is the venue, not the flag. Also notes the cold-start race: a suite started immediately after `docker compose up -d` can fail a DB-dependent test while the database is still coming up, so re-run once against the warm stack before believing it.

## Verification

`scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors, 0 warnings.
