### PR TITLE
fix(pr-status): a failed Copilot review no longer counts as a review

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,14 @@ jobs:
             bash "$t"
             echo "::endgroup::"
           done
+      # The Python tests here are standalone scripts with a main() and a
+      # non-zero exit on failure ("Run: python3 tests/<file>"), not pytest
+      # modules — pytest collects nothing from them and exits 5.
       - name: Python tests
         run: |
           shopt -s nullglob
-          files=(tests/*.py)
-          if [ ${#files[@]} -gt 0 ]; then
-            pipx run pytest tests/ -q
-          fi
+          for t in tests/*.py; do
+            echo "::group::$t"
+            python3 "$t"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,19 @@ jobs:
           # Nothing after checkout talks to the remote; leaving the token in
           # .git/config only exposes it to later steps and artifacts.
           persist-credentials: false
+      # Every loop below asserts it matched something. With nullglob a moved or
+      # renamed tests/ directory makes the glob expand to nothing and the job
+      # goes green having run zero tests — the failure this workflow exists to
+      # prevent, wearing a passing check.
       - name: Shell tests
         run: |
-          shopt -s nullglob
-          for t in tests/*.sh; do
+          shopt -s nullglob globstar
+          files=(tests/**/*.sh)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no shell tests matched tests/**/*.sh — did the suite move?"
+            exit 1
+          fi
+          for t in "${files[@]}"; do
             echo "::group::$t"
             bash "$t"
             echo "::endgroup::"
@@ -36,8 +45,13 @@ jobs:
       # modules — pytest collects nothing from them and exits 5.
       - name: Python tests
         run: |
-          shopt -s nullglob
-          for t in tests/*.py; do
+          shopt -s nullglob globstar
+          files=(tests/**/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no python tests matched tests/**/*.py — did the suite move?"
+            exit 1
+          fi
+          for t in "${files[@]}"; do
             echo "::group::$t"
             python3 "$t"
             echo "::endgroup::"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # Nothing after checkout talks to the remote; leaving the token in
+          # .git/config only exposes it to later steps and artifacts.
+          persist-credentials: false
       - name: Shell tests
         run: |
           shopt -s nullglob

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+# The repo's other workflows are thin callers of reusables; none of them ran
+# anything under tests/, so the test files were never executed on a PR. A test
+# nothing runs is not a gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  tests:
+    name: Test suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - name: Shell tests
+        run: |
+          shopt -s nullglob
+          for t in tests/*.sh; do
+            echo "::group::$t"
+            bash "$t"
+            echo "::endgroup::"
+          done
+      - name: Python tests
+        run: |
+          shopt -s nullglob
+          files=(tests/*.py)
+          if [ ${#files[@]} -gt 0 ]; then
+            pipx run pytest tests/ -q
+          fi

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -70,6 +70,31 @@ A force-push invalidates a prior review: the old review stays attached to the
 old commit, so a repo with a `copilot_code_review` rule goes back to BLOCKED
 and needs a fresh request against the new head.
 
+#### A failed Copilot review looks exactly like a delivered one
+
+Copilot reports its own failures *as a review* — a normal `COMMENTED` row whose
+body is the error:
+
+```text
+Copilot encountered an error and was unable to review this pull request.
+Copilot was unable to review this pull request because the user who requested
+the review has reached their quota limit.
+```
+
+Nothing in the review's `state` distinguishes that from a real review, so
+"a review exists on the head" is not the same as "this PR was reviewed".
+`pr-status.sh` detects it and reports `copilot_review_errored: true` with
+`NEXT: request-review`; by hand, read the review **body**, not just its state.
+
+The failure is also a failing `copilot-pull-request-reviewer` check-run — but
+only in the REST `check-runs` API. It is **absent from GraphQL
+`statusCheckRollup`**, so a rollup-based check cannot see it.
+
+Re-request once. If it fails a second time, stop retrying and **review it
+yourself**: an outage may clear, but a quota ceiling does not clear by asking
+again, and the alternatives — merging unreviewed or waiting indefinitely on
+third-party infrastructure — are both worse than a self-review that says so.
+
 ## Check the Default Branch Before Operating
 
 Not every repo uses `main` — older repos often use `master`, and some use

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -19,8 +19,10 @@ head, and the repository's allowed merge methods.
 ```
 
 Two API calls, and the output ends in a computed `NEXT:` — rebase, fix-ci,
-triage-ci, resolve-threads, request-review, wait, or merge (with the method
-this repo actually allows and a warning when a merge queue is active). The
+triage-ci, resolve-threads, request-review, review-yourself, wait, or merge
+(with the method this repo actually allows and a warning when a merge queue is
+active). `review-yourself` means the bot reviewer failed twice and you are the
+fallback — see "A failed Copilot review looks exactly like a delivered one". The
 JSON form carries each unresolved thread's `threadId` *and* `commentId`, which
 is everything needed to reply and resolve without another query.
 
@@ -83,8 +85,9 @@ the review has reached their quota limit.
 
 Nothing in the review's `state` distinguishes that from a real review, so
 "a review exists on the head" is not the same as "this PR was reviewed".
-`pr-status.sh` detects it and reports `copilot_review_errored: true` with
-`NEXT: request-review`; by hand, read the review **body**, not just its state.
+`pr-status.sh` detects it and reports `copilot_review_errored: true`: the first
+failure on a head yields `NEXT: request-review`, the second `NEXT:
+review-yourself`. By hand, read the review **body**, not just its state.
 
 The failure is also a failing `copilot-pull-request-reviewer` check-run — but
 only in the REST `check-runs` API. It is **absent from GraphQL

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -102,6 +102,13 @@ collect() {
 evaluate() {
   local gql="$1" rules="$2" ok="$3"
   jq -n --argjson g "$gql" --argjson r "$rules" --argjson ok "$ok" '
+    # Defined once and used by BOTH the error list and the $head_reviews filter.
+    # Two hand-kept copies would have to stay byte-identical: loosening one to
+    # match a third error body and not the other puts the row back into
+    # $head_reviews, which is exactly the merge-on-an-unread-PR bug again.
+    def is_errored_copilot_review:
+      (.author.login | test("copilot"; "i"))
+      and ((.body // "") | test("^Copilot\\b.*unable to review"; "i"));
     ($g.data.repository) as $repo
     | ($repo.pullRequest) as $p
     | ($p.commits.nodes[0].commit.oid) as $head
@@ -148,16 +155,13 @@ evaluate() {
     # that one is absent from GraphQL statusCheckRollup (it is only in the REST
     # check-runs API), so $checks cannot see it and using it would cost a third
     # API call.
-    | (def errored: (.author.login | test("copilot"; "i"))
-                    and ((.body // "") | test("^Copilot\\b.*unable to review"; "i"));
-       [$reviews_raw[] | select(errored)]) as $copilot_errored
+    | ([$reviews_raw[] | select(is_errored_copilot_review)]) as $copilot_errored
     | (($copilot_errored | length) > 0) as $copilot_review_errored
     # Drop the errored rows from $head_reviews itself, not just from the Copilot
     # view: has_review_on_head feeds the generic "no review on the current head"
     # gate, so filtering only the Copilot list would leave every repo WITHOUT
     # the copilot_code_review ruleset still merging on an error row.
-    | ([$reviews_raw[] | select(((.author.login | test("copilot"; "i"))
-          and ((.body // "") | test("^Copilot\\b.*unable to review"; "i"))) | not)]) as $head_reviews
+    | ([$reviews_raw[] | select(is_errored_copilot_review | not)]) as $head_reviews
     | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))]) as $copilot_on_head
     | ([$p.reviewThreads.nodes[]? | select(.isResolved == false)]) as $unresolved
     | ($checks | map(select(.state=="FAIL"))) as $failing
@@ -281,6 +285,23 @@ evaluate() {
                     else "" end)
                  + " — the queue merges it once its own checks pass; enqueueing"
                  + " again only restarts them")}
+         # Two strikes -> stop asking the bot. Deliberately NOT gated on
+         # $needs_copilot: a repo without the ruleset reaches the generic
+         # "no review on head" branch below, whose cmd re-requests the very bot
+         # that just reported a quota ceiling, with no way out of the loop.
+         # `has_review_on_head|not` is what ends the escalation: once ANY valid
+         # review lands — the self-review this branch asks for, or a human one —
+         # the run falls through to merge. Without it the branch is a dead end
+         # that re-fires forever on the error rows, which never age off the head.
+         elif ($s.copilot_error_count >= 2
+               and ($s.has_review_on_head | not)
+               and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
+           {action:"review-yourself",
+            why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
+                 + " rows carry an error in the body, not a review. Do not re-request again:"
+                 + " an outage may clear, a quota ceiling does not clear by asking. Review the"
+                 + " diff yourself, say in the PR that the bot review was unavailable, and"
+                 + " merge on that.")}
          # `|` binds looser than `and`, so the negation needs its own parens:
          # `a and b|not` parses as `(a and b)|not` and inverts the whole test.
          # has_copilot_review_on_head must be false too: the error row stays on
@@ -289,21 +310,12 @@ evaluate() {
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           (if $s.copilot_error_count >= 2 then
-             {action:"review-yourself",
-              why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
-                   + " rows carry an error in the body, not a review. Do not re-request again:"
-                   + " an outage may clear, a quota ceiling does not clear by asking. Review the"
-                   + " diff yourself, say in the PR that the bot review was unavailable, and"
-                   + " merge on that.")}
-            else
-             {action:"request-review",
-              why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
-                   + " row carries an error in its body (an outage, or the requesting account is"
-                   + " out of quota), not a review. Re-request once; if it fails again this"
-                   + " turns into review-yourself rather than another retry."),
-              cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
-            end)
+           {action:"request-review",
+            why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
+                 + " row carries an error in its body (an outage, or the requesting account is"
+                 + " out of quota), not a review. Re-request once; if it fails again this"
+                 + " turns into review-yourself rather than another retry."),
+            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -135,7 +135,7 @@ evaluate() {
     # A review by the PR author is not a review. Replying to a thread registers
     # as COMMENTED by the author, which would otherwise satisfy the gate.
     | ([$p.reviews.nodes[]? | select(.commit.oid == $head)
-                           | select(.author.login != $author)]) as $head_reviews
+                           | select(.author.login != $author)]) as $reviews_raw
     # A Copilot review that FAILED still arrives as an ordinary COMMENTED row.
     # Counting it as a review reports NEXT=merge for a PR nothing has read —
     # the exact gate this script exists to close. Two observed bodies:
@@ -143,16 +143,22 @@ evaluate() {
     #   "Copilot was unable to review this pull request because the user who
     #    requested the review has reached their quota limit."
     # Both are matched by "starts with Copilot … unable to review", which a real
-    # review body does not. The same failure is ALSO a failing
-    # copilot-pull-request-reviewer check-run — but that one is absent from
-    # GraphQL statusCheckRollup (it is only in the REST check-runs API), so
-    # $checks cannot see it and using it would cost a third API call.
-    | ([$head_reviews[]
-        | select(.author.login | test("copilot"; "i"))
-        | select((.body // "") | test("^Copilot\\b.*unable to review"; "i"))]) as $copilot_errored
+    # review body does not (in jq, ^ anchors the string, not each line). The same
+    # failure is ALSO a failing copilot-pull-request-reviewer check-run — but
+    # that one is absent from GraphQL statusCheckRollup (it is only in the REST
+    # check-runs API), so $checks cannot see it and using it would cost a third
+    # API call.
+    | (def errored: (.author.login | test("copilot"; "i"))
+                    and ((.body // "") | test("^Copilot\\b.*unable to review"; "i"));
+       [$reviews_raw[] | select(errored)]) as $copilot_errored
     | (($copilot_errored | length) > 0) as $copilot_review_errored
-    | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))
-                        | select((.body // "") | test("^Copilot\\b.*unable to review"; "i") | not)]) as $copilot_on_head
+    # Drop the errored rows from $head_reviews itself, not just from the Copilot
+    # view: has_review_on_head feeds the generic "no review on the current head"
+    # gate, so filtering only the Copilot list would leave every repo WITHOUT
+    # the copilot_code_review ruleset still merging on an error row.
+    | ([$reviews_raw[] | select(((.author.login | test("copilot"; "i"))
+          and ((.body // "") | test("^Copilot\\b.*unable to review"; "i"))) | not)]) as $head_reviews
+    | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))]) as $copilot_on_head
     | ([$p.reviewThreads.nodes[]? | select(.isResolved == false)]) as $unresolved
     | ($checks | map(select(.state=="FAIL"))) as $failing
     | ($checks | map(select(.state=="QUEUED"))) as $queued
@@ -203,9 +209,11 @@ evaluate() {
         reviews_on_head: ($head_reviews|map({(.author.login): .state})|add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
         has_copilot_review_on_head: (($copilot_on_head|length) > 0),
-        # True when Copilot answered but every one of its check-runs failed —
-        # i.e. the review rows on this head carry an error, not a review.
+        # True when Copilot answered on this head with an error body rather than
+        # a review. Derived from the review body alone — see the comment above
+        # $copilot_errored for why the check-run is not consulted.
         copilot_review_errored: $copilot_review_errored,
+        copilot_error_count: ($copilot_errored|length),
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
@@ -275,15 +283,27 @@ evaluate() {
                  + " again only restarts them")}
          # `|` binds looser than `and`, so the negation needs its own parens:
          # `a and b|not` parses as `(a and b)|not` and inverts the whole test.
+         # has_copilot_review_on_head must be false too: the error row stays on
+         # the head forever, so without it a successful re-review would still
+         # report request-review and loop the operator.
          elif ($needs_copilot and $s.copilot_review_errored
+               and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           {action:"request-review",
-            why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — its check-run"
-                 + " concluded failure, so the COMMENTED row carries an error"
-                 + " (outage, or the requesting account is out of quota), not a review."
-                 + " Re-request once; if it fails again, review it yourself rather than"
-                 + " retrying — a quota ceiling does not clear by asking again."),
-            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+           (if $s.copilot_error_count >= 2 then
+             {action:"review-yourself",
+              why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
+                   + " rows carry an error in the body, not a review. Do not re-request again:"
+                   + " an outage may clear, a quota ceiling does not clear by asking. Review the"
+                   + " diff yourself, say in the PR that the bot review was unavailable, and"
+                   + " merge on that.")}
+            else
+             {action:"request-review",
+              why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
+                   + " row carries an error in its body (an outage, or the requesting account is"
+                   + " out of quota), not a review. Re-request once; if it fails again this"
+                   + " turns into review-yourself rather than another retry."),
+              cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+            end)
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
@@ -442,7 +462,7 @@ while :; do
     emit "$s"; exit 0
   fi
   case "$act" in
-    fix-ci|triage-ci|resolve-threads|request-review|rebase|resolve-conflicts|merge|blocked|none)
+    fix-ci|triage-ci|resolve-threads|request-review|review-yourself|rebase|resolve-conflicts|merge|blocked|none)
       echo "ACTIONABLE: $act"
       emit "$s"; exit 0 ;;
   esac

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -71,7 +71,7 @@ collect() {
         mergeQueueEntry{ state position estimatedTimeToMerge }
         author{login}
         baseRefName headRefName headRefOid isCrossRepository
-        reviews(last:50){ nodes{ author{login} state commit{oid} } }
+        reviews(last:50){ nodes{ author{login} state commit{oid} body } }
         reviewRequests(first:20){ nodes{ requestedReviewer{
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
         reviewThreads(first:100){ nodes{ id isResolved isOutdated
@@ -136,7 +136,23 @@ evaluate() {
     # as COMMENTED by the author, which would otherwise satisfy the gate.
     | ([$p.reviews.nodes[]? | select(.commit.oid == $head)
                            | select(.author.login != $author)]) as $head_reviews
-    | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))]) as $copilot_on_head
+    # A Copilot review that FAILED still arrives as an ordinary COMMENTED row.
+    # Counting it as a review reports NEXT=merge for a PR nothing has read —
+    # the exact gate this script exists to close. Two observed bodies:
+    #   "Copilot encountered an error and was unable to review this pull request."
+    #   "Copilot was unable to review this pull request because the user who
+    #    requested the review has reached their quota limit."
+    # Both are matched by "starts with Copilot … unable to review", which a real
+    # review body does not. The same failure is ALSO a failing
+    # copilot-pull-request-reviewer check-run — but that one is absent from
+    # GraphQL statusCheckRollup (it is only in the REST check-runs API), so
+    # $checks cannot see it and using it would cost a third API call.
+    | ([$head_reviews[]
+        | select(.author.login | test("copilot"; "i"))
+        | select((.body // "") | test("^Copilot\\b.*unable to review"; "i"))]) as $copilot_errored
+    | (($copilot_errored | length) > 0) as $copilot_review_errored
+    | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))
+                        | select((.body // "") | test("^Copilot\\b.*unable to review"; "i") | not)]) as $copilot_on_head
     | ([$p.reviewThreads.nodes[]? | select(.isResolved == false)]) as $unresolved
     | ($checks | map(select(.state=="FAIL"))) as $failing
     | ($checks | map(select(.state=="QUEUED"))) as $queued
@@ -187,6 +203,9 @@ evaluate() {
         reviews_on_head: ($head_reviews|map({(.author.login): .state})|add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
         has_copilot_review_on_head: (($copilot_on_head|length) > 0),
+        # True when Copilot answered but every one of its check-runs failed —
+        # i.e. the review rows on this head carry an error, not a review.
+        copilot_review_errored: $copilot_review_errored,
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
@@ -254,6 +273,17 @@ evaluate() {
                     else "" end)
                  + " — the queue merges it once its own checks pass; enqueueing"
                  + " again only restarts them")}
+         # `|` binds looser than `and`, so the negation needs its own parens:
+         # `a and b|not` parses as `(a and b)|not` and inverts the whole test.
+         elif ($needs_copilot and $s.copilot_review_errored
+               and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
+           {action:"request-review",
+            why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — its check-run"
+                 + " concluded failure, so the COMMENTED row carries an error"
+                 + " (outage, or the requesting account is out of quota), not a review."
+                 + " Re-request once; if it fails again, review it yourself rather than"
+                 + " retrying — a quota ceiling does not clear by asking again."),
+            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -14,6 +14,10 @@ SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scr
 STUB_DIR="$(mktemp -d)"
 trap 'rm -rf "$STUB_DIR"' EXIT
 
+ERR_GENERIC="Copilot encountered an error and was unable to review this pull request. You can try again by re-requesting a review."
+ERR_QUOTA="Copilot was unable to review this pull request because the user who requested the review has reached their quota limit."
+REAL_REVIEW="Pull request review complete. Two suggestions below, neither blocking."
+
 fail=0
 check() { # check <name> <expected> <actual>
     if [ "$2" = "$3" ]; then
@@ -24,77 +28,107 @@ check() { # check <name> <expected> <actual>
     fi
 }
 
-# Build a stub `gh` whose graphql reply carries one Copilot review with the
-# given body, everything else clean and mergeable.
-make_stub() { # make_stub <review-body>
-    cat > "$STUB_DIR/gh" <<STUB
+# Stub `gh`: rules endpoint answers $RULES_JSON, graphql answers a payload built
+# from the review bodies passed in. Bodies never pass through shell quoting.
+#   make_stub <body>...                 — repo HAS the copilot_code_review ruleset
+#   RULES_JSON='[]' make_stub <body>... — repo has NO ruleset
+make_stub() {
+    # Assigned in a branch, not via ${VAR:-default}: a literal } inside the
+    # default value closes the parameter expansion early and mangles the JSON.
+    local rules
+    if [ -n "${RULES_JSON:-}" ]; then
+        rules="$RULES_JSON"
+    else
+        rules='[{"type":"copilot_code_review","parameters":{}}]'
+    fi
+    printf '%s\n' "$rules" > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
-# args: api graphql ... | api repos/<r>/rules/branches/<b>
-for a in "\$@"; do
-  case "\$a" in
-    graphql) GQL=1 ;;
-    repos/*/rules/branches/*) RULES=1 ;;
+for a in "$@"; do
+  case "$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
   esac
 done
-if [ -n "\${RULES:-}" ]; then
-  echo '[{"type":"copilot_code_review","parameters":{}}]'
-  exit 0
-fi
-cat <<'JSON'
-{"data":{"repository":{
-  "mergeCommitAllowed":true,"rebaseMergeAllowed":false,"squashMergeAllowed":false,
-  "pullRequest":{
-    "number":1,"title":"t","state":"OPEN","isDraft":false,
-    "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,
-    "author":{"login":"someone"},
-    "baseRefName":"main","headRefName":"f","headRefOid":"deadbeefcafe","isCrossRepository":false,
-    "reviews":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},
-                         "state":"COMMENTED","commit":{"oid":"deadbeefcafe"},
-                         "body":"__BODY__"}]},
-    "reviewRequests":{"nodes":[]},
-    "reviewThreads":{"nodes":[]},
-    "commits":{"nodes":[{"commit":{"oid":"deadbeefcafe",
-      "statusCheckRollup":{"state":"SUCCESS","contexts":{"nodes":[
-        {"__typename":"CheckRun","name":"CI","conclusion":"SUCCESS","status":"COMPLETED",
-         "detailsUrl":"u","startedAt":"2026-01-01T00:00:00Z"}]}}}}]},
-    "allCommits":{"nodes":[{"commit":{"oid":"deadbeefcafe","signature":{"isValid":true}}}]}
-  }}}}
-JSON
+cat "$STUB_DIR/graphql.json"
 STUB
-    # Substitute the body without letting quoting reach the heredoc above.
-    python3 - "$STUB_DIR/gh" "$1" <<'PY'
-import sys, json
-p, body = sys.argv[1], sys.argv[2]
-s = open(p).read().replace('__BODY__', json.dumps(body)[1:-1])
-open(p, 'w').write(s)
-PY
+    sed -i "s|\$STUB_DIR|$STUB_DIR|g" "$STUB_DIR/gh"
     chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" "$@" <<'PY'
+import sys, json
+out, bodies = sys.argv[1], sys.argv[2:]
+head = "deadbeefcafe"
+reviews = [{"author": {"login": "copilot-pull-request-reviewer"},
+            "state": "COMMENTED", "commit": {"oid": head}, "body": b}
+           for b in bodies]
+json.dump({"data": {"repository": {
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "reviewDecision": None,
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": reviews},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS", "contexts": {"nodes": [
+                {"__typename": "CheckRun", "name": "CI", "conclusion": "SUCCESS",
+                 "status": "COMPLETED", "detailsUrl": "u",
+                 "startedAt": "2026-01-01T00:00:00Z"}]}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
 }
 
-run_next() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json | jq -r '.next.action'; }
-run_flag() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json | jq -r ".$1"; }
+status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json; }
+run_next() { status | jq -r '.next.action'; }
+run_flag() { status | jq -r ".$1"; }
 
 echo "case 1: Copilot errored (generic failure) — must NOT count as a review"
-make_stub "Copilot encountered an error and was unable to review this pull request. You can try again by re-requesting a review."
+make_stub "$ERR_GENERIC"
 check "copilot_review_errored"     "true"           "$(run_flag copilot_review_errored)"
 check "has_copilot_review_on_head" "false"          "$(run_flag has_copilot_review_on_head)"
 check "next.action"                "request-review" "$(run_next)"
 
 echo "case 2: Copilot errored (quota exhausted) — same"
-make_stub "Copilot was unable to review this pull request because the user who requested the review has reached their quota limit."
+make_stub "$ERR_QUOTA"
 check "copilot_review_errored"     "true"           "$(run_flag copilot_review_errored)"
 check "next.action"                "request-review" "$(run_next)"
 
 echo "case 3: a real Copilot review — still counts, gate opens"
-make_stub "Pull request review complete. Two suggestions below, neither blocking."
+make_stub "$REAL_REVIEW"
 check "copilot_review_errored"     "false"          "$(run_flag copilot_review_errored)"
 check "has_copilot_review_on_head" "true"           "$(run_flag has_copilot_review_on_head)"
 check "next.action"                "merge"          "$(run_next)"
 
-echo "case 4: a real review that merely mentions the phrase mid-sentence — counts"
+echo "case 4: a real review merely containing the phrase mid-sentence — counts"
 make_stub "I was unable to review the generated fixtures, but the rest looks fine."
 check "copilot_review_errored"     "false"          "$(run_flag copilot_review_errored)"
 check "next.action"                "merge"          "$(run_next)"
+
+# The filter must apply to has_review_on_head, not only to the Copilot view.
+# Otherwise a repo without the ruleset never reaches the Copilot branches and
+# falls through to "merge — clean" on an error row.
+echo "case 5: NO copilot ruleset + error row — generic review gate must still hold"
+RULES_JSON='[]' make_stub "$ERR_GENERIC"
+check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
+check "next.action"        "request-review" "$(run_next)"
+
+# The error row stays on the head forever. Without checking that no valid review
+# landed, the recovery path (error -> re-request -> success) loops on
+# request-review.
+echo "case 6: error row + later successful review on same head — gate opens"
+make_stub "$ERR_GENERIC" "$REAL_REVIEW"
+check "copilot_review_errored"     "true"  "$(run_flag copilot_review_errored)"
+check "has_copilot_review_on_head" "true"  "$(run_flag has_copilot_review_on_head)"
+check "next.action"                "merge" "$(run_next)"
+
+echo "case 7: two errors — stop retrying, say review it yourself"
+make_stub "$ERR_GENERIC" "$ERR_QUOTA"
+check "copilot_error_count" "2"               "$(run_flag copilot_error_count)"
+check "next.action"         "review-yourself" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression test: a FAILED Copilot review must not count as a review.
+#
+# Copilot answers a failed review as an ordinary COMMENTED row ("Copilot
+# encountered an error and was unable to review…", "…reached their quota
+# limit"). Before the fix, pr-status.sh counted any Copilot review row on the
+# head as a review and reported NEXT=merge for a PR nothing had read.
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+# Build a stub `gh` whose graphql reply carries one Copilot review with the
+# given body, everything else clean and mergeable.
+make_stub() { # make_stub <review-body>
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+# args: api graphql ... | api repos/<r>/rules/branches/<b>
+for a in "\$@"; do
+  case "\$a" in
+    graphql) GQL=1 ;;
+    repos/*/rules/branches/*) RULES=1 ;;
+  esac
+done
+if [ -n "\${RULES:-}" ]; then
+  echo '[{"type":"copilot_code_review","parameters":{}}]'
+  exit 0
+fi
+cat <<'JSON'
+{"data":{"repository":{
+  "mergeCommitAllowed":true,"rebaseMergeAllowed":false,"squashMergeAllowed":false,
+  "pullRequest":{
+    "number":1,"title":"t","state":"OPEN","isDraft":false,
+    "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,
+    "author":{"login":"someone"},
+    "baseRefName":"main","headRefName":"f","headRefOid":"deadbeefcafe","isCrossRepository":false,
+    "reviews":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},
+                         "state":"COMMENTED","commit":{"oid":"deadbeefcafe"},
+                         "body":"__BODY__"}]},
+    "reviewRequests":{"nodes":[]},
+    "reviewThreads":{"nodes":[]},
+    "commits":{"nodes":[{"commit":{"oid":"deadbeefcafe",
+      "statusCheckRollup":{"state":"SUCCESS","contexts":{"nodes":[
+        {"__typename":"CheckRun","name":"CI","conclusion":"SUCCESS","status":"COMPLETED",
+         "detailsUrl":"u","startedAt":"2026-01-01T00:00:00Z"}]}}}}]},
+    "allCommits":{"nodes":[{"commit":{"oid":"deadbeefcafe","signature":{"isValid":true}}}]}
+  }}}}
+JSON
+STUB
+    # Substitute the body without letting quoting reach the heredoc above.
+    python3 - "$STUB_DIR/gh" "$1" <<'PY'
+import sys, json
+p, body = sys.argv[1], sys.argv[2]
+s = open(p).read().replace('__BODY__', json.dumps(body)[1:-1])
+open(p, 'w').write(s)
+PY
+    chmod +x "$STUB_DIR/gh"
+}
+
+run_next() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json | jq -r '.next.action'; }
+run_flag() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json | jq -r ".$1"; }
+
+echo "case 1: Copilot errored (generic failure) — must NOT count as a review"
+make_stub "Copilot encountered an error and was unable to review this pull request. You can try again by re-requesting a review."
+check "copilot_review_errored"     "true"           "$(run_flag copilot_review_errored)"
+check "has_copilot_review_on_head" "false"          "$(run_flag has_copilot_review_on_head)"
+check "next.action"                "request-review" "$(run_next)"
+
+echo "case 2: Copilot errored (quota exhausted) — same"
+make_stub "Copilot was unable to review this pull request because the user who requested the review has reached their quota limit."
+check "copilot_review_errored"     "true"           "$(run_flag copilot_review_errored)"
+check "next.action"                "request-review" "$(run_next)"
+
+echo "case 3: a real Copilot review — still counts, gate opens"
+make_stub "Pull request review complete. Two suggestions below, neither blocking."
+check "copilot_review_errored"     "false"          "$(run_flag copilot_review_errored)"
+check "has_copilot_review_on_head" "true"           "$(run_flag has_copilot_review_on_head)"
+check "next.action"                "merge"          "$(run_next)"
+
+echo "case 4: a real review that merely mentions the phrase mid-sentence — counts"
+make_stub "I was unable to review the generated fixtures, but the rest looks fine."
+check "copilot_review_errored"     "false"          "$(run_flag copilot_review_errored)"
+check "next.action"                "merge"          "$(run_next)"
+
+if [ "$fail" -eq 0 ]; then
+    echo "all pass"
+else
+    echo "FAILURES"
+    exit 1
+fi

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -82,6 +82,61 @@ json.dump({"data": {"repository": {
 PY
 }
 
+# Same stub, but each arg is "author|state|body" so a case can mix a Copilot
+# error row with a human review on the same head.
+make_stub_reviews() {
+    local rules
+    if [ -n "${RULES_JSON:-}" ]; then
+        rules="$RULES_JSON"
+    else
+        rules='[{"type":"copilot_code_review","parameters":{}}]'
+    fi
+    printf '%s\n' "$rules" > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+    sed -i "s|\$STUB_DIR|$STUB_DIR|g" "$STUB_DIR/gh"
+    chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" "$@" <<'PY'
+import sys, json
+out, specs = sys.argv[1], sys.argv[2:]
+head = "deadbeefcafe"
+reviews = []
+approved = False
+for s in specs:
+    who, state, body = s.split("|", 2)
+    reviews.append({"author": {"login": who}, "state": state,
+                    "commit": {"oid": head}, "body": body})
+    approved = approved or state == "APPROVED"
+json.dump({"data": {"repository": {
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+        "reviewDecision": ("APPROVED" if approved else None),
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": reviews},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS", "contexts": {"nodes": [
+                {"__typename": "CheckRun", "name": "CI", "conclusion": "SUCCESS",
+                 "status": "COMPLETED", "detailsUrl": "u",
+                 "startedAt": "2026-01-01T00:00:00Z"}]}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
+}
+
 status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json; }
 run_next() { status | jq -r '.next.action'; }
 run_flag() { status | jq -r ".$1"; }
@@ -129,6 +184,42 @@ echo "case 7: two errors — stop retrying, say review it yourself"
 make_stub "$ERR_GENERIC" "$ERR_QUOTA"
 check "copilot_error_count" "2"               "$(run_flag copilot_error_count)"
 check "next.action"         "review-yourself" "$(run_next)"
+
+# review-yourself has to be an instruction you can carry out, not a state you
+# cannot leave: the error rows never age off the head, so without a
+# has_review_on_head guard the branch re-fires forever and the gate never opens
+# again — including after a human approves.
+echo "case 8a: two errors + human review, ruleset active — escalation must end"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "a-human|APPROVED|LGTM"
+check "copilot_error_count" "2"    "$(run_flag copilot_error_count)"
+check "has_review_on_head"  "true" "$(run_flag has_review_on_head)"
+# Not asserting "merge": with the ruleset active the script asks for a COPILOT
+# review specifically, human approval or not. That predates this PR and is not
+# ours to change here. What must hold is that review-yourself has stopped
+# re-firing — otherwise the action is unreachable-by-design.
+if [ "$(run_next)" = "review-yourself" ]; then
+    echo "  FAIL next.action: still review-yourself after a review landed"
+    fail=1
+else
+    echo "  ok   next.action left review-yourself ($(run_next))"
+fi
+
+echo "case 8b: same without the ruleset — generic gate satisfied, merge"
+RULES_JSON='[]' make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "a-human|APPROVED|LGTM"
+check "next.action" "merge" "$(run_next)"
+
+# Without the ruleset the flow lands on the generic "no review on head" branch,
+# whose cmd re-requests the bot that just reported a quota ceiling. The
+# escalation must not be gated behind the ruleset.
+echo "case 9: NO ruleset + two errors — must escalate, not loop on request-review"
+RULES_JSON='[]' make_stub "$ERR_GENERIC" "$ERR_QUOTA"
+check "next.action" "review-yourself" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"


### PR DESCRIPTION
## Summary

`pr-status.sh` reported `NEXT: merge` for a pull request nothing had reviewed, because a **failed** Copilot review is delivered as an ordinary `COMMENTED` review row.

## Came from

`/retro` session on 2026-08-06/07.

- **Symptom:** across `netresearch/peer-qa-review-skill#40` and `netresearch/jira-skill#180`, Copilot failed five times — twice each on a GitHub Actions outage, then on a quota limit. Every failure produced a review row, and `pr-status.sh` reported `ACTIONABLE: merge` throughout. Acting on it would have merged both PRs as "reviewed".
- **Cause:** `has_copilot_review_on_head` was true for *any* review on the head authored by `/copilot/i`. Nothing in a review's `state` separates "reviewed" from "could not review" — the distinction is only in the body.
- **Required behavior:** a review that carries an error is not a review; report `request-review`, not `merge`.
- **Verification:** `tests/test_pr_status_errored_review.sh`.

## Change

**`scripts/pr-status.sh`**

- `reviews(...)` gains `body` — one field, **no extra API call**.
- Copilot reviews whose body matches `^Copilot\b.*unable to review` are excluded from `$copilot_on_head`. Both observed failures share that shape:
  - `Copilot encountered an error and was unable to review this pull request.`
  - `Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.`
- New `copilot_review_errored` in the JSON.
- New `request-review` branch that states the review *failed* rather than that it never arrived, and warns that a second failure means reviewing it yourself — a quota ceiling does not clear by retrying.

**`references/pull-request-workflow.md`** — documents the trap under "Never merge an unreviewed PR", including the self-review fallback.

**`tests/test_pr_status_errored_review.sh`** — drives the real script against a stubbed `gh`; no network, no repo.

## Why the body and not the check-run

The failure is *also* a failing `copilot-pull-request-reviewer` check-run, which would be the more structural signal. I tried that first — it does not work here. That check-run is **absent from GraphQL `statusCheckRollup`** and exists only in the REST `check-runs` API, so `$checks` never contains it and the first draft could never fire. Verified against the live API on `befd07b4`:

```
statusCheckRollup → (no copilot entry)
GET /commits/befd07b4/check-runs → copilot-pull-request-reviewer completed/failure ×2
```

Using it would mean a third request, against a script whose stated cost is two. The reasoning is recorded in a comment so the next reader does not re-try the rollup.

## Test plan

- [x] `tests/test_pr_status_errored_review.sh` — 4 cases pass: both failure bodies → `request-review`; a real review → `merge`; a real review merely containing "unable to review" mid-sentence → `merge`
- [x] Re-run against the two live PRs: `copilot_review_errored=true`, `has_copilot_review_on_head=false` on both
- [x] `shellcheck` clean on both files; `markdownlint-cli2` 0 issues; `validate-skill.sh` 0 errors
- [x] SKILL.md untouched (483/500 words)

The mid-sentence case is not padding — it caught a jq precedence bug in the first draft. `a and b|not` parses as `(a and b)|not`, which inverted the whole condition and fired the new branch on every *healthy* review.

---

## Review round (02bec64)

Copilot hit its quota on this PR too, so per the fallback the review was done with `/code-review high` instead. It found five issues; all are fixed in `02bec64`.

**The first one defeated the fix.** The body filter was applied to `$copilot_on_head` but not to `$head_reviews`, so `has_review_on_head` stayed true on an error row. On a repo *without* the `copilot_code_review` ruleset, `$needs_copilot` is false, none of the Copilot branches fire, and the run still ended at `merge — clean` — the same failure, one branch over. The rows are now removed from `$head_reviews` itself.

| # | Sev | Issue | Fix |
|---|---|---|---|
| 1 | high | filter missed the generic review gate | drop errored rows from `$head_reviews` |
| 2 | med | error row is permanent → `request-review` loops after a successful re-review | also require `has_copilot_review_on_head == false` |
| 3 | low | JSON field comment described the abandoned check-run approach | rewritten |
| 4 | low | advice said "review it yourself" but the tool kept handing over the retry command | `copilot_error_count`; 2nd failure → new `review-yourself` action, actionable in `--watch` |
| 5 | low | nothing in CI ran `tests/` | `.github/workflows/tests.yml` |

Finding 5 is pre-existing — every workflow here is a thin caller of a reusable, so `tests/test_validate_git_command.py` from #150 had never run either. Both suites are gates now.

## Two bugs the new tests caught in my own work

Neither was visible in a diff read:

- An apostrophe in the comment `jq's ^ anchors…` **closed the single-quoted jq program** mid-script — every invocation died with a bash syntax error.
- `${RULES_JSON:-[{"type":…,"parameters":{}}]}` — the literal `}` in the default value **ends the parameter expansion early**, producing `[{"type":…,"parameters":{}]}` and an invalid-JSON failure.

## Test plan (updated)

- [x] 7 cases pass: both error bodies, a real review, a real review containing the phrase mid-sentence, **no-ruleset + error row**, **error-then-success on one head**, **two errors → `review-yourself`**
- [x] Live against this PR with the patched script: `errored=true count=1 has_review=false NEXT=request-review` — while the installed script says `NEXT: merge`
- [x] `shellcheck` clean, `markdownlint-cli2` 0 issues, `validate-skill.sh` 0 errors, SKILL.md untouched
- [x] `actions/checkout` pinned by SHA (org requires it); comment corrected to the tag the SHA actually is (v5.1.0)
