### PR TITLE
Merge-gate tooling: stop calling a pending check red, and add pr-merge.sh

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -66,12 +66,6 @@ ls lefthook.yml .lefthook.yml captainhook.json .pre-commit-config.yaml .husky/pr
 
 Install: `lefthook install` | `composer install` | `npm install` | `pre-commit install`
 
-## Critical Release Rules
-
-1. **Immutable releases**: deleted releases block tag reuse; bump version.
-2. **Multi-branch releases**: Use `--latest=false` from non-default branches.
-3. **Pre-release**: version bumped, CI green, CHANGELOG updated, `git pull` first.
-
 ## PR Merge Requirements
 
 Before merging: threads resolved, CI green (incl. annotations), rebased, signed, **and reviewed** (human or bot, on the current head). Rebase-only + signed: `git merge --ff-only`.
@@ -80,8 +74,10 @@ Before merging: threads resolved, CI green (incl. annotations), rebased, signed,
 
 ```bash
 ./scripts/verify-git-workflow.sh /path/to/repository
-# Full merge-gate state + next valid action, 2 API calls:
+# Merge-gate state + next valid action, 2 API calls:
 ./scripts/pr-status.sh [-R owner/repo] [PR] [--json] [--watch]
+# Merge with the method the repo allows; refuses when the gate is shut:
+./scripts/pr-merge.sh [-R owner/repo] [PR] [--dry-run]
 ```
 
 ---

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -28,6 +28,25 @@ Measured on a 40-PR rollout that did not have it: **183 of 370 shell calls
 were PR-status probing**, the rulesets endpoint was queried exactly once, and
 `copilot_code_review` blocked four merges by surprise.
 
+## Then Merge: `scripts/pr-merge.sh`
+
+```bash
+./scripts/pr-merge.sh -R owner/repo 123
+./scripts/pr-merge.sh -R owner/repo 123 --dry-run   # print the command only
+```
+
+It reads `pr-status.sh --json` and refuses unless `NEXT` is `merge`, printing
+the gate that is shut instead. When it does merge it uses the method the
+repository allows and drops `--delete-branch` where a merge queue is active.
+
+Both of those are silent traps for a hand-written `gh pr merge --merge
+--delete-branch`. A repository with `allow_merge_commit: false` answers
+"Merge commits are not allowed on this repository"; one with a merge queue
+answers "Cannot use `--delete-branch` when merge queue enabled". A 54-repository
+rollout hit each of them three times before the detection was written down
+once. Squash is never used — it discards the atomic commits and their
+signatures.
+
 ### `--watch` returns on the first actionable event, not at full settle
 
 An `until [ pending == 0 ]` loop learns nothing until the slowest matrix job

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -18,7 +18,9 @@
 #   pr-merge.sh -R owner/repo 123
 #   pr-merge.sh -R owner/repo 123 --dry-run   # print the command, run nothing
 #
-# Exit codes: 0 merged (or queued), 1 the gate is shut, 2 usage/lookup error.
+# Exit codes: 0 merged (or queued), 1 the gate is shut and nothing was
+# attempted, 2 an error — usage, lookup, or the merge call itself failed.
+# 1 is retryable later; 2 needs a human.
 set -uo pipefail
 
 REPO=""; PR=""; DRY=0
@@ -44,17 +46,23 @@ command -v jq >/dev/null || die "jq not found"
 STATUS=$("$SCRIPT_DIR/pr-status.sh" ${REPO:+-R "$REPO"} ${PR:+"$PR"} --json) \
   || die "pr-status.sh failed"
 
-read -r ACTION WHY REPO PR QUEUE METHODS <<EOF
-$(printf '%s' "$STATUS" | jq -r '
+# Tab-separated, read with a tab-only IFS: the default IFS splits on spaces too,
+# which would tear `why` apart, and it collapses an empty field so every later
+# variable shifts by one. `jq -e` turns a schema change or truncated output into
+# a failure here rather than an empty ACTION further down.
+FIELDS=$(printf '%s' "$STATUS" | jq -er '
   [ .next.action,
-    (.next.why // "-" | gsub(" ";" ")),
+    (.next.why // "-"),
     .repo,
     (.number|tostring),
     (.queue_active|tostring),
     (.merge_methods|join(","))
-  ] | @tsv')
+  ] | @tsv') || die "pr-status.sh returned unexpected JSON"
+
+IFS=$'\t' read -r ACTION WHY REPO PR QUEUE METHODS <<EOF
+$FIELDS
 EOF
-WHY=${WHY//$' '/ }
+[ -n "$ACTION" ] && [ -n "$REPO" ] && [ -n "$PR" ] || die "pr-status.sh returned no action"
 
 if [ "$ACTION" != "merge" ]; then
   printf 'pr-merge: not merging %s#%s — %s: %s\n' "$REPO" "$PR" "$ACTION" "$WHY" >&2
@@ -86,7 +94,7 @@ fi
 OUT=$("${CMD[@]}" 2>&1); RC=$?
 if [ "$RC" -ne 0 ]; then
   printf 'pr-merge: %s#%s failed: %s\n' "$REPO" "$PR" "$(printf '%s' "$OUT" | tr '\n' ' ')" >&2
-  exit 1
+  exit 2
 fi
 
 if [ "$QUEUE" = "true" ]; then

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# pr-merge.sh — merge a pull request with the method the repository allows,
+# and only when the merge gate is actually open.
+#
+# Why this exists: `gh pr merge --merge --delete-branch` is wrong in two common
+# repository configurations and gives no useful error until it fails. A repo
+# with `allow_merge_commit: false` answers "Merge commits are not allowed on
+# this repository"; a repo with a merge queue answers "Cannot use --delete-branch
+# when merge queue enabled". Hand-rolling the detection per call site is how a
+# 54-repository rollout hit both, three times each. pr-status.sh already knows
+# the answer — this reads it instead of guessing.
+#
+# Squash is never used: it discards atomic commits and their signatures.
+#
+# Usage:
+#   pr-merge.sh                       # PR for the current branch
+#   pr-merge.sh 123
+#   pr-merge.sh -R owner/repo 123
+#   pr-merge.sh -R owner/repo 123 --dry-run   # print the command, run nothing
+#
+# Exit codes: 0 merged (or queued), 1 the gate is shut, 2 usage/lookup error.
+set -uo pipefail
+
+REPO=""; PR=""; DRY=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() { printf 'pr-merge: %s\n' "$1" >&2; exit 2; }
+need() { [ $# -ge 2 ] && [ -n "${2:-}" ] || die "$1 requires a value"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -R|--repo) need "$@"; REPO="$2"; shift 2 ;;
+    --dry-run) DRY=1; shift ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) die "unknown flag: $1" ;;
+    *)  PR="$1"; shift ;;
+  esac
+done
+
+command -v gh >/dev/null || die "gh not found"
+command -v jq >/dev/null || die "jq not found"
+[ -x "$SCRIPT_DIR/pr-status.sh" ] || die "pr-status.sh not found next to this script"
+
+STATUS=$("$SCRIPT_DIR/pr-status.sh" ${REPO:+-R "$REPO"} ${PR:+"$PR"} --json) \
+  || die "pr-status.sh failed"
+
+read -r ACTION WHY REPO PR QUEUE METHODS <<EOF
+$(printf '%s' "$STATUS" | jq -r '
+  [ .next.action,
+    (.next.why // "-" | gsub(" ";" ")),
+    .repo,
+    (.number|tostring),
+    (.queue_active|tostring),
+    (.merge_methods|join(","))
+  ] | @tsv')
+EOF
+WHY=${WHY//$' '/ }
+
+if [ "$ACTION" != "merge" ]; then
+  printf 'pr-merge: not merging %s#%s — %s: %s\n' "$REPO" "$PR" "$ACTION" "$WHY" >&2
+  exit 1
+fi
+
+# pr-status reports the method it picked; fall back to the allowed list. Squash
+# is excluded on purpose even when it is the only method the repo offers — in
+# that case pr-status already answers `blocked` and we never get here.
+METHOD=$(printf '%s' "$STATUS" | jq -r '.next.method // ""')
+if [ -z "$METHOD" ]; then
+  case ",$METHODS," in
+    *,merge,*)  METHOD="--merge" ;;
+    *,rebase,*) METHOD="--rebase" ;;
+    *) die "repo allows only [$METHODS] — enable merge or rebase, squash is not used" ;;
+  esac
+fi
+
+# A merge queue rejects --delete-branch outright, and deletes the branch itself
+# once the entry merges.
+CMD=(gh pr merge "$PR" --repo "$REPO" "$METHOD")
+[ "$QUEUE" = "true" ] || CMD+=(--delete-branch)
+
+if [ "$DRY" = "1" ]; then
+  printf '%q ' "${CMD[@]}"; printf '\n'
+  exit 0
+fi
+
+OUT=$("${CMD[@]}" 2>&1); RC=$?
+if [ "$RC" -ne 0 ]; then
+  printf 'pr-merge: %s#%s failed: %s\n' "$REPO" "$PR" "$(printf '%s' "$OUT" | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+if [ "$QUEUE" = "true" ]; then
+  printf 'pr-merge: %s#%s queued (%s, strategy set by the queue)\n' "$REPO" "$PR" "$METHOD"
+else
+  printf 'pr-merge: %s#%s merged (%s)\n' "$REPO" "$PR" "$METHOD"
+fi

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -215,6 +215,12 @@ evaluate() {
             + (if $s.queue_active
                then {note:"merge queue active — omit --delete-branch (it is rejected) and let the queue pick the strategy"}
                else {} end))
+         elif ($s.mergeState == "UNSTABLE" and $s.checks.pending > 0) then
+           # GitHub reports UNSTABLE while a non-required check is merely
+           # pending, not only when one is red. Calling that "a non-required
+           # check is red" sends the reader hunting for a failure that does
+           # not exist — nothing here has failed yet.
+           {action:"wait", why:"UNSTABLE while \($s.checks.pending) non-required check(s) are still running — nothing has failed"}
          elif $s.mergeState == "UNSTABLE" then
            {action:"triage-ci", why:"UNSTABLE: a non-required check is red; the gate stays shut until it is green or the PR is force-merged"}
          elif $s.checks.pending > 0 then


### PR DESCRIPTION
Two changes to the merge-gate tooling, both from a 54-repository rollout that ran into them repeatedly.

**`pr-status.sh` called a pending check red.** GitHub reports `UNSTABLE` while a non-required check is merely *running*, not only when one has failed, but the advice read "UNSTABLE: a non-required check is red" either way. Sweeping 18 pull requests that each had `0 fail` produced 18 invitations to go find a failure that did not exist. `UNSTABLE` with nothing failed and something pending is now `wait`, naming the count; `UNSTABLE` with a real failure keeps the old advice.

**`pr-merge.sh` is new.** `gh pr merge --merge --delete-branch` is wrong in two ordinary configurations and only says so after failing: a repository with `allow_merge_commit: false` answers "Merge commits are not allowed on this repository", and one with a merge queue answers "Cannot use `--delete-branch` when merge queue enabled". The rollout hit each three times and re-derived the detection at every call site, even though `pr-status.sh --json` already reports `merge_methods` and `queue_active`.

The script reads that JSON, refuses unless `NEXT` is `merge` — printing which gate is shut instead of a raw API error — and otherwise merges with the allowed method, dropping `--delete-branch` where a queue is active. Squash is never selected, including when it is the only method offered; `pr-status.sh` already answers `blocked` in that case.

Verified against a stubbed status for the five branches: rebase-only repo, queue active, `next.method` absent (derived from `merge_methods`, correctly skipping squash), squash-only (refused), and a shut gate (refused). The refusal path is also confirmed against a live pull request. `shellcheck` is clean on both scripts.

SKILL.md gained the new script and lost the three release rules, which duplicated the `github-release` skill that this skill's own description already routes to — the file is capped at 500 words and now sits at 483.