### PR TITLE
docs: describe a change, read the CI that judges it, and re-read what a merge touched

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -114,6 +114,24 @@
       "name": "issue-with-known-fix",
       "prompt": "I found the root cause of a bug in an upstream project and have a three-line patch. File the issue using their template.",
       "expected_output": "Should state the fix in the Summary with a pointer to the diff section, keeping the template's sections intact, because template ordering puts evidence before solution and buries the actionable part"
+    },
+    {
+      "id": 20,
+      "name": "green-job-vs-test-report",
+      "prompt": "The pipeline on my merge request is green. Is it safe to merge?",
+      "expected_output": "Should not treat job status as sufficient: should read the pipeline's test report (failed_count vs total_count per suite) and list which jobs can actually block (allow_failure false / required checks); should mention that a checking job running a mutating command such as php-cs-fixer fix without --dry-run exits 0 regardless, and that a test_report of total_count 0 means no data rather than no failures"
+    },
+    {
+      "id": 21,
+      "name": "merge-dropped-lines-without-conflict",
+      "prompt": "I merged a long-running upstream branch into my feature branch. All conflicts are resolved and the tests still pass. Anything left to check?",
+      "expected_output": "Should warn that a clean auto-merge can drop entries inside a file that both sides rewrote, without any conflict marker, and recommend diffing the merged content of shared manifests (composer.json, package.json) against the pre-merge version rather than trusting the absence of conflicts"
+    },
+    {
+      "id": 22,
+      "name": "conflict-side-selection-check-the-body",
+      "prompt": "Six merge conflicts all look the same: upstream made a minimal nullability fix to a signature my branch already rewrote further. Can I resolve them all by taking my side?",
+      "expected_output": "Should refuse a blanket rule and require checking each function body outside the conflict, specifically whether tightening a nullable parameter to a non-null default leaves a null test or null coalesce dead; should also require checking call sites of any method whose parameters were reordered, since positional calls do not conflict"
     }
   ]
 }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -90,6 +90,30 @@
       "name": "worktree-review-workflow",
       "prompt": "How do I review a PR without stashing my current work?",
       "expected_output": "Should recommend git worktree to create separate working directory for the review branch"
+    },
+    {
+      "id": 16,
+      "name": "pr-body-before-after",
+      "prompt": "I changed the wording of an error message in our CLI. Write the pull request description.",
+      "expected_output": "Should include the old and the new output as captured transcripts run against the same input, not a prose description; should mention how to produce the pair (run against base via git checkout <base> -- <file>, or a stub); should cover the other response shapes the change can meet, not only the motivating one"
+    },
+    {
+      "id": 17,
+      "name": "verify-unchanged-claim",
+      "prompt": "My commit message says the fallback branch keeps its existing wording. Anything to check before I push?",
+      "expected_output": "Should treat the no-change claim as a claim needing the same proof as a changed one, and require actually exercising the fallback path (e.g. a before/after table filled in before the summary sentence is written) rather than asserting it"
+    },
+    {
+      "id": 18,
+      "name": "gitlab-contribution-capability",
+      "prompt": "On this self-managed GitLab the last 20 merge requests all came from in-repo branches and I see no forks. Can outsiders contribute?",
+      "expected_output": "Should refuse to infer policy from the MR history and instead read issues_enabled / merge_requests_enabled / forking_access_level via an AUTHENTICATED API call with -L; should note that anonymous requests return those fields as null (unknown, not disabled), and that an account-level project-creation limit is a different blocker than a project policy"
+    },
+    {
+      "id": 19,
+      "name": "issue-with-known-fix",
+      "prompt": "I found the root cause of a bug in an upstream project and have a three-line patch. File the issue using their template.",
+      "expected_output": "Should state the fix in the Summary with a pointer to the diff section, keeping the template's sections intact, because template ordering puts evidence before solution and buries the actionable part"
     }
   ]
 }

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -126,9 +126,9 @@ and back again all work, and take a couple of minutes:
 
 ```bash
 run_it > after.txt
-git checkout origin/main -- src/Thing.php   # old behaviour
+git checkout <base> -- src/Thing.php   # old behaviour; <base> is the PR's target, not always main
 run_it > before.txt
-git checkout HEAD -- src/Thing.php          # restore; verify with git status
+git checkout HEAD -- src/Thing.php     # restore; verify with git status
 ```
 
 Say in the body that the transcripts are captured output rather than
@@ -1001,8 +1001,12 @@ Where a pipeline publishes a test report, read it — the two disagree more ofte
 they should, and the report is the stronger statement.
 
 ```bash
+# Same placeholders as the GitLab section below: GITLAB_HOST, $P the URL-encoded
+# project path or numeric id, $TOKEN a PRIVATE-TOKEN.
+export GITLAB_HOST=git.example.com
+
 # GitLab: the report, not just the job list
-curl -s -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID/pipelines/$PIPELINE/test_report" \
+curl -s -H "PRIVATE-TOKEN: $TOKEN" "https://$GITLAB_HOST/api/v4/projects/$P/pipelines/$PIPELINE/test_report" \
   | jq '{total_count, failed_count, suites: [.test_suites[] | {name, failed_count, total_count}]}'
 
 # GitHub: the rollup hides startup failures entirely — see the section below
@@ -1023,7 +1027,7 @@ Two ways a check stops being a gate without anyone noticing:
   block:
 
 ```bash
-curl -s -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID/pipelines/$PIPELINE/jobs" \
+curl -s -H "PRIVATE-TOKEN: $TOKEN" "https://$GITLAB_HOST/api/v4/projects/$P/pipelines/$PIPELINE/jobs" \
   | jq -r '.[] | select(.allow_failure == false) | "\(.status)  \(.name)"'
 ```
 
@@ -1664,7 +1668,7 @@ Before concluding that a project takes issues, forks or merge requests only from
 members, read the project's own capability flags:
 
 ```bash
-curl -s -L -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID" \
+curl -s -L -H "PRIVATE-TOKEN: $TOKEN" "https://$GITLAB_HOST/api/v4/projects/$P" \
   | jq '{issues_enabled, merge_requests_enabled, forking_access_level, permissions}'
 ```
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -500,6 +500,54 @@ git rm -rfq --ignore-unmatch -- <path>   # plain `git rm` refuses when the index
 git ls-files -- <path> | wc -l           # must be 0
 ```
 
+### A clean auto-merge can drop lines neither side deleted
+
+The previous section is about files. The same silence applies *inside* a file: where
+both sides rewrote overlapping regions, git may resolve the hunk in one side's favour
+and report nothing. Entries the other side had are then simply gone, with no conflict
+marker to notice.
+
+```bash
+# After every merge, read what came out of the files both sides touched
+git diff --numstat HEAD -- composer.json package.json   # unexpected churn?
+git show HEAD:composer.json | jq -S '.["require-dev"]' > /tmp/before.json
+jq -S '.["require-dev"]' composer.json | diff /tmp/before.json -
+```
+
+**Real case:** a merge of an 82-commit `develop` into a long-lived branch resolved
+`composer.json` without conflict — and dropped two `require-dev` entries the branch had
+added. One of them registered a PHPStan extension, so the analysis would have run
+against a baseline generated *with* that extension while no longer loading it. Nothing
+in the merge output mentioned either package.
+
+### Choosing a side resolves the signature, not the body
+
+When several conflicts share a shape, it is tempting to resolve them with one rule —
+"their change is a subset of ours, take ours". The rule is about the *conflicting lines*;
+whether it holds depends on code that is **not** in the conflict.
+
+The recurring trap is a parameter whose nullability changed:
+
+```php
+// theirs — a minimal deprecation fix
+public function f(?int $max = null)
+// ours — went further, and looks like a superset
+public function f(int $max = 0)
+
+// …but the body, untouched and outside the conflict:
+$max = (int)($max ?? end($allLtsVersions) ?: 0);   // ?? is now dead, $max stays 0
+```
+
+**Real case:** six conflicts of exactly this shape, resolved with one rule. Four were
+right. In the other two the branch had tightened `?Type $x = null` to a non-null
+default while the body still tested for null — one silently returned an empty version
+range, the other resolved a path to `/` instead of the repository root. Both had been
+failing for months; the merge preserved them.
+
+After resolving by side-selection, read the body of every function whose signature you
+just decided on, and check the callers of any method whose parameters were reordered —
+positional call sites do not conflict and do not warn.
+
 ### DCO and third-party history are structurally incompatible
 
 A DCO check requires every commit to carry a `Signed-off-by` **matching its author**.
@@ -945,6 +993,43 @@ gh api graphql -f query='
 
 **Real-world lesson (PR #575):** Automated reviewers can generate 100+ comment threads.
 Without pagination, only the first 100 threads are returned, leaving others unaddressed.
+
+## A Green Job Is Not a Green Test Run
+
+Job status answers "did the command exit 0". It does not answer "did the tests pass".
+Where a pipeline publishes a test report, read it — the two disagree more often than
+they should, and the report is the stronger statement.
+
+```bash
+# GitLab: the report, not just the job list
+curl -s -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID/pipelines/$PIPELINE/test_report" \
+  | jq '{total_count, failed_count, suites: [.test_suites[] | {name, failed_count, total_count}]}'
+
+# GitHub: the rollup hides startup failures entirely — see the section below
+gh run list --repo "$R" --commit "$SHA" --json name,status,conclusion
+```
+
+Two ways a check stops being a gate without anyone noticing:
+
+- **The command mutates instead of checking.** A job running `php-cs-fixer fix`
+  (rather than `fix --dry-run`) repairs the files in the container, throws them away
+  with it, and exits 0. Every repaired file is recorded as a failed case in the JUnit
+  report while the job is green. One project had run that way for three and a half
+  years — 30 standing violations, a permanently green gate, and the evidence expiring
+  with the artifact about an hour after each run.
+- **Nothing is enforced because nothing fails.** `allow_failure: true` (GitLab) and
+  non-required checks (GitHub) are legitimate, but they make the pipeline's colour a
+  poor summary. Before reading a pipeline as approval, list which jobs can actually
+  block:
+
+```bash
+curl -s -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID/pipelines/$PIPELINE/jobs" \
+  | jq -r '.[] | select(.allow_failure == false) | "\(.status)  \(.name)"'
+```
+
+When a report's numbers look implausible — everything failing, or nothing at all —
+check the artifact before believing it. An expired or never-collected JUnit artifact
+reports `total_count: 0`, which reads like "no failures" and means "no data".
 
 ## Diagnosing CI Failures (Annotations First)
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -98,6 +98,78 @@ web UI: consistent authentication, structured `--json` output, and clearer
 errors. Drop to raw `gh api` only for endpoints the porcelain commands don't
 cover yet.
 
+## Describing the Change (PR Body, Commit Message, Issue)
+
+The rest of this file is about getting a change *merged*. This section is about
+making it *reviewable*. A reviewer who cannot see what changed has to reproduce
+your work before they can judge it.
+
+### Show before/after for anything observable
+
+If the change alters output, an error message, a rendered page, a CLI line or an
+API response, the PR body carries **both states**. Not a description of them —
+the captured text:
+
+```markdown
+**Before**
+
+    Reason: An error occured on handling the request.
+
+**After**
+
+    Reason: An error occured on handling the request. (HTTP 500, code 1603956982)
+```
+
+Produce them the same way: run the old and the new code against the *same*
+input. A stub server, a fixture, or `git checkout <base> -- <file>` for one run
+and back again all work, and take a couple of minutes:
+
+```bash
+run_it > after.txt
+git checkout origin/main -- src/Thing.php   # old behaviour
+run_it > before.txt
+git checkout HEAD -- src/Thing.php          # restore; verify with git status
+```
+
+Say in the body that the transcripts are captured output rather than
+illustrations — the difference matters to a reviewer deciding how much to trust
+them.
+
+Cover the shapes the change can meet, not only the motivating one. A table of
+input → before → after exposes the cases you would otherwise never run.
+
+### "Unchanged" is a claim, and needs the same proof
+
+Negative claims escape verification because nothing looks wrong when you skip
+them. "The fallback keeps its wording", "existing callers are unaffected",
+"no behaviour change for empty input" — each asserts the result of a run you
+have to actually perform.
+
+Build the before/after table *before* writing the summary sentence. Filling in
+the rows is what catches the case you assumed was untouched; writing the
+sentence first only records the assumption.
+
+### When you already have the fix, lead with it
+
+Issue templates order evidence before solution — they are written for reports
+where the cause is still unknown. When you arrive with a diagnosis *and* a
+patch, that ordering buries the actionable part under everything that proves it,
+and a maintainer reading top-down never reaches it.
+
+State the fix in the summary, then keep the evidence below it:
+
+```markdown
+### Summary
+
+<symptom, one paragraph>
+
+**The fix is to <X>** — <why it is safe>. Diff under [Possible fixes](#possible-fixes)
+below; everything in between is the evidence for the diagnosis.
+```
+
+Keep the template's sections — reviewers navigate by them — and add the pointer
+rather than reordering them.
+
 ## Atomic Commits (Default — No Squash Unless Asked)
 
 **The project default is atomic commits preserved end-to-end.** Squash is destructive: it loses GPG signatures, collapses bisection granularity, and destroys narrative. Never squash unless the user asks for it in this task.
@@ -1500,6 +1572,38 @@ Everything above assumes GitHub. GitLab has the same concepts under different
 field names, a different CLI and a different thread model — translate it, don't
 improvise mid-run. Export `GITLAB_HOST` (or pass `--hostname`) for self-managed
 instances.
+
+### "Can I contribute here?" is a flag lookup, not an inference
+
+Before concluding that a project takes issues, forks or merge requests only from
+members, read the project's own capability flags:
+
+```bash
+curl -s -L -H "PRIVATE-TOKEN: $TOKEN" "$HOST/api/v4/projects/$ID" \
+  | jq '{issues_enabled, merge_requests_enabled, forking_access_level, permissions}'
+```
+
+Two traps sit on that call:
+
+- **Anonymous requests null the flags.** Without a token the same fields come
+  back `null`, which reads like "disabled" and means "not visible to you". Only
+  an authenticated answer distinguishes the two.
+- **Follow redirects.** Instances reachable under two hostnames answer the API
+  on one of them; without `-L` you get a `307`/`404` and may conclude the project
+  or its API does not exist.
+
+Do not substitute observation for the flags. "The last 20 MRs all came from
+in-repo branches" is consistent with forks being forbidden *and* with nobody
+having needed one — a project whose `forking_access_level` is `enabled` will
+show exactly the same history if all its contributors are members. Likewise, an
+`open_issues_count` you cannot read is not an absent tracker.
+
+The flags also separate two failure modes that look identical from outside: a
+project that refuses outside contributions, and an account that may not create
+projects (`Limit reached — You cannot create projects in your personal
+namespace`). The first is a policy to respect; the second is a permission to
+request, and saying which one blocks you is the difference between a useful
+report and a shrug.
 
 ### One-block preflight
 


### PR DESCRIPTION
`pull-request-workflow.md` covers getting a change merged in considerable detail — merge gates, thread resolution, signing, rulesets, merge queues — and says nothing about what the pull request should contain. This adds a section for that, plus one GitLab gap, all four from friction in a single session.

## What this adds

**Show before/after** (`## Describing the Change`). When a change alters observable behaviour, the body carries both states as captured transcripts, not as prose. The section includes the cheapest way to produce the pair — run against the base revision via `git checkout <base> -- <file>` and back — and asks for the other response shapes the change can meet, not only the motivating one.

**"Unchanged" is a claim.** A commit in the session that prompted this asserted a fallback branch "keeps its wording". Building the before/after table for the PR showed it did not: `Unknown (Status 502)` had become `Unknown (HTTP 502)`. Negative claims escape verification precisely because nothing looks wrong when you skip them, so the section asks for the table before the summary sentence.

**GitLab: contribution capability is a flag lookup** (in the GitLab section). Whether a project takes issues, forks or merge requests is answered by `issues_enabled` / `merge_requests_enabled` / `forking_access_level` — and only on an authenticated call that follows redirects, because anonymous requests return those fields as `null`, which reads like "disabled" and means "not visible to you". In the session this was inferred instead, from "the last 20 MRs all came from in-repo branches", and the inference was wrong: forking was enabled the whole time. The section also separates the two blockers that look identical from outside — a project policy versus an account that may not create projects.

**Lead with the fix when the issue already has one.** Issue templates order evidence before solution, because they are written for reports where the cause is unknown. Filing a diagnosed bug with a patch in that order buries the actionable part; in the session the diff sat at line 82 under 50 lines of evidence and the reader asked why there was no fix.

## Notes

Four evals added covering the new guidance (ids 16–19). `Build/Scripts/validate-skill.sh` passes with 0 errors / 0 warnings; `scripts/verify-harness.sh --status` reports Level 3 complete. Documentation only — no script or hook behaviour changes.

Came from /retro: yes

---

## Added in a second pass (same session, same file)

**A green job is not a green test run.** Job status answers whether the command exited 0; where a pipeline publishes a test report, that report is the stronger statement. A checking job running a mutating command — `php-cs-fixer fix` rather than `fix --dry-run` — exits 0 whatever it finds. One project had run that way for three and a half years: 30 standing violations behind a permanently green gate, the evidence expiring with the artifact about an hour after each run. Also: list which jobs can actually block before reading a pipeline's colour as approval, and treat `total_count: 0` as *no data*, not *no failures*.

**A clean auto-merge can drop lines neither side deleted.** The existing guidance covers files added under a deleted path; this is the same silence inside a file. A merge resolved `composer.json` without conflict and lost two `require-dev` entries, one registering a PHPStan extension — so the analysis would have run against a baseline generated *with* that extension while no longer loading it.

**Choosing a side resolves the signature, not the body.** Six conflicts of one shape, one resolution rule, two of them wrong: the branch had tightened `?Type $x = null` to a non-null default while the body still tested for null. One silently returned an empty version range, the other resolved a path to `/` instead of the repository root. Reordered parameters get the same treatment — positional call sites neither conflict nor warn.

Three further evals (ids 20–22). Both passes are in one PR because they edit the same file; splitting them would guarantee a conflict between two of my own branches.
