### PR TITLE
docs(commits): prove the commit landed by comparing HEAD

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -157,13 +157,13 @@ gh api /repos/{owner}/{repo}/commits/HEAD --jq '.commit.verification | {verified
 
 ```bash
 BEFORE=$(git rev-parse HEAD)
-git add <named paths>
+git add -- path/to/file path/to/other
 git commit -s -F msg.txt
 [ "$(git rev-parse HEAD)" != "$BEFORE" ] || { echo "commit aborted — re-stage and retry" >&2; exit 1; }
 git log -1 --format='%h %G?'          # now describes YOUR commit
 ```
 
-`git commit && echo done` is not enough either: with `set -o pipefail` off, in a `&&` chain after a subshell, or when the exit code is consumed by a following `echo`, the failure is easy to lose. The HEAD comparison cannot be. The same trap makes a following `git push` succeed while pushing nothing new — the branch simply has not moved.
+Checking `git commit`'s own exit code works, but only if nothing reads it first — and in practice the next thing in the block is a status line that answers from the *previous* commit and looks right. `git log -1 --format='%G?'` prints `G`, and the `git push` that follows succeeds while pushing nothing new, because the branch never moved. HEAD is the one value the aborted commit did not leave intact, which is why comparing it answers the question the others only appear to.
 
 **Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
 

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -153,6 +153,18 @@ gh api /repos/{owner}/{repo}/commits/HEAD --jq '.commit.verification | {verified
 
 **Never amend a commit with pre-commit-hook failures.** If the pre-commit hook fails, the commit **did not happen**. Running `git commit --amend` then modifies the PREVIOUS commit, which can destroy work. Fix the hook issue, re-stage, and create a new commit.
 
+**Prove the commit landed before reporting it — compare HEAD, not the last commit.** A reformatting hook (`ruff format`, `black`, `isort`, `prettier`) rewrites the staged files and *aborts* the commit. Every check that reads "the last commit" then describes the commit before yours and reports success:
+
+```bash
+BEFORE=$(git rev-parse HEAD)
+git add <named paths>
+git commit -s -F msg.txt
+[ "$(git rev-parse HEAD)" != "$BEFORE" ] || { echo "commit aborted — re-stage and retry" >&2; exit 1; }
+git log -1 --format='%h %G?'          # now describes YOUR commit
+```
+
+`git commit && echo done` is not enough either: with `set -o pipefail` off, in a `&&` chain after a subshell, or when the exit code is consumed by a following `echo`, the failure is easy to lose. The HEAD comparison cannot be. The same trap makes a following `git push` succeed while pushing nothing new — the branch simply has not moved.
+
 **Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
 
 **Never bypass signing** unless explicitly told to. `--no-gpg-sign` and `-c commit.gpgsign=false` disable commit signing; the result will fail branch-protection or policy checks that require signed commits later.


### PR DESCRIPTION
A reformatting pre-commit hook — `ruff format`, `black`, `isort`, `prettier` — rewrites the staged files and **aborts** the commit. The reference already says the commit did not happen. What it did not say is that the usual success checks cannot tell.

`git log -1 --format='%G?'` after an aborted commit reports the signature of the commit *before* the one you meant to make, so it prints `G` and reads as "signed and committed". A `&&`-chained echo is just as easy to lose. The push afterwards succeeds as well, because the branch has not moved and there is nothing to reject.

That is not hypothetical: it happened twice in one session, once undetected until a later check, and once caught immediately — by the comparison this commit documents.

```bash
BEFORE=$(git rev-parse HEAD)
git add <named paths>
git commit -s -F msg.txt
[ "$(git rev-parse HEAD)" != "$BEFORE" ] || { echo "commit aborted — re-stage and retry" >&2; exit 1; }
git log -1 --format='%h %G?'
```

HEAD moving is the only signal that is not shared with the previous commit, so it is the only one that answers the question being asked.