### PR TITLE
chore(release): v1.19.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.18.8",
+  "version": "1.19.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.18.8"
+  version: "1.19.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
`main` is **48 commits ahead of v1.18.8**, so nothing merged since that tag has reached an installed copy of the skill.

The symptom that surfaced this: `scripts/pr-status.sh` landed in [#120](https://github.com/netresearch/git-workflow-skill/pull/120) *after* v1.18.8, so no released version contains it — `git ls-tree -r v1.18.8 | grep pr-status` is empty, and every cached plugin version from 1.18.0 through 1.18.8 ships only `spec-cleanup-guard.sh` and `verify-git-workflow.sh`. Guidance that tells the agent to prefer `pr-status.sh` over a hand-rolled status loop therefore points at a file that is not there, and the loop gets rebuilt from scratch every session — which is exactly what happened in the session that found this, three times, each time with a different wrong `gh --json` field name.

Minor rather than patch: one `feat` alongside six `fix` and twenty `docs`, no breaking change in the range.

Only the two version fields change, matching the shape of [ec06bf9](https://github.com/netresearch/git-workflow-skill/commit/ec06bf9) — `.claude-plugin/plugin.json` and the `version:` in `skills/git-workflow/SKILL.md`. The version-parity hook passes.

Tagging `v1.19.0` after merge is what triggers the publish workflow; that step is deliberately left to a human.
