### PR TITLE
docs(review): decide on a suggestion instead of executing it

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -132,6 +132,18 @@
       "name": "conflict-side-selection-check-the-body",
       "prompt": "Six merge conflicts all look the same: upstream made a minimal nullability fix to a signature my branch already rewrote further. Can I resolve them all by taking my side?",
       "expected_output": "Should refuse a blanket rule and require checking each function body outside the conflict, specifically whether tightening a nullable parameter to a non-null default leaves a null test or null coalesce dead; should also require checking call sites of any method whose parameters were reordered, since positional calls do not conflict"
+    },
+    {
+      "id": 23,
+      "name": "review-suggestion-against-verbatim-material",
+      "prompt": "A reviewer points out a spelling mistake in my pull request: an example transcript says 'occured'. Fix it?",
+      "expected_output": "Should check whether the line is verbatim material before editing: if the transcript is captured output, the misspelling belongs to the system that emitted it and correcting it turns evidence into an approximation and breaks grepping for the real string; should decline citing the upstream source line rather than declining bare"
+    },
+    {
+      "id": 24,
+      "name": "literal-review-fix-would-be-incomplete",
+      "prompt": "A reviewer says the test setup should not build its clock from time(). I'll replace it with a fixed timestamp on that line.",
+      "expected_output": "Should trace the change through the surrounding code before applying: pinning the instant the code reads while the fixtures still come from time() puts the two far apart and fails everything as expired, turning a rare flake into a certain failure; should pin one constant and drive both from it, and say in the reply what was done instead of the literal suggestion"
     }
   ]
 }

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -269,7 +269,7 @@ Observed 2026-07-30 on a `docker:S8544` finding: gate `OK`, 0 open issues, 0 fai
 ### A suggestion against verbatim material is a suggestion to falsify it
 
 Reviewers read a diff, not its provenance. When a comment proposes tidying something
-that was **copied in verbatim** — a captured transcript, a quoted log line, an error
+that was **copied verbatim** — a captured transcript, a quoted log line, an error
 string, a fixture recorded from a real system — check the source of truth before
 touching it. Improving such a line does not improve the artifact; it turns evidence
 into an approximation, and quietly breaks anyone who greps their own logs for the
@@ -279,8 +279,8 @@ string as it is actually emitted.
 transcript. The misspelling belonged to the server under discussion:
 
 ```php
-// upstream, unchanged for years
-throw new …('An error occured on handling the request.', 1603956982);
+// ter_rest/Classes/Http/RouteHandler.php:125, quoted as it stands
+: $this->responseFactory->createErrorResponse($request, 1603956982, 'An error occured on handling the request.');
 ```
 
 Declined, citing that line. The reply matters as much as the decision — a bare "no"

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -266,6 +266,47 @@ On `CLOSED / FIXED`, treat it as an ordinary already-fixed bot thread: reply wit
 
 Observed 2026-07-30 on a `docker:S8544` finding: gate `OK`, 0 open issues, 0 failing checks, `mergeStateStatus: BLOCKED` on one stale thread — a merge that looked inexplicably stuck until the thread was read.
 
+### A suggestion against verbatim material is a suggestion to falsify it
+
+Reviewers read a diff, not its provenance. When a comment proposes tidying something
+that was **copied in verbatim** — a captured transcript, a quoted log line, an error
+string, a fixture recorded from a real system — check the source of truth before
+touching it. Improving such a line does not improve the artifact; it turns evidence
+into an approximation, and quietly breaks anyone who greps their own logs for the
+string as it is actually emitted.
+
+**Real case:** a review asked to correct "occured" to "occurred" in a before/after
+transcript. The misspelling belonged to the server under discussion:
+
+```php
+// upstream, unchanged for years
+throw new …('An error occured on handling the request.', 1603956982);
+```
+
+Declined, citing that line. The reply matters as much as the decision — a bare "no"
+reads as resistance, while the quoted source makes the reason checkable in seconds.
+
+The general form: before editing any line, know whether you are its author or its
+witness. Prose you wrote is yours to improve; recorded output is not.
+
+### Check whether the literal fix is complete before applying it
+
+A correct diagnosis does not guarantee a sufficient remedy. A reviewer sees the line
+they commented on, not the rest of the mechanism — so applying the suggestion exactly
+as written can leave a half-change that is worse than the original.
+
+**Real case:** a comment correctly objected to `time()` in a test-setup example as
+non-deterministic and asked for a fixed instant. Applying that to the shown line alone
+would have frozen the clock the code reads while the fixtures around it still came
+from `time()` — putting the two years apart and failing every assertion as expired. A
+rare flake would have become a certain failure. The fix that works pins **one**
+constant and drives both from it.
+
+Trace the suggested change through the code it touches before committing to it. When
+it turns out to be incomplete, say so in the reply and describe what you did instead —
+that is the part a reviewer cannot see, and the reason to prefer it over the literal
+reading.
+
 ### AI-authored commits on the branch are untrusted
 
 Distinct from a review *comment*: Copilot **Autofix**, Gemini "apply suggestion", and similar bot-authored **commits already pushed onto the PR branch** are patches, not settled work — they can carry real bugs, and they arrive looking done. In one `/pr-finish` run the autofix commits had (a) deleted a variable's initialization while keeping the line that reads it — an `UnboundLocalError` on every non-account query — and (b) added an unbounded `while True` pagination loop that later OOM-crashed the machine (see the *Cap memory when the fix activates or relies on a loop* bullet under *Fixing the failure*). Treat every bot commit like an untrusted patch:


### PR DESCRIPTION
`pull-request-workflow.md` already covers verifying an AI reviewer's factual claim before applying or declining it. This adds the two cases next to that one, where the claim is *true* and applying it is still wrong — both from a single review in one session.

## A suggestion against verbatim material is a suggestion to falsify it

Reviewers read a diff, not its provenance. A comment asked to correct "occured" to "occurred" in a captured before/after transcript. The misspelling belongs to the server under discussion:

```php
throw new …('An error occured on handling the request.', 1603956982);
```

Improving that line would have turned evidence into an approximation — in a section that argues transcripts must be captured rather than illustrated — and broken anyone grepping their own logs for the string as it is actually emitted.

The section also asks for the source citation *in the reply*. A bare "no" reads as resistance; a quoted line makes the reason checkable in seconds. The general form: before editing any line, know whether you are its author or its witness.

## Check whether the literal fix is complete before applying it

A correct diagnosis does not guarantee a sufficient remedy. A comment correctly objected to `time()` in a test-setup example as non-deterministic and asked for a fixed instant. Applying that to the commented line alone would have frozen the clock the code reads while the fixtures around it still came from `time()` — putting the two years apart and failing every assertion as expired. A rare flake would have become a certain failure.

The fix that works pins one constant and drives both from it. The reply has to say that, because the incompleteness is exactly what the reviewer could not see.

## Notes

Two evals added (ids 23–24). `Build/Scripts/validate-skill.sh` passes with 0 errors / 0 warnings. Documentation only.

Came from /retro: yes
