### PR TITLE
ci: add secret and workflow scanning to security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,16 +1,36 @@
 name: Security
 
+# Aggregated security scans for skill repos: secret scanning (betterleaks),
+# workflow static analysis (zizmor), dependency review on PRs, and a composer
+# audit (every skill repo ships a composer.json for split-licensing /
+# Packagist distribution).
+#
+# Top-level `permissions: {}` denies everything by default; each reusable
+# caller job re-declares the exact union its reusable's jobs require, so the
+# token passed to each reusable is fully explicit and never relies on the
+# repo default. This is the same pattern proven in netresearch/.github's
+# go-app template (top {} + per-job security-events: write).
+
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
+
+permissions: {}
 
 jobs:
   gitleaks:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+    permissions:
+      contents: read
+      security-events: write
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
 
   dependency-review:
     if: github.event_name == 'pull_request'
@@ -21,3 +41,6 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin


### PR DESCRIPTION
Adds the secret- and workflow-scanning jobs this repo was missing.

`security.yml` here predates the current skill template, so it never received
the `zizmor` job added in netresearch/.github#327. This brings the file to the
current template revision and adds the shared `.github/zizmor.yml`.

**What changes**

- adds the **zizmor** job — static analysis of this repo's own workflows
- drops the `GITLEAKS_LICENSE` secret mapping — secret scanning runs on
  betterleaks (OSS, no licence), the reusable never read the secret, and the
  org-level secret has since been deleted
- adds top-level `permissions: {}` and an explicit permission set per caller
  job, so nothing relies on the repository default
- narrows triggers from `[main, master]` to `[main]` — this repo's default
  branch is `main`, verified before the change
- adds the missing `composer-audit` permissions block

`.github/zizmor.yml` exempts first-party `netresearch/*` reusables from the
blanket hash-pin policy (they track `@main` by convention); third-party actions
stay hash-pin enforced. Without it the two new caller lines flag themselves.

**What deliberately does not change**

This repo is not a template consumer (no `.github/template.yaml`) and this PR
does not make it one. Full template adoption would also overwrite `release.yml`,
`lint.yml`, `harness-verify.yml` and `auto-merge-deps.yml` — the change class
that broke every skill release org-wide on 2026-06-18 — and would add a drift
check that goes red immediately on the template files this repo does not carry.
That is a separate decision; only the two files above are touched here.
