### PR TITLE
docs(pr-workflow): add the URL cause of --force-with-lease "stale info"

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -982,6 +982,8 @@ tail -20 build.log            # inspection only — never part of the gate
 
 ### `--force-with-lease` Rejected with "stale info"
 
+Two different causes produce this message: the tracking ref moved (below), or there is no tracking ref at all (the subsection after it). Neither is a reason to escalate to plain `--force`.
+
 On PRs that bots touch (auto-approve, Renovate/Dependabot, a CI step that pushes), `git push --force-with-lease` can be rejected with `stale info` even when your local work is correct: a bot updated the remote branch since your last fetch, so the lease's expected ref (your `origin/<branch>` tracking ref) no longer matches and the push aborts. This is the safety check working — don't escalate to plain `--force`.
 
 Fetch, see what arrived, then push — the lease now matches the ref you just fetched:
@@ -998,6 +1000,27 @@ If a bot keeps pushing inside the fetch→push window so the plain lease never m
 ```bash
 git push --force-with-lease="$BR:$(git rev-parse origin/"$BR")" origin "$BR"
 ```
+
+#### When the push target is a URL, not a remote
+
+Fetching does not help — and cannot — if the push names a URL:
+
+```bash
+git push --force-with-lease git@github.com:me/repo.git HEAD:my-branch
+# ! [rejected]  HEAD -> my-branch (stale info)
+```
+
+A URL has no remote-tracking ref, so the lease has nothing to compare against and the push is rejected every time, however recently you fetched. This is not the safety check catching a real race; it is the check with no input. Typically hit when pushing to a fork that was never added as a remote — `gh repo fork --clone=false` creates the fork on the server but adds nothing locally.
+
+Add the remote once, fetch it, then push to it by name:
+
+```bash
+git remote add fork git@github.com:me/repo.git
+git fetch fork
+git push --force-with-lease fork HEAD:my-branch
+```
+
+`git remote -v` before force-pushing is the cheap check: if the target is not listed there, the lease cannot work. Do not reach for plain `--force` — that discards the protection instead of supplying it.
 
 ### Complex Conflicts
 


### PR DESCRIPTION
## Summary

Documents a third cause of `--force-with-lease` being rejected with `stale info` — pushing to a URL instead of a named remote — which, unlike the two already covered, cannot be fixed by fetching.

## Came from

`/retro` session on 2026-08-07: `3b2909e2-2cc1-4876-a6d4-76ec690cc48d`
Finding: A17 — an upstream command failed and the existing guidance did not explain why.

- **Symptom:** `git push --force-with-lease git@github.com:me/repo.git HEAD:my-branch` → `! [rejected] HEAD -> my-branch (stale info)`, immediately after a successful fetch, with the local work correct.
- **Cause:** A URL has no remote-tracking ref, so the lease has nothing to compare against and is rejected every time however recently you fetched. This is distinct from the two causes already in this file: the bot-moved-the-branch case at "`--force-with-lease` Rejected with 'stale info'" and the bare-repo-worktree case under merging divergent upstream history both describe a tracking ref that exists but no longer matches. Here there is no tracking ref at all. Typically hit after `gh repo fork --clone=false`, which creates the fork server-side and adds nothing locally.
- **Required behavior:** `git remote add <name> <url>`, `git fetch <name>`, then push to the remote by name. Check `git remote -v` before force-pushing; if the target is not listed, the lease cannot work. Never escalate to plain `--force`, which removes the protection rather than supplying it.
- **Verification:** No `evals/` entry added — this is a documentation change to a troubleshooting section. Reproduced and fixed in-session by exactly the sequence documented.

## Change

`references/pull-request-workflow.md`, in the existing "stale info" section:

- New `#### When the push target is a URL, not a remote` subsection with the failing command, why fetching cannot help, the fix, and the `git remote -v` pre-check.
- One added lead sentence so the section frames both causes up front, instead of the bot case reading as the only one.

## Test plan

- [ ] The `git remote add` / `git fetch` / `git push --force-with-lease <remote>` sequence succeeds where the URL form failed
- [ ] The section reads coherently: lead sentence, tracking-ref-moved case, pin variant, URL case
- [ ] `SKILL.md` untouched (483 words, unchanged)
