### PR TITLE
docs: rebase_merge 405 handling and scoped captainhook disable

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -109,6 +109,11 @@ against the repo root, before inspecting it.
   falls back to `<git-dir>/hooks` otherwise). Works with captainhook's plugin in place, so other
   Composer plugins (phpstan/extension-installer, TYPO3 composer installers, etc.) continue to
   auto-register normally.
+- **Fix (scoped alternative)**: `composer config extra.captainhook.disable-plugin true`
+  before the install disables ONLY the captainhook plugin — all other Composer plugins
+  (phpstan/extension-installer, TYPO3 installers, …) keep working. It edits `composer.json`,
+  so revert it before committing (`git checkout composer.json`); useful for one-off
+  installs in throwaway worktrees where hooks are not wanted anyway.
 - **Fix (last-resort fallback)**: `composer install --no-plugins` — only if the hooks-dir
   workaround above doesn't resolve it. Be aware this disables *all* Composer plugins for that
   install, which has broader side effects: phpstan extensions won't auto-register, TYPO3

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1495,8 +1495,24 @@ checkout actually sits on the expected commit.
 
 ### Rebase when the MR is behind
 
-GitLab will happily report `mergeable` while the branch is behind the target —
-being behind is not a blocker there, unlike a GitHub merge queue. If the
+On projects with `merge_method: rebase_merge` (semi-linear history) a behind
+branch IS a blocker: `glab mr merge` fails with a bare
+`{message: 405 Method Not Allowed}` and the MR shows
+`detailed_merge_status: need_rebase`. The light path is a server-side rebase —
+no local fetch dance needed:
+
+```bash
+glab mr rebase <MR>
+# poll until the status leaves need_rebase (it passes through "checking")
+glab mr view <MR> --output json | jq -r '.detailed_merge_status'
+```
+
+The rebase creates a new head SHA, so wait for the freshly triggered pipeline
+before retrying the merge.
+
+On plain merge-commit projects GitLab will happily report `mergeable` while
+the branch is behind the target — being behind is not a blocker there, unlike
+a GitHub merge queue. If the
 procedure calls for a rebase, drive it locally and fetch the base explicitly
 (bare-repo worktrees often lack `remote.origin.fetch`, and `--force-with-lease`
 then fails with "stale info"):


### PR DESCRIPTION
Two additions from a live session (2026-07-30):

1. **pull-request-workflow.md**: On `merge_method: rebase_merge` projects, `glab mr merge` on a behind branch fails with a bare `405 Method Not Allowed` (`detailed_merge_status: need_rebase`). Documents the server-side `glab mr rebase` path, the status poll (passes through `checking`), and waiting for the freshly triggered pipeline before merging.
2. **git-hooks-setup.md**: `composer config extra.captainhook.disable-plugin true` as a scoped middle option in the CaptainHook worktree FAQ — disables only the captainhook plugin (unlike `--no-plugins`), must be reverted before committing.