### PR TITLE
fix(pr-status): tell an enqueued PR apart from a merge-ready one

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -144,6 +144,12 @@
       "name": "literal-review-fix-would-be-incomplete",
       "prompt": "A reviewer says the test setup should not build its clock from time(). I'll replace it with a fixed timestamp on that line.",
       "expected_output": "Should trace the change through the surrounding code before applying: pinning the instant the code reads while the fixtures still come from time() puts the two far apart and fails everything as expired, turning a rare flake into a certain failure; should pin one constant and drive both from it, and say in the reply what was done instead of the literal suggestion"
+    },
+    {
+      "id": 25,
+      "name": "already-enqueued-pr-reads-as-clean",
+      "prompt": "I queued my PR for merge ten minutes ago. The status check now says mergeState CLEAN, every check green, no open threads, NEXT: merge. Should I run the merge again?",
+      "expected_output": "Should say no and check the PR's own queue entry first: mergeStateStatus describes the branch, so an enqueued PR keeps reading CLEAN and looks merge-ready; mergeQueueEntry (position, state, estimatedTimeToMerge) is the field that distinguishes 'ready to enqueue' from 'already in line', and a repo-level merge_queue ruleset does not answer it; should wait for the queue to merge it and note that enqueueing again only restarts its checks"
     }
   ]
 }

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1354,7 +1354,7 @@ gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){
   pullRequest(number:NNN){ mergeQueueEntry{ state position estimatedTimeToMerge } }}}'
 ```
 
-`mergeQueueEntry` is null unless this PR holds an entry; when it does not, it
+`mergeQueueEntry` is null unless this PR holds an entry; when it does, it
 carries `position`, `state` (`QUEUED`, `AWAITING_CHECKS`, `MERGEABLE`,
 `UNMERGEABLE`, `LOCKED`) and an ETA in seconds. The repo-level signal — a
 `merge_queue` ruleset exists — answers a different question and cannot stand in

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1343,6 +1343,26 @@ remote:   Branches that are queued for merging cannot be updated.
 Note the mutation input field is `id:`, not `pullRequestId:` — the latter fails
 with `InputObject 'DequeuePullRequestInput' doesn't accept argument`.
 
+**An enqueued PR still reads as `CLEAN`, so "clean, go merge" is the wrong
+verdict.** `mergeStateStatus` describes the branch, not the queue: a PR sitting
+in the queue keeps answering `CLEAN` with every check green and no open thread,
+which is exactly what a merge-readiness check looks for. Ask the PR itself
+whether it is already in line:
+
+```bash
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){
+  pullRequest(number:NNN){ mergeQueueEntry{ state position estimatedTimeToMerge } }}}'
+```
+
+`mergeQueueEntry` is null unless this PR holds an entry; when it does not, it
+carries `position`, `state` (`QUEUED`, `AWAITING_CHECKS`, `MERGEABLE`,
+`UNMERGEABLE`, `LOCKED`) and an ETA in seconds. The repo-level signal — a
+`merge_queue` ruleset exists — answers a different question and cannot stand in
+for it. `pr-status.sh` reports both, as `queue=` and an `in queue` line, and
+answers `wait` rather than `merge` while an entry is held; `pr-merge.sh`
+refuses on that same verdict. Enqueueing an entry that already exists only
+restarts its checks and pushes the merge further out.
+
 **`--delete-branch` is rejected while a merge queue is enabled.** `gh pr merge`
 fails outright with:
 

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -208,7 +208,11 @@ evaluate() {
            {action:"wait",
             why:("already in the merge queue at position \($s.queue_entry.position)"
                  + " (\($s.queue_entry.state))"
-                 + (if $s.queue_entry.eta
+                 # Spelled `!= null` rather than left implicit: jq counts only
+                 # null and false as false, so a 0-second ETA does render — but
+                 # a reader arriving from a language where 0 is falsy reads a
+                 # bug here that is not present.
+                 + (if ($s.queue_entry.eta != null)
                     then ", ~\((($s.queue_entry.eta) / 60) | floor) min to go"
                     else "" end)
                  + " — the queue merges it once its own checks pass; enqueueing"
@@ -269,7 +273,7 @@ render() {
     "  threads     : \(.unresolved_threads) unresolved",
     "  merge       : methods=[\(.merge_methods|join(","))] auto=\(.auto_merge_allowed) queue=\(.queue_active)",
     (if .queue_entry then
-       "  in queue    : position \(.queue_entry.position), \(.queue_entry.state)\(if .queue_entry.eta then ", ~\(((.queue_entry.eta) / 60) | floor) min" else "" end)"
+       "  in queue    : position \(.queue_entry.position), \(.queue_entry.state)\(if (.queue_entry.eta != null) then ", ~\(((.queue_entry.eta) / 60) | floor) min" else "" end)"
      else empty end),
     "",
     "NEXT: \(.next.action) — \(.next.why)",

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -68,6 +68,7 @@ collect() {
       mergeCommitAllowed rebaseMergeAllowed squashMergeAllowed autoMergeAllowed
       pullRequest(number:$pr){
         number title state isDraft mergeable mergeStateStatus reviewDecision
+        mergeQueueEntry{ state position estimatedTimeToMerge }
         author{login}
         baseRefName headRefName headRefOid isCrossRepository
         reviews(last:50){ nodes{ author{login} state commit{oid} } }
@@ -162,7 +163,16 @@ evaluate() {
                           (if $repo.squashMergeAllowed then "squash" else empty end) ]),
         auto_merge_allowed: $repo.autoMergeAllowed,
         queue_active: (($p.mergeStateStatus == "BLOCKED" or $p.mergeStateStatus == "CLEAN")
-                       and ($ruletypes | index("merge_queue")) != null)
+                       and ($ruletypes | index("merge_queue")) != null),
+        # queue_active describes the REPO — a queue exists and this PR would go
+        # through it. queue_entry describes THIS PR: non-null only while it is
+        # actually sitting in the queue. Without the second one, an enqueued PR
+        # still reads as CLEAN and gets answered "merge", which re-enqueues it.
+        queue_entry: (if $p.mergeQueueEntry then
+                        {state: $p.mergeQueueEntry.state,
+                         position: $p.mergeQueueEntry.position,
+                         eta: $p.mergeQueueEntry.estimatedTimeToMerge}
+                      else null end)
       }
     # ---- next valid action, highest-priority first -------------------------
     | . as $s
@@ -188,6 +198,21 @@ evaluate() {
          elif $s.unresolved_threads > 0 then
            {action:"resolve-threads", why:"\($s.unresolved_threads) unresolved review thread(s)",
             threads:$s.threads}
+         # Sits after the branches that report real work (failing checks,
+         # open threads) — those stay worth doing while queued, and a queue
+         # entry that fails its own checks is dropped anyway. It sits before
+         # every review and merge branch: GitHub already let this PR past the
+         # rulesets when it accepted the entry, so "request a review" or
+         # "merge" here is advice that would dequeue it and start over.
+         elif ($s.queue_entry != null) then
+           {action:"wait",
+            why:("already in the merge queue at position \($s.queue_entry.position)"
+                 + " (\($s.queue_entry.state))"
+                 + (if $s.queue_entry.eta
+                    then ", ~\((($s.queue_entry.eta) / 60) | floor) min to go"
+                    else "" end)
+                 + " — the queue merges it once its own checks pass; enqueueing"
+                 + " again only restarts them")}
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
@@ -243,6 +268,9 @@ render() {
     "  reviews     : \(if .has_review_on_head then (.reviews_on_head|to_entries|map("\(.key)=\(.value)")|join(", ")) else "NONE on current head" end)  decision=\(if .reviewDecision=="" then "-" else .reviewDecision end)",
     "  threads     : \(.unresolved_threads) unresolved",
     "  merge       : methods=[\(.merge_methods|join(","))] auto=\(.auto_merge_allowed) queue=\(.queue_active)",
+    (if .queue_entry then
+       "  in queue    : position \(.queue_entry.position), \(.queue_entry.state)\(if .queue_entry.eta then ", ~\(((.queue_entry.eta) / 60) | floor) min" else "" end)"
+     else empty end),
     "",
     "NEXT: \(.next.action) — \(.next.why)",
     (if .next.method then "  method: \(.next.method)" else empty end),


### PR DESCRIPTION
## The bug, as it happened

A PR was queued for merge. Ten minutes later `pr-status.sh` reported:

```
  state       : OPEN  mergeable=MERGEABLE  mergeState=CLEAN
  checks      : 68 pass, 0 fail, 0 pending, 17 skip (of 85)
  threads     : 0 unresolved
  merge       : methods=[merge] auto=true queue=true

NEXT: merge — clean
```

Every word of that is true and the verdict is still wrong: the PR was already in the queue at position 2. Acting on it would have enqueued it a second time, restarting the queue's checks and pushing the merge further out — in a congested runner pool, by a lot.

`mergeStateStatus` describes the branch, not the queue, so an enqueued PR keeps answering `CLEAN` with everything green and nothing open. That is exactly the shape the merge branch looks for.

## Why the existing signal could not catch it

`queue_active` was already there, but it answers a different question — *does a `merge_queue` ruleset exist and would this PR travel through it* — and that stays true both before and after enqueueing. The PR's own `mergeQueueEntry` is what separates the two states:

```
$ gh api graphql -f query='{repository(owner:"netresearch",name:"t3x-nr-llm"){
    pullRequest(number:583){ mergeQueueEntry{ state position estimatedTimeToMerge } }}}'
{"state":"AWAITING_CHECKS","position":2,"estimatedTimeToMerge":659,"enqueuer":{"login":"CybotTM"}}
```

Null unless this PR holds an entry, and when it does it carries a position, a state and an ETA — all worth showing.

## The change

- `pr-status.sh` queries `mergeQueueEntry`, exposes it as `queue_entry`, renders an `in queue` line and answers `wait` instead of `merge` while an entry is held.
- The new branch sits **after** the ones that report real work: a failing check or an open thread is still worth acting on while queued, and an entry whose checks fail is dropped by the queue anyway. It sits **before** every review and merge branch, because GitHub already let the PR past the rulesets when it accepted the entry — "request a review" or "merge" there is advice that would undo the entry and start over.
- `pr-merge.sh` needed no change of its own. It acts on `next.action`, so it now refuses with the queue position as the reason.
- `references/pull-request-workflow.md` gains the distinction next to the existing merge-queue material, and `evals/evals.json` gains a case for it.

## Verification

Against the live PR that produced the bug, still sitting in the queue:

```
$ ./skills/git-workflow/scripts/pr-status.sh -R netresearch/t3x-nr-llm 583
  merge       : methods=[merge] auto=true queue=true
  in queue    : position 2, AWAITING_CHECKS, ~10 min

NEXT: wait — already in the merge queue at position 2 (AWAITING_CHECKS), ~10 min to go — the queue merges it once its own checks pass; enqueueing again only restarts them

$ ./skills/git-workflow/scripts/pr-merge.sh -R netresearch/t3x-nr-llm 583 --dry-run
pr-merge: not merging netresearch/t3x-nr-llm#583 — wait: already in the merge queue at position 2 …
exit 1
```

A repo without a queue is unaffected — no `in queue` line, verdict unchanged:

```
$ ./skills/git-workflow/scripts/pr-status.sh -R netresearch/t3x-nr-repurpose 62
  merge       : methods=[merge] auto=true queue=false
NEXT: none — PR is MERGED
```

`shellcheck` clean on both scripts (also via the pre-commit hook), `bash -n` clean, `scripts/verify-harness.sh` reports `Level 3 COMPLETE | 0 error(s), 0 warning(s)`, and `evals.json` parses.
