### PR TITLE
feat(pr-status): name the required checks that never reported

### DIFF
--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -125,6 +125,10 @@ evaluate() {
     # protection alone misses rulesets entirely.
     | ([$r[]? | select(.type=="required_status_checks")
         | .parameters.required_status_checks[]?.context]) as $required
+    # Required contexts with no check-run at all. A context that never
+    # reported is invisible on the PR page — the rollup only lists what ran —
+    # so this reads as BLOCKED with everything green.
+    | ([$required[] | select(. as $c | ($checks | map(.name) | index($c)) == null)]) as $undispatched
     | ([$r[]? | .type] | unique) as $ruletypes
     | (($ruletypes | index("copilot_code_review")) != null) as $needs_copilot
     | ($p.author.login) as $author
@@ -178,6 +182,7 @@ evaluate() {
         unsigned: [$p.allCommits.nodes[]?.commit
                    | select((.signature.isValid // false) | not)
                    | .oid[0:8]],
+        undispatched: $undispatched,
         rulesets: $ruletypes,
         reviews_on_head: ($head_reviews|map({(.author.login): .state})|add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
@@ -314,6 +319,22 @@ evaluate() {
             # SC2026 catches it, but only after the parse has already gone
             # wrong further down).
             cmd:"git rebase --exec \"git commit --amend --no-edit -S\" $(git merge-base HEAD origin/\($s.base)) ; git push --force-with-lease"}
+         # Same shape as fix-signatures above: a required context that never
+         # reported produces no red check and no rollup entry, so it used to
+         # end here as "investigate". Two causes, both mechanical: the
+         # workflows were never dispatched, or this is a fork PR whose runs
+         # sit at action_required and need approving once per push.
+         elif (($s.undispatched|length) > 0) then
+           {action:"await-checks",
+            why:("\($s.undispatched|length) required check(s) never reported — \($s.undispatched|join(", "))"
+                 + ". Nothing is red; they were never dispatched, or this is a fork PR"
+                 + " whose runs need approving (once per push)"),
+            # No single quotes: this jq program lives in a single-quoted
+            # shell string (same trap the fix-signatures cmd above notes).
+            cmd:("gh run list --repo \($s.repo) --branch \($s.head) --json databaseId,status,name"
+                 + " — then for each action_required id:"
+                 + " gh api -X POST repos/\($s.repo)/actions/runs/ID/approve."
+                 + " If none await approval, close+reopen the PR to re-fire the events")}
          else
            {action:"investigate", why:"mergeState=\($s.mergeState) with no failing check, no open thread and no missing review — check branch protection manually"}
          end)


### PR DESCRIPTION
## The dead end

`BLOCKED` with **no failing check, no open thread and no missing review** currently ends at `NEXT: investigate — check branch protection manually`.

That is the signature of a required context which **never reported at all**. The status rollup only lists checks that ran, so the PR page shows nothing but green — there is no red thing to look at, and `mergeStateStatus` alone never says which context is missing. Hit three times in one session — [t3x-nr-repurpose#70](https://github.com/netresearch/t3x-nr-repurpose/pull/70), [t3x-nr-mcp-agent#92](https://github.com/netresearch/t3x-nr-mcp-agent/pull/92), [t3x-cowriter#134](https://github.com/netresearch/t3x-cowriter/pull/134) — each answered by hand-diffing the ruleset's required contexts against the reported check-runs.

## Two causes, both mechanical

- **Workflows never dispatched.** Common after an Actions incident, or after a force-push during one. `gh run list` for the branch shows nothing at all. Close+reopen re-fires the `pull_request` events without adding a commit.
- **Fork PR awaiting approval.** Runs sit at `completed/action_required` and need approving **once per push**. Until then the PR shows a misleadingly small green set: cowriter#134 displayed **5 passing checks of 88**, and approving them immediately exposed a Rector failure and eight failing unit cells. A fork PR's green is not green until approved.

## The change

Both inputs were already collected — `$required` from the rules endpoint, `$checks` from the rollup — so the diff costs no extra API call. The verdict now names them:

> NEXT: await-checks — 7 required check(s) never reported — All security checks, CodeQL, Opengrep OSS, betterleaks, ci / All CI checks, scorecard, zizmor. Nothing is red; they were never dispatched, or this is a fork PR whose runs need approving (once per push)

`undispatched` is also exposed in `--json` next to the other check facts. This follows the `fix-signatures` precedent immediately above it, added for the same reason: a gate GitHub reports only as `mergeStateStatus`, with no red check to find.

## Verified

- the jq diff reproduces exactly the seven contexts hand-derived from repurpose#70 at the time
- no regression: merged PRs still answer `none — PR is MERGED`, and `undispatched` is `[]` on a clean PR
- `bash -n` clean — the `cmd` string deliberately carries no single quotes, the trap the neighbouring `fix-signatures` comment already documents
