### PR TITLE
fix(pr-status): drop the review-yourself action, keep the advice

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -84,9 +84,11 @@ the review has reached their quota limit.
 Nothing in the review's `state` distinguishes that from a real review, so
 "a review exists on the head" is not the same as "this PR was reviewed".
 `pr-status.sh` detects it and reports `copilot_review_errored: true` with
-`NEXT: request-review` and a `copilot_error_count`; from the second failure on a
-head it drops the retry command and tells you to review it yourself. By hand,
-read the review **body**, not just its state.
+`NEXT: request-review` and a `copilot_error_count`. From the second failure on a
+head it drops the retry command and tells you to review it yourself — in every
+repo, with or without the `copilot_code_review` ruleset, since the generic
+review gate re-requests the same bot. By hand, read the review **body**, not
+just its state.
 
 The action stays `request-review` even then, deliberately. The tool cannot
 observe that a human read the diff — a review by the PR author is excluded from

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -19,10 +19,8 @@ head, and the repository's allowed merge methods.
 ```
 
 Two API calls, and the output ends in a computed `NEXT:` — rebase, fix-ci,
-triage-ci, resolve-threads, request-review, review-yourself, wait, or merge
-(with the method this repo actually allows and a warning when a merge queue is
-active). `review-yourself` means the bot reviewer failed twice and you are the
-fallback — see "A failed Copilot review looks exactly like a delivered one". The
+triage-ci, resolve-threads, request-review, wait, or merge (with the method
+this repo actually allows and a warning when a merge queue is active). The
 JSON form carries each unresolved thread's `threadId` *and* `commentId`, which
 is everything needed to reply and resolve without another query.
 
@@ -85,9 +83,16 @@ the review has reached their quota limit.
 
 Nothing in the review's `state` distinguishes that from a real review, so
 "a review exists on the head" is not the same as "this PR was reviewed".
-`pr-status.sh` detects it and reports `copilot_review_errored: true`: the first
-failure on a head yields `NEXT: request-review`, the second `NEXT:
-review-yourself`. By hand, read the review **body**, not just its state.
+`pr-status.sh` detects it and reports `copilot_review_errored: true` with
+`NEXT: request-review` and a `copilot_error_count`; from the second failure on a
+head it drops the retry command and tells you to review it yourself. By hand,
+read the review **body**, not just its state.
+
+The action stays `request-review` even then, deliberately. The tool cannot
+observe that a human read the diff — a review by the PR author is excluded from
+the review gate by design — so a distinct "you are done now" action would be one
+nothing could ever satisfy, and it would re-fire forever on the operator it was
+written for.
 
 The failure is also a failing `copilot-pull-request-reviewer` check-run — but
 only in the REST `check-runs` API. It is **absent from GraphQL

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -210,7 +210,16 @@ evaluate() {
                    | .oid[0:8]],
         undispatched: $undispatched,
         rulesets: $ruletypes,
-        reviews_on_head: ($head_reviews|map({(.author.login): .state})|add // {}),
+        # Every distinct state per author, not just the last one. `add` over
+        # map({login: state}) overwrites, so a reviewer who approves and then
+        # replies to a thread displayed as COMMENTED and the approval vanished
+        # from the only surface that shows it — beside decision=APPROVED, which
+        # then reads as an approval on an older commit. Shape is unchanged
+        # (login -> string) so consumers indexing by login still work.
+        reviews_on_head: ($head_reviews
+                          | group_by(.author.login)
+                          | map({(.[0].author.login): (map(.state)|unique|join("+"))})
+                          | add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
         has_copilot_review_on_head: (($copilot_on_head|length) > 0),
         # True when Copilot answered on this head with an error body rather than

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -326,12 +326,27 @@ evaluate() {
            {action:"request-review", why:"copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — a push invalidates the previous review, it stays on the old commit",
             cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
          elif ($s.has_review_on_head|not) then
-           {action:"request-review",
-            why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed"
-                 + (if $s.reviewDecision == "APPROVED"
-                    then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
-                    else "" end)),
-            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+           # The generic gate is also reached by repos WITHOUT the
+           # copilot_code_review ruleset, and its cmd re-requests Copilot. Once
+           # Copilot has failed twice on this head, handing that command back
+           # is an unbounded loop: the retry errors, no review lands, the same
+           # cmd is offered again. The two-strikes suppression therefore lives
+           # here as well as in the ruleset branch above — it must not be gated
+           # on $needs_copilot.
+           (if $s.copilot_error_count >= 2 then
+             {action:"request-review",
+              why:("no review on the current head (\($s.headOid[0:8])) — and Copilot failed"
+                   + " \($s.copilot_error_count)x on it, so its rows carry an error rather than"
+                   + " a review. Do not keep re-requesting: an outage may clear, a quota ceiling"
+                   + " does not clear by asking. Review the diff yourself and decide on that.")}
+            else
+             {action:"request-review",
+              why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed"
+                   + (if $s.reviewDecision == "APPROVED"
+                      then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
+                      else "" end)),
+              cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+            end)
          # A required check that is QUEUED with nothing running is not "CI is
          # slow" — no runner has picked it up. It is reported separately
          # because the answer differs: waiting is right for a running check,

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -244,6 +244,12 @@ evaluate() {
       }
     # ---- next valid action, highest-priority first -------------------------
     | . as $s
+    # Bound once: two branches below suppress the retry command on it (the
+    # ruleset one and the generic one). As two hand-kept copies, raising the
+    # threshold in one place only would quietly restore the unbounded
+    # re-request loop in the other — the same trap `is_errored_copilot_review`
+    # is factored out to avoid.
+    | ($s.copilot_error_count >= 2) as $copilot_exhausted
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -303,7 +309,7 @@ evaluate() {
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           (if $s.copilot_error_count >= 2 then
+           (if $copilot_exhausted then
              {action:"request-review",
               why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
                    + " rows carry an error in the body, not a review. Do not keep re-requesting:"
@@ -333,20 +339,27 @@ evaluate() {
            # cmd is offered again. The two-strikes suppression therefore lives
            # here as well as in the ruleset branch above — it must not be gated
            # on $needs_copilot.
-           (if $s.copilot_error_count >= 2 then
-             {action:"request-review",
-              why:("no review on the current head (\($s.headOid[0:8])) — and Copilot failed"
-                   + " \($s.copilot_error_count)x on it, so its rows carry an error rather than"
-                   + " a review. Do not keep re-requesting: an outage may clear, a quota ceiling"
-                   + " does not clear by asking. Review the diff yourself and decide on that.")}
-            else
-             {action:"request-review",
-              why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed"
-                   + (if $s.reviewDecision == "APPROVED"
-                      then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
-                      else "" end)),
-              cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
-            end)
+           # The stale-APPROVED warning belongs on BOTH variants. It matters most
+           # in the exhausted one: render prints mergeState=CLEAN and
+           # decision=APPROVED directly above this line, so dropping "do not
+           # merge unreviewed" there reads as license to merge on a review that
+           # sits on an older commit.
+           ((if $s.reviewDecision == "APPROVED"
+             then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
+             else "" end)) as $stale_approval
+           | (if $copilot_exhausted then
+               {action:"request-review",
+                why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed."
+                     + " Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"
+                     + " rather than a review. Do not keep re-requesting: an outage may clear, a"
+                     + " quota ceiling does not clear by asking. Review the diff yourself and"
+                     + " decide on that\($stale_approval)")}
+              else
+               {action:"request-review",
+                why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed"
+                     + $stale_approval),
+                cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+              end)
          # A required check that is QUEUED with nothing running is not "CI is
          # slow" — no runner has picked it up. It is reported separately
          # because the answer differs: waiting is right for a running check,

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -255,9 +255,17 @@ evaluate() {
     # active, has_copilot_review_on_head implies has_review_on_head, so the
     # generic branch is unreachable there — which is why fixing one of them
     # left the other silently unwarned.
-    | (if $s.reviewDecision == "APPROVED"
+    # Both conditions matter: an APPROVED decision only sits on an OLDER commit
+    # when nothing reviewed the current head. The copilot branch below is not
+    # gated on has_review_on_head, so without the second test this note fires on
+    # a current, valid approval and tells the operator to disregard it.
+    | (if ($s.reviewDecision == "APPROVED") and ($s.has_review_on_head | not)
        then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
        else "" end) as $stale_approval
+    # Same reason: only claim "nothing reviewed this head" when that is true.
+    | (if ($s.has_review_on_head | not)
+       then "no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed. "
+       else "" end) as $unreviewed
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -319,8 +327,8 @@ evaluate() {
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
            (if $copilot_exhausted then
              {action:"request-review",
-              why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed."
-                   + " Copilot failed \($s.copilot_error_count)x on it, so the COMMENTED rows"
+              why:($unreviewed
+                   + "Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]), so the COMMENTED rows"
                    + " carry an error in the body rather than a review. Do not keep"
                    + " re-requesting: an outage may clear, a quota ceiling does not clear by"
                    + " asking. Review the diff yourself, say in the PR that the bot review was"
@@ -329,10 +337,11 @@ evaluate() {
                    + " diff\($stale_approval)")}
             else
              {action:"request-review",
-              why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
+              why:($unreviewed
+                   + "Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
                    + " row carries an error in its body (an outage, or the requesting account is"
                    + " out of quota), not a review. Re-request once; if it fails again, review it"
-                   + " yourself rather than retrying."),
+                   + " yourself rather than retrying\($stale_approval)"),
               cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
             end)
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -216,14 +216,17 @@ evaluate() {
         # from the only surface that shows it — beside decision=APPROVED, which
         # then reads as an approval on an older commit. Shape is unchanged
         # (login -> string) so consumers indexing by login still work.
-        # Order-preserving dedupe, NOT unique: unique sorts alphabetically, so
-        # APPROVED would lead even when a later CHANGES_REQUESTED on the same
-        # commit superseded it. Chronology is the point here — newest state last.
+        # Dedupe keeping the LAST occurrence, not unique and not keep-first.
+        # unique sorts alphabetically, so APPROVED would lead even when a later
+        # CHANGES_REQUESTED on the same commit superseded it; keep-first has the
+        # same flaw once a state recurs (CHANGES_REQUESTED, APPROVED,
+        # CHANGES_REQUESTED would end on the withdrawn APPROVED). The trailing
+        # entry is read as the current state, so it has to be the newest one.
         reviews_on_head: ($head_reviews
                           | group_by(.author.login)
                           | map({(.[0].author.login):
                                  (map(.state)
-                                  | reduce .[] as $st ([]; if index($st) then . else . + [$st] end)
+                                  | reduce .[] as $st ([]; (. - [$st]) + [$st])
                                   | join("+"))})
                           | add // {}),
         has_review_on_head: (($head_reviews|length) > 0),

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -220,8 +220,12 @@ evaluate() {
         # unique sorts alphabetically, so APPROVED would lead even when a later
         # CHANGES_REQUESTED on the same commit superseded it; keep-first has the
         # same flaw once a state recurs (CHANGES_REQUESTED, APPROVED,
-        # CHANGES_REQUESTED would end on the withdrawn APPROVED). The trailing
-        # entry is read as the current state, so it has to be the newest one.
+        # CHANGES_REQUESTED would end on the withdrawn APPROVED).
+        # What this guarantees is exactly: each distinct state once, ordered by
+        # its LAST occurrence. Not "the trailing entry is the current state" —
+        # a CHANGES_REQUESTED followed by a thread reply renders
+        # CHANGES_REQUESTED+COMMENTED, and the blocking state is the first one.
+        # This field is for display; the decision path reads $head_reviews.
         reviews_on_head: ($head_reviews
                           | group_by(.author.login)
                           | map({(.[0].author.login):

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -285,37 +285,40 @@ evaluate() {
                     else "" end)
                  + " — the queue merges it once its own checks pass; enqueueing"
                  + " again only restarts them")}
-         # Two strikes -> stop asking the bot. Deliberately NOT gated on
-         # $needs_copilot: a repo without the ruleset reaches the generic
-         # "no review on head" branch below, whose cmd re-requests the very bot
-         # that just reported a quota ceiling, with no way out of the loop.
-         # `has_review_on_head|not` is what ends the escalation: once ANY valid
-         # review lands — the self-review this branch asks for, or a human one —
-         # the run falls through to merge. Without it the branch is a dead end
-         # that re-fires forever on the error rows, which never age off the head.
-         elif ($s.copilot_error_count >= 2
-               and ($s.has_review_on_head | not)
-               and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           {action:"review-yourself",
-            why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
-                 + " rows carry an error in the body, not a review. Do not re-request again:"
-                 + " an outage may clear, a quota ceiling does not clear by asking. Review the"
-                 + " diff yourself, say in the PR that the bot review was unavailable, and"
-                 + " merge on that.")}
          # `|` binds looser than `and`, so the negation needs its own parens:
          # `a and b|not` parses as `(a and b)|not` and inverts the whole test.
          # has_copilot_review_on_head must be false too: the error row stays on
          # the head forever, so without it a successful re-review would still
          # report request-review and loop the operator.
+         #
+         # Repeated failures change the ADVICE, not the action. An earlier
+         # version escalated to a distinct "review-yourself" action; it was
+         # unreachable-to-leave, because a review by the PR author is excluded
+         # from $head_reviews by design (line above) — and the operator driving
+         # this script IS usually the author, so doing what the action asked
+         # produced a row that was then discarded and the action re-fired
+         # forever. The tool cannot observe "a human read the diff", so it no
+         # longer pretends to: it keeps reporting the honest state and only
+         # stops handing over a retry command a quota ceiling will reject.
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           {action:"request-review",
-            why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
-                 + " row carries an error in its body (an outage, or the requesting account is"
-                 + " out of quota), not a review. Re-request once; if it fails again this"
-                 + " turns into review-yourself rather than another retry."),
-            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+           (if $s.copilot_error_count >= 2 then
+             {action:"request-review",
+              why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
+                   + " rows carry an error in the body, not a review. Do not keep re-requesting:"
+                   + " an outage may clear, a quota ceiling does not clear by asking. Review the"
+                   + " diff yourself, say in the PR that the bot review was unavailable, and"
+                   + " decide on that. This stays request-review because the ruleset still has"
+                   + " no bot review — the tool cannot see that you read the diff.")}
+            else
+             {action:"request-review",
+              why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
+                   + " row carries an error in its body (an outage, or the requesting account is"
+                   + " out of quota), not a review. Re-request once; if it fails again, review it"
+                   + " yourself rather than retrying."),
+              cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+            end)
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
@@ -474,7 +477,7 @@ while :; do
     emit "$s"; exit 0
   fi
   case "$act" in
-    fix-ci|triage-ci|resolve-threads|request-review|review-yourself|rebase|resolve-conflicts|merge|blocked|none)
+    fix-ci|triage-ci|resolve-threads|request-review|rebase|resolve-conflicts|merge|blocked|none)
       echo "ACTIONABLE: $act"
       emit "$s"; exit 0 ;;
   esac

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -255,17 +255,20 @@ evaluate() {
     # active, has_copilot_review_on_head implies has_review_on_head, so the
     # generic branch is unreachable there — which is why fixing one of them
     # left the other silently unwarned.
-    # Both conditions matter: an APPROVED decision only sits on an OLDER commit
-    # when nothing reviewed the current head. The copilot branch below is not
-    # gated on has_review_on_head, so without the second test this note fires on
-    # a current, valid approval and tells the operator to disregard it.
-    | (if ($s.reviewDecision == "APPROVED") and ($s.has_review_on_head | not)
+    # An APPROVED decision sits on an OLDER commit only when nothing APPROVED
+    # the current head. has_review_on_head is the wrong test: it is true for any
+    # non-author review including a COMMENTED one, and a thread reply registers
+    # as exactly that (see the $reviews_raw comment), so one reply after the
+    # last push would drop this warning while the approval is still stale.
+    | ([$s.reviews_on_head[]? | select(. == "APPROVED")] | length == 0) as $no_current_approval
+    | (if ($s.reviewDecision == "APPROVED") and $no_current_approval
        then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
        else "" end) as $stale_approval
-    # Same reason: only claim "nothing reviewed this head" when that is true.
-    | (if ($s.has_review_on_head | not)
-       then "no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed. "
-       else "" end) as $unreviewed
+    # One source for the phrase; the branches differ only in what follows it.
+    # The copilot branch is not gated on has_review_on_head, so it must not
+    # assert this when a review does exist on the head.
+    | "no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed" as $no_review
+    | (if ($s.has_review_on_head | not) then "\($no_review). " else "" end) as $unreviewed
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -364,15 +367,14 @@ evaluate() {
            # merge on a review that sits on an older commit.
            (if $copilot_exhausted then
                {action:"request-review",
-                why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed."
-                     + " Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"
+                why:("\($no_review). "
+                     + "Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"
                      + " rather than a review. Do not keep re-requesting: an outage may clear, a"
                      + " quota ceiling does not clear by asking. Review the diff yourself and"
                      + " decide on that\($stale_approval)")}
               else
                {action:"request-review",
-                why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed"
-                     + $stale_approval),
+                why:($no_review + $stale_approval),
                 cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
               end)
          # A required check that is QUEUED with nothing running is not "CI is

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -216,9 +216,15 @@ evaluate() {
         # from the only surface that shows it — beside decision=APPROVED, which
         # then reads as an approval on an older commit. Shape is unchanged
         # (login -> string) so consumers indexing by login still work.
+        # Order-preserving dedupe, NOT unique: unique sorts alphabetically, so
+        # APPROVED would lead even when a later CHANGES_REQUESTED on the same
+        # commit superseded it. Chronology is the point here — newest state last.
         reviews_on_head: ($head_reviews
                           | group_by(.author.login)
-                          | map({(.[0].author.login): (map(.state)|unique|join("+"))})
+                          | map({(.[0].author.login):
+                                 (map(.state)
+                                  | reduce .[] as $st ([]; if index($st) then . else . + [$st] end)
+                                  | join("+"))})
                           | add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
         has_copilot_review_on_head: (($copilot_on_head|length) > 0),
@@ -269,12 +275,10 @@ evaluate() {
     # non-author review including a COMMENTED one, and a thread reply registers
     # as exactly that (see the $reviews_raw comment), so one reply after the
     # last push would drop this warning while the approval is still stale.
-    # Read the LIST, not reviews_on_head: that field is map({login: state})|add,
-    # so it keeps one state per author and the last review wins. A reviewer who
-    # approves the head and then replies to a thread collapses to COMMENTED
-    # there, which would resurrect this warning against an approval that is on
-    # the head — the mirror image of the bug above, and order-dependent, so it
-    # would look intermittent.
+    # Read the LIST, not reviews_on_head: that field joins the states per author
+    # into one string for display, so testing it would mean substring-matching
+    # "APPROVED" out of e.g. "APPROVED+CHANGES_REQUESTED" and calling a
+    # superseded approval current. The list carries each review as its own row.
     | ([$head_reviews[] | select(.state == "APPROVED")] | length == 0) as $no_current_approval
     | (if ($s.reviewDecision == "APPROVED") and $no_current_approval
        then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -250,6 +250,14 @@ evaluate() {
     # re-request loop in the other — the same trap `is_errored_copilot_review`
     # is factored out to avoid.
     | ($s.copilot_error_count >= 2) as $copilot_exhausted
+    # Hoisted so BOTH exhausted variants can append it. The two branches below
+    # serve disjoint repo populations — with the copilot_code_review ruleset
+    # active, has_copilot_review_on_head implies has_review_on_head, so the
+    # generic branch is unreachable there — which is why fixing one of them
+    # left the other silently unwarned.
+    | (if $s.reviewDecision == "APPROVED"
+       then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
+       else "" end) as $stale_approval
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -311,12 +319,14 @@ evaluate() {
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
            (if $copilot_exhausted then
              {action:"request-review",
-              why:("Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]) — the COMMENTED"
-                   + " rows carry an error in the body, not a review. Do not keep re-requesting:"
-                   + " an outage may clear, a quota ceiling does not clear by asking. Review the"
-                   + " diff yourself, say in the PR that the bot review was unavailable, and"
-                   + " decide on that. This stays request-review because the ruleset still has"
-                   + " no bot review — the tool cannot see that you read the diff.")}
+              why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed."
+                   + " Copilot failed \($s.copilot_error_count)x on it, so the COMMENTED rows"
+                   + " carry an error in the body rather than a review. Do not keep"
+                   + " re-requesting: an outage may clear, a quota ceiling does not clear by"
+                   + " asking. Review the diff yourself, say in the PR that the bot review was"
+                   + " unavailable, and decide on that. This stays request-review because the"
+                   + " ruleset still has no bot review — the tool cannot see that you read the"
+                   + " diff\($stale_approval)")}
             else
              {action:"request-review",
               why:("Copilot answered on \($s.headOid[0:8]) but the review FAILED — the COMMENTED"
@@ -339,15 +349,11 @@ evaluate() {
            # cmd is offered again. The two-strikes suppression therefore lives
            # here as well as in the ruleset branch above — it must not be gated
            # on $needs_copilot.
-           # The stale-APPROVED warning belongs on BOTH variants. It matters most
-           # in the exhausted one: render prints mergeState=CLEAN and
-           # decision=APPROVED directly above this line, so dropping "do not
-           # merge unreviewed" there reads as license to merge on a review that
-           # sits on an older commit.
-           ((if $s.reviewDecision == "APPROVED"
-             then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
-             else "" end)) as $stale_approval
-           | (if $copilot_exhausted then
+           # The stale-APPROVED warning belongs on BOTH exhausted variants: render
+           # prints mergeState=CLEAN and decision=APPROVED directly above this
+           # line, so dropping "do not merge unreviewed" reads as license to
+           # merge on a review that sits on an older commit.
+           (if $copilot_exhausted then
                {action:"request-review",
                 why:("no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed."
                      + " Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -260,7 +260,13 @@ evaluate() {
     # non-author review including a COMMENTED one, and a thread reply registers
     # as exactly that (see the $reviews_raw comment), so one reply after the
     # last push would drop this warning while the approval is still stale.
-    | ([$s.reviews_on_head[]? | select(. == "APPROVED")] | length == 0) as $no_current_approval
+    # Read the LIST, not reviews_on_head: that field is map({login: state})|add,
+    # so it keeps one state per author and the last review wins. A reviewer who
+    # approves the head and then replies to a thread collapses to COMMENTED
+    # there, which would resurrect this warning against an approval that is on
+    # the head — the mirror image of the bug above, and order-dependent, so it
+    # would look intermittent.
+    | ([$head_reviews[] | select(.state == "APPROVED")] | length == 0) as $no_current_approval
     | (if ($s.reviewDecision == "APPROVED") and $no_current_approval
        then "; the existing APPROVED review sits on an older commit and this repo does not dismiss it"
        else "" end) as $stale_approval

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -85,8 +85,12 @@ json.dump({"data": {"repository": {
 PY
 }
 
-# Same stub, but each arg is "author|state|body" so a case can mix a Copilot
-# error row with a human review on the same head.
+# Same stub, but each arg is "author|state|body" — optionally with a fourth
+# field "older" to place that review on a PREVIOUS commit rather than the head.
+# Needed to model a stale approval honestly: GitHub does not let an author
+# approve their own PR, so "APPROVED by the author on the head" is a state that
+# cannot occur in production and would test the author filter instead of the
+# commit-staleness filter the warning is actually about.
 make_stub_reviews() {
     local rules
     if [ -n "${RULES_JSON:-}" ]; then
@@ -115,9 +119,11 @@ head = "deadbeefcafe"
 reviews = []
 approved = False
 for s in specs:
-    who, state, body = s.split("|", 2)
+    parts = s.split("|", 3)
+    who, state, body = parts[0], parts[1], parts[2]
+    oid = "0ldc0mm1t" if len(parts) > 3 and parts[3] == "older" else head
     reviews.append({"author": {"login": who}, "state": state,
-                    "commit": {"oid": head}, "body": body})
+                    "commit": {"oid": oid}, "body": body})
     approved = approved or state == "APPROVED"
 json.dump({"data": {"repository": {
     "nameWithOwner": "o/r",
@@ -255,17 +261,34 @@ RULES_JSON='[]' make_stub_reviews \
 check "has_review_on_head" "true"  "$(run_flag has_review_on_head)"
 check "next.action"        "merge" "$(run_next)"
 
-# Finding from review: the comment on case 10 claimed it covered the
-# reviewDecision == APPROVED branch. It does not — case 10 lands on merge, while
-# that string lives only on the generic "no review on head" branch. Reaching it
-# needs APPROVED with an EMPTY $head_reviews, i.e. the approval sitting on an
-# older commit. That gap is why the stale-approval warning could go missing from
-# the exhausted variant unnoticed.
-echo "case 11: stale APPROVED on an older commit + two errors — warning survives"
+# The approval is by ANOTHER user and sits on an OLDER commit — the state the
+# warning is written for, and the only way to reach the reviewDecision ==
+# APPROVED branch through the commit filter rather than the author filter.
+# Run for both repo populations: the ruleset branch and the generic branch serve
+# disjoint sets (with the ruleset active the generic one is unreachable), which
+# is how a fix landed on one of them and left the other unwarned.
+echo "case 11: stale APPROVED on an older commit + two errors — NO ruleset"
 RULES_JSON='[]' make_stub_reviews \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
-  "someone|APPROVED|approved on an older commit"
+  "a-human|APPROVED|approved before the last push|older"
+check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
+check "next.action"        "request-review" "$(run_next)"
+check "next.cmd absent"    "null"           "$(run_flag 'next.cmd')"
+for phrase in "do not merge unreviewed" "sits on an older commit"; do
+    if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
+        echo "  ok   why keeps: $phrase"
+    else
+        echo "  FAIL why lost: $phrase"
+        fail=1
+    fi
+done
+
+echo "case 12: same, WITH the copilot ruleset — the other branch must warn too"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "a-human|APPROVED|approved before the last push|older"
 check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
 check "next.action"        "request-review" "$(run_next)"
 check "next.cmd absent"    "null"           "$(run_flag 'next.cmd')"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -42,16 +42,18 @@ make_stub() {
         rules='[{"type":"copilot_code_review","parameters":{}}]'
     fi
     printf '%s\n' "$rules" > "$STUB_DIR/rules.json"
-    cat > "$STUB_DIR/gh" <<'STUB'
+    # Unquoted delimiter so $STUB_DIR expands now; \$@ stays literal for the
+    # stub. Avoids `sed -i`, whose no-suffix form is GNU-only and fails the
+    # suite on BSD/macOS with an error pointing at sed, not at the test.
+    cat > "$STUB_DIR/gh" <<STUB
 #!/usr/bin/env bash
-for a in "$@"; do
-  case "$a" in
+for a in "\$@"; do
+  case "\$a" in
     repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
   esac
 done
 cat "$STUB_DIR/graphql.json"
 STUB
-    sed -i "s|\$STUB_DIR|$STUB_DIR|g" "$STUB_DIR/gh"
     chmod +x "$STUB_DIR/gh"
     python3 - "$STUB_DIR/graphql.json" "$@" <<'PY'
 import sys, json
@@ -92,16 +94,18 @@ make_stub_reviews() {
         rules='[{"type":"copilot_code_review","parameters":{}}]'
     fi
     printf '%s\n' "$rules" > "$STUB_DIR/rules.json"
-    cat > "$STUB_DIR/gh" <<'STUB'
+    # Unquoted delimiter so $STUB_DIR expands now; \$@ stays literal for the
+    # stub. Avoids `sed -i`, whose no-suffix form is GNU-only and fails the
+    # suite on BSD/macOS with an error pointing at sed, not at the test.
+    cat > "$STUB_DIR/gh" <<STUB
 #!/usr/bin/env bash
-for a in "$@"; do
-  case "$a" in
+for a in "\$@"; do
+  case "\$a" in
     repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
   esac
 done
 cat "$STUB_DIR/graphql.json"
 STUB
-    sed -i "s|\$STUB_DIR|$STUB_DIR|g" "$STUB_DIR/gh"
     chmod +x "$STUB_DIR/gh"
     python3 - "$STUB_DIR/graphql.json" "$@" <<'PY'
 import sys, json
@@ -180,46 +184,51 @@ check "copilot_review_errored"     "true"  "$(run_flag copilot_review_errored)"
 check "has_copilot_review_on_head" "true"  "$(run_flag has_copilot_review_on_head)"
 check "next.action"                "merge" "$(run_next)"
 
-echo "case 7: two errors — stop retrying, say review it yourself"
+# Repeated failures change the advice, not the action: the retry command is
+# dropped so an agent following NEXT stops re-requesting a bot that is out of
+# quota. The action stays request-review because the ruleset genuinely still has
+# no bot review — anything else would claim a state the tool cannot observe.
+echo "case 7: two errors — same action, no retry command, different advice"
 make_stub "$ERR_GENERIC" "$ERR_QUOTA"
-check "copilot_error_count" "2"               "$(run_flag copilot_error_count)"
-check "next.action"         "review-yourself" "$(run_next)"
+check "copilot_error_count" "2"              "$(run_flag copilot_error_count)"
+check "next.action"         "request-review" "$(run_next)"
+check "next.cmd absent"     "null"           "$(run_flag 'next.cmd')"
+if status | jq -e '.next.why | test("Review the diff yourself")' >/dev/null; then
+    echo "  ok   why carries the self-review instruction"
+else
+    echo "  FAIL why does not carry the self-review instruction"
+    fail=1
+fi
 
-# review-yourself has to be an instruction you can carry out, not a state you
-# cannot leave: the error rows never age off the head, so without a
-# has_review_on_head guard the branch re-fires forever and the gate never opens
-# again — including after a human approves.
-echo "case 8a: two errors + human review, ruleset active — escalation must end"
+# One retry IS offered on the first failure — an outage may simply have cleared.
+echo "case 7b: one error — retry command still offered"
+make_stub "$ERR_GENERIC"
+check "copilot_error_count" "1" "$(run_flag copilot_error_count)"
+if [ "$(run_flag 'next.cmd')" = "null" ]; then
+    echo "  FAIL first failure should still offer the re-request command"
+    fail=1
+else
+    echo "  ok   retry command offered on the first failure"
+fi
+
+# Regression for a dead end that shipped once: an earlier version escalated to a
+# distinct "review-yourself" action guarded on has_review_on_head. A review by
+# the PR author is excluded from that gate by design, and the operator driving
+# this script IS usually the author — so carrying out the instruction produced a
+# row that was discarded and the action re-fired forever, with pr-merge.sh
+# refusing anything but "merge". Every emitted action must be one --watch and
+# pr-merge.sh recognise.
+echo "case 8: author self-reviews after two errors — action stays a known one"
 make_stub_reviews \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
-  "a-human|APPROVED|LGTM"
-check "copilot_error_count" "2"    "$(run_flag copilot_error_count)"
-check "has_review_on_head"  "true" "$(run_flag has_review_on_head)"
-# Not asserting "merge": with the ruleset active the script asks for a COPILOT
-# review specifically, human approval or not. That predates this PR and is not
-# ours to change here. What must hold is that review-yourself has stopped
-# re-firing — otherwise the action is unreachable-by-design.
-if [ "$(run_next)" = "review-yourself" ]; then
-    echo "  FAIL next.action: still review-yourself after a review landed"
-    fail=1
-else
-    echo "  ok   next.action left review-yourself ($(run_next))"
-fi
+  "someone|COMMENTED|Reviewed this myself, the bot was unavailable."
+check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
+check "next.action"        "request-review" "$(run_next)"
 
-echo "case 8b: same without the ruleset — generic gate satisfied, merge"
-RULES_JSON='[]' make_stub_reviews \
-  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
-  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
-  "a-human|APPROVED|LGTM"
-check "next.action" "merge" "$(run_next)"
-
-# Without the ruleset the flow lands on the generic "no review on head" branch,
-# whose cmd re-requests the bot that just reported a quota ceiling. The
-# escalation must not be gated behind the ruleset.
-echo "case 9: NO ruleset + two errors — must escalate, not loop on request-review"
+echo "case 9: NO ruleset + two errors — generic gate, no review exists"
 RULES_JSON='[]' make_stub "$ERR_GENERIC" "$ERR_QUOTA"
-check "next.action" "review-yourself" "$(run_next)"
+check "next.action" "request-review" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -226,9 +226,32 @@ make_stub_reviews \
 check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
 check "next.action"        "request-review" "$(run_next)"
 
-echo "case 9: NO ruleset + two errors — generic gate, no review exists"
+# The action alone cannot detect this regression — it is request-review either
+# way. What distinguishes "stop retrying" from "retry forever" is the cmd, so
+# assert on that. An earlier revision moved the two-strikes suppression inside
+# the $needs_copilot guard, which handed the retry command back to every repo
+# without the ruleset; this case passed regardless until the cmd was checked.
+echo "case 9: NO ruleset + two errors — retry command dropped here too"
 RULES_JSON='[]' make_stub "$ERR_GENERIC" "$ERR_QUOTA"
-check "next.action" "request-review" "$(run_next)"
+check "next.action"     "request-review" "$(run_next)"
+check "next.cmd absent" "null"           "$(run_flag 'next.cmd')"
+if status | jq -e '.next.why | test("Review the diff yourself")' >/dev/null; then
+    echo "  ok   why carries the self-review instruction without the ruleset"
+else
+    echo "  FAIL why lacks the self-review instruction when no ruleset is set"
+    fail=1
+fi
+
+# Keeps the recovery path covered: a real APPROVED review by someone other than
+# the author opens the gate even though the error rows are still on the head.
+# Also the only case that exercises the reviewDecision == APPROVED branch.
+echo "case 10: NO ruleset + two errors + human APPROVED — gate opens"
+RULES_JSON='[]' make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "a-human|APPROVED|LGTM"
+check "has_review_on_head" "true"  "$(run_flag has_review_on_head)"
+check "next.action"        "merge" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -119,9 +119,13 @@ head = "deadbeefcafe"
 reviews = []
 approved = False
 for s in specs:
-    parts = s.split("|", 3)
-    who, state, body = parts[0], parts[1], parts[2]
-    oid = "0ldc0mm1t" if len(parts) > 3 and parts[3] == "older" else head
+    # Split the optional trailing flag off the RIGHT, so a body containing a
+    # pipe stays intact instead of being silently truncated into the flag slot.
+    if s.endswith("|older"):
+        s, oid = s[: -len("|older")], "0ldc0mm1t"
+    else:
+        oid = head
+    who, state, body = s.split("|", 2)
     reviews.append({"author": {"login": who}, "state": state,
                     "commit": {"oid": oid}, "body": body})
     approved = approved or state == "APPROVED"
@@ -292,6 +296,40 @@ make_stub_reviews \
 check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
 check "next.action"        "request-review" "$(run_next)"
 check "next.cmd absent"    "null"           "$(run_flag 'next.cmd')"
+for phrase in "do not merge unreviewed" "sits on an older commit"; do
+    if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
+        echo "  ok   why keeps: $phrase"
+    else
+        echo "  FAIL why lost: $phrase"
+        fail=1
+    fi
+done
+
+# The copilot branch is NOT gated on has_review_on_head, so wording written for
+# "nothing reviewed this head" must not be asserted there unconditionally: with a
+# valid approval ON the head, claiming otherwise tells the operator to disregard
+# a current review.
+echo "case 13: two errors + valid APPROVED ON the head — no false claims"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "a-human|APPROVED|LGTM on the current head"
+check "has_review_on_head" "true" "$(run_flag has_review_on_head)"
+for phrase in "no review on the current head" "sits on an older commit"; do
+    if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
+        echo "  FAIL why falsely claims: $phrase"
+        fail=1
+    else
+        echo "  ok   why does not claim: $phrase"
+    fi
+done
+
+# The single-error branch had neither warning while the generic one did.
+echo "case 14: ONE error + stale APPROVED — warnings on the first strike too"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|APPROVED|approved before the last push|older"
+check "copilot_error_count" "1" "$(run_flag copilot_error_count)"
 for phrase in "do not merge unreviewed" "sits on an older commit"; do
     if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
         echo "  ok   why keeps: $phrase"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -360,6 +360,22 @@ else
     fail=1
 fi
 
+# Case 15 uses two distinct logins, so no key collides and it cannot catch a
+# lossy per-author projection. The SAME reviewer approving the head and then
+# commenting on it is what collapses the state.
+echo "case 16: same reviewer approves the head then comments — no false staleness"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|APPROVED|LGTM on the current head" \
+  "a-human|COMMENTED|one more thought on the same head"
+check "next.action" "request-review" "$(run_next)"
+if status | jq -e '.next.why | test("sits on an older commit")' >/dev/null; then
+    echo "  FAIL claims staleness for an approval that is on the head"
+    fail=1
+else
+    echo "  ok   no false staleness after the approver comments"
+fi
+
 if [ "$fail" -eq 0 ]; then
     echo "all pass"
 else

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -63,6 +63,7 @@ reviews = [{"author": {"login": "copilot-pull-request-reviewer"},
             "state": "COMMENTED", "commit": {"oid": head}, "body": b}
            for b in bodies]
 json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
     "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
     "pullRequest": {
         "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
@@ -119,6 +120,7 @@ for s in specs:
                     "commit": {"oid": head}, "body": body})
     approved = approved or state == "APPROVED"
 json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
     "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
     "pullRequest": {
         "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
@@ -204,12 +206,12 @@ fi
 echo "case 7b: one error — retry command still offered"
 make_stub "$ERR_GENERIC"
 check "copilot_error_count" "1" "$(run_flag copilot_error_count)"
-if [ "$(run_flag 'next.cmd')" = "null" ]; then
-    echo "  FAIL first failure should still offer the re-request command"
-    fail=1
-else
-    echo "  ok   retry command offered on the first failure"
-fi
+case "$(run_flag 'next.cmd')" in
+    *"repos/o/r/pulls/1/requested_reviewers"*)
+        echo "  ok   retry command offered on the first failure, with the real repo" ;;
+    *)  echo "  FAIL first failure should offer a re-request cmd naming the repo"
+        fail=1 ;;
+esac
 
 # Regression for a dead end that shipped once: an earlier version escalated to a
 # distinct "review-yourself" action guarded on has_review_on_head. A review by
@@ -252,6 +254,29 @@ RULES_JSON='[]' make_stub_reviews \
   "a-human|APPROVED|LGTM"
 check "has_review_on_head" "true"  "$(run_flag has_review_on_head)"
 check "next.action"        "merge" "$(run_next)"
+
+# Finding from review: the comment on case 10 claimed it covered the
+# reviewDecision == APPROVED branch. It does not — case 10 lands on merge, while
+# that string lives only on the generic "no review on head" branch. Reaching it
+# needs APPROVED with an EMPTY $head_reviews, i.e. the approval sitting on an
+# older commit. That gap is why the stale-approval warning could go missing from
+# the exhausted variant unnoticed.
+echo "case 11: stale APPROVED on an older commit + two errors — warning survives"
+RULES_JSON='[]' make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
+  "someone|APPROVED|approved on an older commit"
+check "has_review_on_head" "false"          "$(run_flag has_review_on_head)"
+check "next.action"        "request-review" "$(run_next)"
+check "next.cmd absent"    "null"           "$(run_flag 'next.cmd')"
+for phrase in "do not merge unreviewed" "sits on an older commit"; do
+    if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
+        echo "  ok   why keeps: $phrase"
+    else
+        echo "  FAIL why lost: $phrase"
+        fail=1
+    fi
+done
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -396,6 +396,16 @@ make_stub_reviews \
   "a-human|APPROVED|fixed, good now"
 check "reviews_on_head[a-human]" "CHANGES_REQUESTED+APPROVED" "$(run_flag '"reviews_on_head"."a-human"')"
 
+# No other fixture repeats a state, so the dedupe branch of the reduce is never
+# reached by the suite. Recurrence is what separates keep-first from keep-last.
+echo "case 19: state recurs — the trailing entry must be the current one"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|CHANGES_REQUESTED|not yet" \
+  "a-human|APPROVED|fixed" \
+  "a-human|CHANGES_REQUESTED|found something else"
+check "reviews_on_head[a-human]" "APPROVED+CHANGES_REQUESTED" "$(run_flag '"reviews_on_head"."a-human"')"
+
 if [ "$fail" -eq 0 ]; then
     echo "all pass"
 else

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -376,6 +376,15 @@ else
     echo "  ok   no false staleness after the approver comments"
 fi
 
+# render/--json must not hide the approval either: it is the only surface that
+# shows per-reviewer state, and it sits directly above the corrected why.
+echo "case 17: approve-then-comment stays visible in reviews_on_head"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|APPROVED|LGTM on the current head" \
+  "a-human|COMMENTED|one more thought on the same head"
+check "reviews_on_head[a-human]" "APPROVED+COMMENTED" "$(run_flag '"reviews_on_head"."a-human"')"
+
 if [ "$fail" -eq 0 ]; then
     echo "all pass"
 else

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -314,7 +314,10 @@ make_stub_reviews \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
   "a-human|APPROVED|LGTM on the current head"
-check "has_review_on_head" "true" "$(run_flag has_review_on_head)"
+check "has_review_on_head" "true"           "$(run_flag has_review_on_head)"
+# Pin the branch too: asserting only absences passes vacuously if this stops
+# being the branch that answers.
+check "next.action"        "request-review" "$(run_next)"
 for phrase in "no review on the current head" "sits on an older commit"; do
     if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
         echo "  FAIL why falsely claims: $phrase"
@@ -338,6 +341,24 @@ for phrase in "do not merge unreviewed" "sits on an older commit"; do
         fail=1
     fi
 done
+
+# has_review_on_head is true for ANY non-author review, including a COMMENTED
+# one — and a reply to a review thread registers as exactly that. Using it as
+# the staleness test drops the warning after a single reply, while the approval
+# is still sitting on the pre-push commit.
+echo "case 15: stale APPROVED + a COMMENTED reply on the head — warning survives"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|APPROVED|approved before the last push|older" \
+  "other-human|COMMENTED|replying to a thread"
+check "has_review_on_head" "true"           "$(run_flag has_review_on_head)"
+check "next.action"        "request-review" "$(run_next)"
+if status | jq -e '.next.why | test("sits on an older commit")' >/dev/null; then
+    echo "  ok   staleness warning survives a COMMENTED reply"
+else
+    echo "  FAIL staleness warning dropped by a COMMENTED reply"
+    fail=1
+fi
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -385,6 +385,17 @@ make_stub_reviews \
   "a-human|COMMENTED|one more thought on the same head"
 check "reviews_on_head[a-human]" "APPROVED+COMMENTED" "$(run_flag '"reviews_on_head"."a-human"')"
 
+# Chronology matters, and the fixture has to make alphabetical order DISAGREE
+# with it — otherwise `unique` produces the same string and the case proves
+# nothing. CHANGES_REQUESTED then APPROVED: sorted gives APPROVED first (the
+# superseded state leading), chronological keeps the current one last.
+echo "case 18: CHANGES_REQUESTED then APPROVED — chronology, not alphabet"
+make_stub_reviews \
+  "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
+  "a-human|CHANGES_REQUESTED|not yet" \
+  "a-human|APPROVED|fixed, good now"
+check "reviews_on_head[a-human]" "CHANGES_REQUESTED+APPROVED" "$(run_flag '"reviews_on_head"."a-human"')"
+
 if [ "$fail" -eq 0 ]; then
     echo "all pass"
 else


### PR DESCRIPTION
## Summary

Follow-up to #151, which shipped a `review-yourself` action that **cannot be left**. Removes the action; the advice it carried stays.

## The defect

`review-yourself` ends on `has_review_on_head`. But `$head_reviews` excludes reviews by the PR author by design — a thread reply registers as a `COMMENTED` row and would otherwise satisfy the review gate. The operator driving this script is usually the author, so carrying out the instruction ("review the diff yourself … and merge on that") produces a row that is immediately discarded. `copilot_error_count` stays ≥ 2, `has_review_on_head` stays false, and the action re-fires on every subsequent run. `pr-merge.sh` refuses anything but `merge`, so there is no way out.

Reproduced against `origin/main` — two Copilot quota errors, an author self-review, all checks green, no unresolved threads:

```
origin/main (shipped): review-yourself
this branch:           request-review
```

**Second loop, same root cause.** With the ruleset active, once a *non-author* review lands the next branch re-requests the bot that just reported a quota ceiling; that errors, `copilot_error_count` grows, and `merge` is never reached. This one is **not** pre-existing — a note in #151's test 8a claimed it was, and that was wrong: before #151 the error row satisfied `has_copilot_review_on_head`, so the branch could not fire at all.

## Why removal rather than a third patch

Both loops are the same mistake: an action whose exit condition is *"a human reviewed it"* has no exit condition, because the tool cannot observe that. Each previous attempt to guard it opened a different hole — three review rounds, three distinct dead ends. The escalation is a second feature riding on #151's actual fix, and it is not carrying its weight.

Removing it also settles a third defect: the branch sat above the pending-required gate, so it answered "merge on that" while required checks were still running, and `--watch` returned on it immediately.

**What #151 set out to fix is untouched** — an errored Copilot review is still not counted as a review. That part is verified and stays.

## What replaces it

Repeated failures change the **advice** and drop the retry command. The action stays `request-review`, which is the honest state: the ruleset really does still have no bot review, and the tool cannot see that you read the diff.

| Copilot errors on head | action | retry cmd | advice |
|---|---|---|---|
| 1 | `request-review` | offered | re-request once, an outage may have cleared |
| ≥ 2 | `request-review` | **dropped** | review it yourself and decide on that |

## Test plan

- [x] 10 cases pass. New: 7 (retry command dropped + advice changed), 7b (one retry still offered on the first failure), 8 (author self-review cannot produce an unsatisfiable action)
- [x] Reproduced the shipped dead end against `origin/main` and the fix on this branch, same stub
- [x] `shellcheck` clean, `validate-skill.sh` 0 errors, `markdownlint-cli2` 0 issues, python suite passes
- [x] Stub no longer uses `sed -i` — the no-suffix form is GNU-only and failed the suite on BSD/macOS

## Note on how this reached main

#151 was merged from another session on the same account while its third review round was still open; the finding above had been identified but the fix was not yet committed, and the worktree went with the branch. Hence a follow-up PR rather than another push to #151.

---

## Review basis

**Copilot reviewed none of this.** Six requests across this PR and its predecessor all came back as errors — first a GitHub Actions outage, then a quota ceiling on the requesting account. Each failure arrives as an ordinary `COMMENTED` review, which is the very confusion this PR exists to remove.

The fallback was twelve `/code-review` rounds against each pushed delta. Eleven found real defects, every one of them mine. What they caught, in order:

| Round | Defect |
|---|---|
| 1 | Detection via check-run conclusion — impossible, that check-run is absent from GraphQL `statusCheckRollup` |
| 2 | Filter applied to the Copilot view only, so repos without the ruleset still merged on an error row |
| 3 | `review-yourself` unreachable-to-leave: a self-review by the PR author is excluded from the gate by design |
| 4 | Two-strikes suppression moved inside `$needs_copilot`, reviving the retry loop it was written to stop |
| 5 | Stale-APPROVED warning dropped on the exhausted path — under `mergeState=CLEAN` it read as license to merge |
| 6 | Fix applied to one of the two branches the commit claimed to cover; they serve disjoint repo populations |
| 7 | Wording asserted "no review on the current head" where a valid current approval could exist |
| 8 | Staleness tested via `has_review_on_head`, true for any `COMMENTED` row including a thread reply |
| 9 | Staleness tested via a per-author projection that keeps only the last state, hiding an approval |
| 10 | Display used `unique`, sorting a superseded `APPROVED` to the front |
| 11 | Order-preserving dedupe kept the first occurrence while the comment promised the newest last |

Two of the tests written along the way were themselves worthless — one because alphabetical and chronological order happened to agree in its fixture, one because it asserted only absences and would have passed vacuously if its branch stopped being reached. Both were caught by re-running each new test against the *unfixed* commit; that counter-check is recorded in every commit message that adds a case.

The final round reported no correctness defects in the change; its one finding was a comment of mine promising more than the code guarantees, fixed in `8e61d03` as a comment-only diff.

**19 test cases**, each verified to fail against the implementation it guards. `shellcheck`, `validate-skill.sh`, `markdownlint-cli2` and the Python suite all clean. 21/22 checks green.