### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.20.0"
+  version: "1.21.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Version bump 1.20.0 → 1.21.0.

Changes since v1.20.0:

- docs(watcher): driving many PRs at once with parallel pr-status watches
- fix(watcher): one result file per PR in a fresh temp dir
- docs(advanced-git): main worktree is reference only — work in fresh worktrees
- docs(advanced-git): use origin/main as worktree start point in examples
- feat: ship merge-gate.sh the hooks recipe already references
- fix(merge-gate): parse short/=-joined flags; paginate review threads
- docs(pr-workflow): triage review findings individually, not as a batch
- docs(pr-workflow): language-agnostic wording for doc-comment suggestions
- fix(pr-status): tell an enqueued PR apart from a merge-ready one
- docs(pr-status): fix the inverted mergeQueueEntry sentence, spell the ETA null check
- docs(pull-request-workflow): parallel-merged config PR turns green checks red on main
- docs(pr-workflow): follow-up push to an auto-merged branch is silently lost
- docs(pr-workflow): wrap prose, extract .state via --jq, stop on any non-OPEN state
- docs(pr-workflow): signature source-of-truth is the API; systemic failures get central fixes
- docs(pr-workflow): grammar fix in the signature paragraph per review
- docs(git-workflow): warn about destructive checkout and identical hunks
- docs(git-workflow): address review on the checkout and hunk sections
- feat(pr-status): tell a queued check apart from a running one
- fix(pr-status): age the queued signal before calling it a capacity problem
- fix(merge-gate): re-poll UNKNOWN merge state before denying; document silent queue drops
- docs(advanced-git): merge-tip rebase collapse, no tail-piped gates, named staging, worktree .git file
- feat(pr-status): name the unsigned commit instead of saying investigate

Surfaces bumped: `.claude-plugin/plugin.json`, SKILL.md frontmatter version.
