### PR TITLE
docs(pr-workflow): run the target repo's contribution gate before an upstream PR

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -765,6 +765,23 @@ required_status_checks:
 /src/crypto/ @security-team
 ```
 
+## Contributing to a Repo You Do Not Own
+
+Before opening the PR, run the target repo's own contribution gate — all of it, from its `CONTRIBUTING.md`, not the subset that resembles your usual one. Their checklist is the review contract, and the items that look like boilerplate are the ones that fail.
+
+```bash
+gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' | base64 -d
+```
+
+Then actually run each item. Two that are routinely skipped and routinely red:
+
+- **The whole-tree analyzer, not the package you touched.** `staticcheck ./...`, `go vet ./...`, `phpstan analyse` at the configured level — scoping it to your directory hides failures your change caused elsewhere.
+- **The spell checker.** Repos running cspell in CI usually set `incremental_files_only: true`, so it checks exactly the files your PR touched — a domain term absent from the project dictionary fails the build on a doc-only change. Run it before pushing, and add the word to the project word list using the repo's own tooling rather than rewording to dodge it.
+
+Check `SECURITY.md` before filing anything security-flavoured as a public issue. Many projects route vulnerabilities to a private address, so a public issue is both wrong and unwelcome — and this applies to a finding you were going to *mention* in a PR body too.
+
+Match the repo's commit conventions exactly: Conventional Commits type and scope, sign-off, signature, and any attribution trailer their `CONTRIBUTING.md` requires. A commit-message linter is a pre-commit hook in many repos and will reject the message locally before CI ever sees it.
+
 ## PR Lifecycle
 
 ### States


### PR DESCRIPTION
## Summary

Adds a "Contributing to a Repo You Do Not Own" section: run the target repo's own `CONTRIBUTING.md` gate in full before opening the PR, and read its `SECURITY.md` before filing anything security-flavoured in public.

## Came from

`/retro` session on 2026-08-07: `3b2909e2-2cc1-4876-a6d4-76ec690cc48d`
Finding: A6 — user correction ("ensure you are following CONTRIBUTING.md").

- **Symptom:** A PR was opened against an external repo after running our habitual gate rather than theirs. The user had to ask for their checklist to be followed.
- **Cause:** This reference assumes a repo whose conventions are already ours, so "run the gate" resolves to the familiar one. Running the target's checklist afterwards found a real CI blocker that the habitual gate could not have caught: the repo runs cspell with `incremental_files_only: true`, so it checks exactly the changed files, and a domain term missing from the project word list would have failed the build on a documentation change. The analyzer had also been run against one package instead of the whole tree.
- **Required behavior:** Fetch and read the target's `CONTRIBUTING.md`, run every item in it, and treat the whole-tree analyzer and the spell checker as the two most likely to be skipped and to fail. Check `SECURITY.md` before filing a security-flavoured issue publicly. Match their commit conventions exactly, since a message linter usually rejects locally before CI sees it.
- **Verification:** No `evals/` entry added — documentation change. Both named failure modes were observed in the session that produced the finding; running the target's gate is what surfaced them before review.

## Change

`references/pull-request-workflow.md` — new "Contributing to a Repo You Do Not Own" section immediately before "PR Lifecycle", covering: the `gh api … CONTRIBUTING.md` fetch, the whole-tree analyzer, the incremental spell checker and the instruction to extend the project word list with the repo's own tooling rather than reword around it, `SECURITY.md` routing for vulnerability reports, and commit-convention matching.

`SKILL.md` untouched (483 words).

## Test plan

- [ ] `SKILL.md` still 483 words, under the 500-word cap
- [ ] The `gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' | base64 -d` command runs as written
- [ ] Section placement reads sensibly against the surrounding PR-lifecycle material
