### PR TITLE
docs(pull-request-workflow): glab mr merge is asynchronous — verify before tagging

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1454,6 +1454,24 @@ glab mr merge "$M" --remove-source-branch --yes
 a green pipeline is a precondition of the command rather than something to
 re-check afterwards.
 
+**The merge itself is asynchronous** — the command returns before the target
+branch has moved. A `git pull` fired right after races the server-side merge
+and can deliver the *pre-merge* tip while the MR already reports
+`state=merged`; anything derived from that checkout (a release tag, a branch
+cut from "main") then pins the old commit. One session tagged `v1.1.0` on the
+pre-merge tip this way and the tag pipeline published an image without the
+feature. Before tagging or branching off a freshly merged target:
+
+```bash
+# the remote target must equal the MR's merge commit
+test "$(git ls-remote origin "$TARGET" | cut -f1)" \
+   = "$(glab api "projects/$P/merge_requests/$M" | jq -r .merge_commit_sha)"
+```
+
+And never swallow the pull's outcome (`git pull --ff-only 2>&1 | tail -1`
+hides a refused fast-forward) — confirm with `git rev-parse HEAD` that the
+checkout actually sits on the expected commit.
+
 ### Rebase when the MR is behind
 
 GitLab will happily report `mergeable` while the branch is behind the target —


### PR DESCRIPTION
`glab mr merge` returns before the target branch has moved. A `git pull` fired right after races the server-side merge and can deliver the *pre-merge* tip while the MR already reports `state=merged` — a tag or branch cut from that checkout pins the old commit. In a real session this published `v1.1.0` on the pre-merge tip and the tag pipeline built an image without the feature.

Adds to the GitLab section:
- `git ls-remote origin $TARGET` vs the MR's `merge_commit_sha` as the gate before tagging/branching off a freshly merged target
- the don't-swallow-pull-output caveat (`git pull --ff-only 2>&1 | tail -1` hides a refused fast-forward; confirm with `git rev-parse HEAD`)

https://claude.ai/code/session_01VvAsXqGVJ7wLZjTtJsB4oG