### PR TITLE
feat(pr-status): name the unsigned commit instead of saying investigate

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -156,6 +156,12 @@
       "name": "required-check-queued-not-running",
       "prompt": "My PR has been waiting on CI for forty minutes and the status tool says the required checks are still running. Should I enqueue it for merge so it goes in as soon as they finish?",
       "expected_output": "Should check whether those checks are actually running or merely queued: queued and in_progress are different API states, and a required check sitting in queued with nothing running means no runner has picked it up, not that CI is slow; should warn that a merge queue drops an entry whose required check does not report inside check_response_timeout_minutes and that the clock covers waiting for a runner, so enqueueing now risks a silent dequeue and each retry leaves more runs holding slots; should not try to look up the concurrency limit, which is not exposed by the API"
+    },
+    {
+      "id": 27,
+      "name": "blocked-with-everything-green",
+      "prompt": "My PR is mergeStateStatus BLOCKED. Every check passes, no review thread is open, the ruleset needs zero approvals and every required context is present. What is holding it?",
+      "expected_output": "Should suspect an unsigned commit rather than re-reading branch protection: a required_signatures ruleset is shut by one commit anywhere on the branch that carries no valid signature, and GitHub surfaces that only as BLOCKED, never as a failing check or a rollup entry, so nothing visible names it; should check every commit on the branch, not just the head, and re-sign the branch with a rebase that amends each commit rather than only the tip"
     }
   ]
 }

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -76,6 +76,11 @@ collect() {
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
         reviewThreads(first:100){ nodes{ id isResolved isOutdated
           comments(first:1){ nodes{ databaseId author{login} path } } } }
+        # One unsigned commit anywhere on the branch shuts a required_signatures
+        # ruleset, and GitHub surfaces that only as mergeStateStatus BLOCKED —
+        # no red check, nothing in the rollup. Without this the tool can only
+        # say "investigate".
+        allCommits: commits(first:100){ nodes{ commit{ oid signature{ isValid } } } }
         commits(last:1){ nodes{ commit{ oid statusCheckRollup{ state
           contexts(first:100){ nodes{
             __typename
@@ -170,6 +175,9 @@ evaluate() {
         },
         required_contexts: $required,
         rules_fetched: ($ok == 1),
+        unsigned: [$p.allCommits.nodes[]?.commit
+                   | select((.signature.isValid // false) | not)
+                   | .oid[0:8]],
         rulesets: $ruletypes,
         reviews_on_head: ($head_reviews|map({(.author.login): .state})|add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
@@ -292,6 +300,20 @@ evaluate() {
            {action:"triage-ci", why:"UNSTABLE: a non-required check is red; the gate stays shut until it is green or the PR is force-merged"}
          elif $s.checks.pending > 0 then
            {action:"wait", why:"\($s.checks.pending) check(s) still running (none of them required)"}
+         # Checked last, because it only matters once everything visible is
+         # green: an unsigned commit produces no red check and no rollup entry,
+         # so it surfaces purely as BLOCKED and used to end here as
+         # "investigate".
+         elif (($s.unsigned|length) > 0 and (($ruletypes | index("required_signatures")) != null)) then
+           {action:"fix-signatures",
+            why:("\($s.unsigned|length) commit(s) on this branch carry no valid signature — \($s.unsigned|join(", "))"
+                 + " — and the required_signatures ruleset is active. GitHub reports this"
+                 + " only as mergeStateStatus \($s.mergeState), never as a failing check"),
+            # No single quotes in here: the whole jq program lives in a
+            # single-quoted shell string and one would end it (shellcheck
+            # SC2026 catches it, but only after the parse has already gone
+            # wrong further down).
+            cmd:"git rebase --exec \"git commit --amend --no-edit -S\" $(git merge-base HEAD origin/\($s.base)) ; git push --force-with-lease"}
          else
            {action:"investigate", why:"mergeState=\($s.mergeState) with no failing check, no open thread and no missing review — check branch protection manually"}
          end)


### PR DESCRIPTION
## The gap

A `required_signatures` ruleset is shut by **one** commit anywhere on the branch that carries no valid signature. GitHub surfaces that only as `mergeStateStatus: BLOCKED` — no failing check, no entry in the status rollup, nothing in the review or thread state. Every signal `pr-status` looks at is green, so it fell through to:

```
NEXT: investigate — mergeState=BLOCKED with no failing check, no open thread
and no missing review — check branch protection manually
```

Which is honest, and useless.

## Where it came from

Eight PRs in today's dependency campaign sat at `BLOCKED` with everything green. Diagnosing it by hand meant reading the `pull_request` ruleset parameters (zero approvals required, threads resolved — not it), diffing the 51 required contexts against the 65 present ones (all present — not it), and finally calling `GET /repos/{repo}/commits/{sha}` per commit, which showed `verified: false, reason: unsigned` on the first commit of each branch.

The tool now answers that in its first run.

## The change

- The GraphQL query gains `allCommits: commits(first:100){ nodes{ commit{ oid signature{ isValid } } } }` — one extra field on a query that already runs.
- `unsigned` is exposed in `--json`.
- A new verdict **`fix-signatures`** fires when unsigned commits exist *and* the `required_signatures` ruleset is active, naming the offending short SHAs and stating that GitHub reports this only as `BLOCKED`.
- It sits last in the chain, because it only matters once the visible gates are satisfied.

The suggested command re-signs **every** commit on the branch:

```
git rebase --exec "git commit --amend --no-edit -S" $(git merge-base HEAD origin/<base>) ; git push --force-with-lease
```

Amending only `HEAD` leaves an unsigned parent and the gate stays shut — that is exactly how the campaign PRs got into this state, since a later amend signed the tip while the parent stayed unsigned.

## Verification

```
$ bash -n … && shellcheck …            Syntax ok / clean
$ pr-status.sh … t3x-nr-image-sitemap 42 --json | jq -c '{unsigned, next:.next.action}'
{"unsigned":[],"next":"triage-ci"}
$ pr-status.sh … t3x-nr-temporal-cache 71 --json | jq -c '{unsigned, next:.next.action}'
{"unsigned":[],"next":"rebase"}
```

Both branches were re-signed a few minutes before this PR, so the field correctly reports an empty list and the verdict falls through unchanged.

The positive branch is shown on synthetic input, which is weaker evidence and worth stating plainly — there is no longer an unsigned PR in the org to point it at. Three fixture commits, one with `isValid: false`, one with `isValid: true`, one with no signature object at all: the extraction returns the two unsigned ones, the verdict reads `fix-signatures — 2 commit(s) … only as mergeStateStatus BLOCKED` while the ruleset is active, and falls back to `investigate` when it is not.

The missing-signature-object case is covered by `(.signature.isValid // false)`, since such a commit returns null rather than false.

## One thing this does not do

It does not explain **why** those commits were unsigned. `commit.gpgsign` is true globally here and a probe repository signs immediately, so the batch scripts that produced them should have signed too. I have not established the cause and am not guessing at one in the code.