### PR TITLE
feat(hook): deny asking gh whether a pull request can merge

### DIFF
--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -1,0 +1,37 @@
+name: Hook Tests
+
+# Lives beside lint.yml rather than inside it: lint.yml is governed by the
+# skill template and must stay byte-identical across skill repos, while these
+# tests are specific to the PreToolUse hook this repo ships.
+#
+# The hook decides whether a command runs at all in every session that installs
+# the plugin, so a silent regression there is expensive. Standard library only —
+# nothing to install.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  hooks:
+    name: Hook Script Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run hook tests
+        run: python3 -m unittest discover -s scripts -p 'test_*.py' -v

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -1,0 +1,123 @@
+"""Tests for the PreToolUse command validator.
+
+Run with: python3 -m unittest discover -s scripts -p 'test_*.py'
+
+The merge-readiness cases are the commands that motivated that check: asking
+GitHub whether a pull request can merge, rather than pr-status.sh, hides the
+two states that usually block it. The rest of the file guards the checks that
+were already here so the new one cannot quietly change their behaviour.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import ClassVar
+
+HOOK = Path(__file__).with_name("validate_git_command.py")
+
+
+def decision(output: str) -> str:
+    """The permissionDecision the hook returned, or '' when it stayed advisory."""
+    try:
+        return json.loads(output)["hookSpecificOutput"]["permissionDecision"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return ""
+
+
+def run_hook(command: str) -> str:
+    """Feed a command to the hook and return whatever it printed."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps({"command": command}),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout
+
+
+class MergeReadinessGate(unittest.TestCase):
+    WARNS: ClassVar[list[tuple[str, str]]] = [
+        (
+            "gh api mergeable_state",
+            "gh api repos/netresearch/t3x-nr-llm/pulls/619 --jq .mergeable_state",
+        ),
+        (
+            "gh pr view mergeStateStatus",
+            "gh pr view 43 -R netresearch/t3x-contexts --json state,mergeStateStatus",
+        ),
+        (
+            "reviewDecision is the same question",
+            "gh pr view 12 -R o/r --json reviewDecision",
+        ),
+        (
+            "inside a loop over several pull requests",
+            "for n in 1 2; do gh api repos/o/r/pulls/$n --jq .mergeable_state; done",
+        ),
+    ]
+
+    QUIET: ClassVar[list[tuple[str, str]]] = [
+        (
+            "pr-status.sh is the recommended shape",
+            "pr-status.sh -R netresearch/t3x-nr-llm 619 --watch",
+        ),
+        (
+            "reading the head sha is not a merge-readiness question",
+            "gh pr view 619 -R o/r --json headRefOid --jq .headRefOid",
+        ),
+        (
+            "reading review comments",
+            "gh api repos/o/r/pulls/619/comments --jq '.[].body'",
+        ),
+        (
+            "the isRequired deep dive names the unmet context",
+            "gh api graphql -f query='{...isRequired(pullRequestNumber:619)... mergeStateStatus}'",
+        ),
+        (
+            "merging itself",
+            "gh pr merge 619 -R o/r --merge",
+        ),
+        (
+            "the word in prose, not a query",
+            'git commit -m "explain why mergeStateStatus alone is not enough"',
+        ),
+    ]
+
+    def test_asking_github_directly_is_denied(self) -> None:
+        for name, command in self.WARNS:
+            with self.subTest(name):
+                output = run_hook(command)
+                self.assertIn("pr-status.sh", output, name)
+                self.assertEqual("deny", decision(output), name)
+
+    def test_legitimate_commands_are_not_denied(self) -> None:
+        for name, command in self.QUIET:
+            with self.subTest(name):
+                output = run_hook(command)
+                self.assertNotIn("Merge readiness", output, name)
+                self.assertNotEqual("deny", decision(output), name)
+
+
+class ExistingChecks(unittest.TestCase):
+    def test_non_conventional_commit_message_warns(self) -> None:
+        self.assertIn("onventional", run_hook('git commit -m "fixed stuff"'))
+
+    def test_conventional_commit_message_stays_quiet(self) -> None:
+        self.assertNotIn(
+            "onventional", run_hook('git commit -m "fix: correct the tally"')
+        )
+
+    def test_force_push_warns(self) -> None:
+        self.assertIn("Force push", run_hook("git push -f origin main"))
+
+    def test_hard_reset_warns(self) -> None:
+        self.assertIn("Hard reset", run_hook("git reset --hard origin/main"))
+
+    def test_unrelated_command_produces_nothing(self) -> None:
+        self.assertEqual("", run_hook("ls -la"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -214,6 +214,47 @@ def handrolled_pr_poll(cmd: str) -> str | None:
     )
 
 
+# Asking GitHub directly whether a pull request can merge is the poll above
+# without the loop: `gh pr view --json mergeStateStatus` and
+# `gh api .../pulls/N --jq .mergeable_state` answer "blocked" and never say
+# why, staying blind to the two states that usually cause it — an unresolved
+# review thread and a failing check. pr-status.sh reports both and ends with a
+# NEXT: line naming the action.
+#
+# Only a segment that actually INVOKES gh counts. Matching the words anywhere
+# would block writing ABOUT the rule: a heredoc carrying test cases, an echo,
+# a grep pattern, this rule's own tests.
+MERGE_READINESS_FIELD = re.compile(
+    r"\bmergeable_state\b|\bmergeStateStatus\b|\bmergeable\b|\breviewDecision\b"
+)
+# A loop body arrives as " do gh api ..." once the command is split on
+# separators, so the shell keywords that can precede the call are skipped.
+QUERIES_FORGE = re.compile(r"\s*(?:(?:do|then|else|\{)\s+)*gh\s+(?:pr\s+view|api)\b")
+
+
+def merge_readiness_without_pr_status(cmd: str) -> str | None:
+    # A command that already runs pr-status.sh is the recommended shape, and
+    # `isRequired` is the GraphQL query naming WHICH required context is unmet
+    # — a deliberate deep dive pr-status.sh does not break down.
+    if "pr-status.sh" in cmd or "isRequired" in cmd:
+        return None
+
+    for segment in re.split(r"(?:\|\||&&|[;|&\n])", cmd):
+        if QUERIES_FORGE.match(segment) and MERGE_READINESS_FIELD.search(segment):
+            return (
+                "Merge readiness asked of gh directly. Use "
+                "`pr-status.sh -R <owner/repo> <pr>` instead: it reports checks, "
+                "reviews, rulesets and unresolved threads together and ends with "
+                "a NEXT: line naming the action. mergeable_state and "
+                "mergeStateStatus answer only 'blocked' and never say why, so an "
+                "unresolved thread or a red check stays invisible and the pull "
+                "request looks like it is merely waiting. To find out which "
+                "required context is unmet, run pr-status.sh first, then the "
+                "GraphQL query with `isRequired` — that one is not gated."
+            )
+    return None
+
+
 def check_conventional_commit(message: str) -> str | None:
     """Validate commit message follows conventional commits."""
     if not re.match(CONVENTIONAL_COMMIT_PATTERN, message):
@@ -327,7 +368,12 @@ def main():
     # Gates that refuse the call outright. Checked before the advisory
     # warnings because a denied command never runs, so warning about its
     # style would be noise.
-    for gate in (forge_body_hard_wrapped, reply_path_without_pr, handrolled_pr_poll):
+    for gate in (
+        forge_body_hard_wrapped,
+        reply_path_without_pr,
+        handrolled_pr_poll,
+        merge_readiness_without_pr_status,
+    ):
         reason = gate(command)
         if reason:
             deny(reason)


### PR DESCRIPTION
The skill already documents `pr-status.sh` as the status tool for the wait/merge cycle, and the hook already gates the hand-rolled *poll*. The single-shot query was not gated: `gh pr view --json mergeStateStatus` and `gh api .../pulls/N --jq .mergeable_state` answer "blocked" and never say why, staying blind to the two states that usually cause it — an unresolved review thread and a failing check.

Documenting it did not hold. In one session I issued 24 such queries despite the rule being in my own instructions, and told the operator a pull request was "waiting for your approval" while two CodeQL review threads and two red CI jobs sat unattended. They had to point it out. That is what this gate is for.

Scope is deliberately narrow. Only a segment that actually invokes `gh` counts, and shell keywords are skipped so a loop body (` do gh api ...` after splitting on separators) is caught as well — that was the exact shape I kept using. Writing *about* the rule stays possible: a heredoc carrying test cases, an echo, a grep pattern, this rule's own tests. Commands that already run `pr-status.sh` pass, and so does the GraphQL query carrying `isRequired` — that one names which required context is unmet, which pr-status.sh does not break down, so it is a deliberate deep dive rather than a status check.

`scripts/validate_git_command.py` had no tests at all. It has them now — standard library only, no dependency to install — covering the new gate in both directions plus the conventional-commit, force-push and hard-reset checks that were already there, and a CI job runs them. A PreToolUse hook decides whether commands run in every session that installs this plugin, so a silent regression there is expensive.