### PR TITLE
docs: recipes for rebasing, splitting and describing long-lived branches

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, resolving PR review comments, merging PRs (including CI verification, auto-merge queues, and post-merge cleanup), managing PR review threads, merging PRs with signed commits, handling merge conflicts, integrating Git with CI/CD, setting up git hooks (lefthook, captainhook, husky, pre-commit), or debugging hook-install failures in git worktrees. Not for creating releases (use github-release) or diagnosing BLOCKED/won't-merge PRs (use github-project)."
+description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, resolving PR review comments, merging PRs (including CI verification, auto-merge queues, and post-merge cleanup), managing PR review threads, merging PRs with signed commits, handling merge conflicts, rebasing a long-lived branch onto a moved base or splitting one into several PRs, integrating Git with CI/CD, setting up git hooks (lefthook, captainhook, husky, pre-commit), or debugging hook-install failures in git worktrees. Not for creating releases (use github-release) or diagnosing BLOCKED/won't-merge PRs (use github-project)."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -377,5 +377,75 @@
         "pattern": "(?i)(stage|git add|commit).{0,60}(then|before).{0,20}(git rm|remove|delete)|recoverable.{0,30}(removal|history)|enters? .{0,10}history"
       }
     ]
+  },
+  {
+    "name": "detect_upstream_work_dropped_by_merge",
+    "prompt": "This branch carries a 'Merge branch develop' commit. Before I merge it back, how do I check that the merge did not silently drop changes develop had made?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(merge-base|merge-file|--diff3)"
+      },
+      {
+        "type": "content",
+        "pattern": "(revert|dropped|discard|silently)"
+      }
+    ]
+  },
+  {
+    "name": "rebase_long_branch_with_reference_merge",
+    "prompt": "I need to rebase a 35-commit branch onto a base that moved a lot. How do I make sure the result is correct?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(reference merge|REF|merge the base into)"
+      },
+      {
+        "type": "content",
+        "pattern": "git diff.*(REF|HEAD)"
+      }
+    ]
+  },
+  {
+    "name": "pr_body_must_match_current_diff",
+    "prompt": "This MR has been open for eight months and I just rebased it. Update the description.",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(git diff|re-derive|verify).*(target|HEAD|base)"
+      },
+      {
+        "type": "content",
+        "pattern": "(stale|no longer|delete the section|remove)"
+      }
+    ]
+  },
+  {
+    "name": "check_ci_enabled_before_watching_pipeline",
+    "prompt": "I pushed 20 minutes ago and no pipeline has appeared for the merge request. Keep waiting?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(jobs_enabled|builds_access_level|CI.*(disabled|switched off))"
+      },
+      {
+        "type": "content",
+        "pattern": "(403|projects/)"
+      }
+    ]
+  },
+  {
+    "name": "verify_branch_split_by_blob_identity",
+    "prompt": "I split one big branch into six smaller branches. How do I prove nothing was left behind?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(rev-parse|blob|object id)"
+      },
+      {
+        "type": "content",
+        "pattern": "(each file|every changed file|not carried)"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1114,3 +1114,93 @@ A tree can hold untracked files the user explicitly keeps untracked; `-A`/`.` sw
 ## Bulk sed/rename across a worktree must not touch its `.git` FILE
 
 A linked worktree's `.git` is a file holding a `gitdir:` pointer, not a directory — `--exclude-dir=.git` does NOT protect it, and a blind `sed -i` over `grep -rl` output rewrites the pointer and breaks the worktree (`fatal: not a git repository`). Exclude the path explicitly (`grep -rl --exclude=.git` or filter the file list) before any bulk edit.
+
+## A long rebase needs a reference merge to resolve against
+
+Replaying dozens of commits onto a moved base means meeting the same conflict
+several times, each time in a different intermediate state, with nothing at the
+end that says the result is right. Build the answer once, then resolve against
+it:
+
+```bash
+# 1. Target state, in a throwaway worktree: merge the base into the branch tip
+#    and resolve the (few) genuine conflicts by hand.
+git -C .bare worktree add --detach /tmp/ref <branch>
+git -C /tmp/ref merge --no-commit --no-ff origin/<base>   # resolve by hand, then
+git -C /tmp/ref commit -m REF                             # REF = the tree to land on
+
+# 2. Rebase for real; resolve each conflict from REF instead of re-deciding it.
+git checkout <REF-sha> -- <conflicted-path>
+
+# 3. The assertion that makes the detour worth it.
+git diff --stat <REF-sha> HEAD    # must print nothing
+```
+
+Step 3 is the point. It catches what conflict markers cannot: in one 35-commit
+rebase it surfaced a duplicated `autoload-dev` block in `composer.json` that Git
+had merged cleanly from two sides. Commits that come out empty are branch
+fixups already contained in REF — `git rebase --skip` them, or fold them with
+`--autosquash` afterwards.
+
+Two caveats. Resolving from REF puts final content into intermediate commits, so
+individual commits are no longer independently green — acceptable when the
+branch is reviewed as a whole or about to be fixup-folded, not when it must stay
+bisectable. And this is the one safe use of `git checkout <ref> -- <path>`
+against a dirty tree (see the rule above): a conflicted file's content lives in
+committed objects on both sides, so nothing unrecoverable is overwritten.
+
+## A merge resolved in favour of the branch silently reverts upstream work
+
+When `Merge branch 'develop'` keeps the branch's version of a file, the upstream
+changes it dropped disappear without a trace: from the *next* merge base that
+revert looks like an intentional branch edit, so no later diff, rebase, or
+review flags it. Observed cost — a merge discarded four files' worth of an
+upstream "raise phpstan to level 1" commit, reinstating an
+`(string)isset(...) !== ''` expression and an `empty()` test against an
+`ObjectStorage` that is never true. Both survived a rebase, because the rebase
+faithfully replayed the bad resolution.
+
+Cheap check first — which files upstream touched since the merge still differ:
+
+```bash
+for f in $(git diff --name-only <upstream-parent-of-merge> origin/<base>); do
+  git diff --quiet origin/<base> HEAD -- "$f" || echo "DIFFERS: $f"
+done
+```
+
+Then redo the resolution properly per suspect file, with the *true* ancestor of
+that merge — not today's merge base, which already contains the bad resolution:
+
+```bash
+BASE=$(git merge-base <branch-parent-of-merge> <upstream-parent-of-merge>)
+git show "$BASE:$f" > /tmp/base && git show <branch>:"$f" > /tmp/ours \
+  && git show origin/<base>:"$f" > /tmp/theirs
+git merge-file -p --diff3 /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
+diff -u "$f" /tmp/merged      # differences here are upstream work the merge dropped
+```
+
+Worth running on any branch that carries a `Merge branch '<base>'` commit and is
+about to be merged back.
+
+## Verify a branch split by blob identity, not by reading the diffs
+
+Splitting one branch into several — per topic, per reviewer, to unblock the
+easy parts — invites silently leaving something behind. Reading the diffs cannot
+prove coverage; comparing object ids can:
+
+```bash
+for f in $(git diff --name-only origin/<base> <umbrella>); do
+  u=$(git rev-parse "<umbrella>:$f")
+  carried=""
+  for b in <branch-1> <branch-2> …; do
+    [ "$(git rev-parse "$b:$f" 2>/dev/null)" = "$u" ] && carried=$b && break
+  done
+  [ -n "$carried" ] || echo "NOT CARRIED: $f"
+done
+```
+
+Everything the loop prints is either a deliberate drop — name each one — or an
+oversight. Files that several branches change by hunk (`composer.json`, a CI
+config) never match a single branch and need the complementary check: parse both
+sides and compare key by key, e.g. `yaml.safe_load` per job for a CI file, so
+"no job lost" is a computed result rather than an impression.

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -98,6 +98,30 @@ Treat `unable to review` as **no review** and re-request; if the re-request retu
 
 **On a docs/prose PR the loop does not decay — it must be actively terminated.** The bot re-reads the whole changed file each round and keeps surfacing a *new cosmetic* nit (wording, an illustrative example value, a spelling), so pushing a fix just triggers another round almost indefinitely. To converge: once a finding is purely cosmetic and defensible, **reply on the thread and resolve it *without* a new commit** — no push means no re-review means no new nit. Reserve fresh pushes for substantive findings; batch several real fixes into one push rather than one-per-thread.
 
+## Check the producer is switched on before arming the watcher
+
+A watch whose event can never be produced is indistinguishable from one whose
+event has not arrived yet: both are silence. Before waiting on a pipeline,
+confirm the host will create one at all — a project can have CI switched off
+entirely, and then no push, force-push or retarget produces anything to watch.
+
+On GitLab the give-away is that pipeline endpoints alone refuse a token that
+works everywhere else — `GET /projects/:id/pipelines` and `/jobs` return `403`
+while `/projects/:id` and the merge-request endpoints return `200`. That is not a
+scope problem:
+
+```bash
+glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}'
+# {"jobs_enabled": false, "builds_access_level": "disabled"} -> nothing will run
+```
+
+Observed cost: two watchers armed across ~40 minutes for a merge request whose
+project had `builds_access_level: disabled`, reported to the user as "no
+pipeline yet" when the correct answer was "no pipeline, ever, until someone
+re-enables CI". Give a wait a stop condition it can actually reach, and when a
+watch stays silent past the expected window, re-check the producer rather than
+extending the timeout.
+
 ## Auto-merge armed + CLEAN but never enqueued: disable/re-enable to nudge
 
 On a merge-queue repo a PR can sit `CLEAN` with auto-merge **armed** and every required check green, yet never gets a `mergeQueueEntry` — it silently fails to enter the queue, so the watcher just times out. Confirm the symptom, then re-arm to force GitHub to re-evaluate enqueue-readiness:

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -203,6 +203,25 @@ Build the before/after table *before* writing the summary sentence. Filling in
 the rows is what catches the case you assumed was untouched; writing the
 sentence first only records the assumption.
 
+### A long-lived PR body describes the branch it had, not the branch it has
+
+A body written months ago documents a state the branch has since left. Every
+rebase, revert and upstream merge invalidates part of it, and nothing in the
+tooling notices. Before publishing an update, re-derive each factual claim from
+`git diff <target>...HEAD` — image tags, memory limits, thresholds, and above
+all the New/Changed column: a job listed as **New** that the target already has
+hides whatever your version alters about it.
+
+Observed in one MR: a "switched coverage to PCOV" section after PCOV had been
+reverted, `php:8.3` images that were `8.4`, `MSI 70/80` against an actual
+`19/77`, and a job marked **New** that existed upstream — which concealed that
+the change also dropped its memory limit from 2G to 512M.
+
+When a change is gone, **delete its section**. Rewording it to "X stays the
+coverage driver" replaces a false statement with a true but empty one: the body
+is the delta against the target, and something that does not change has no row
+in it.
+
 ### When you already have the fix, lead with it
 
 Issue templates order evidence before solution — they are written for reports


### PR DESCRIPTION
## Summary

Five recipes from an eight-month-old merge request that was rebased onto a base 20 commits ahead and then split into eight MRs. Each one is a technique the session had to work out from scratch because the skill did not cover it.

## Came from

`/retro` session on 2026-08-10: `3e729d81-7fec-4248-8f83-22e84ac39467`
Findings: B16 (hard-won technique) x3, B18 (review-issue learning), A6 (user correction) x2, B15 (trigger-coverage gap)

- **Symptom:** a 35-commit rebase with repeated conflicts and no end-state check; an earlier merge had silently reverted upstream work in four files and survived the rebase; the MR body carried four claims that no longer matched the diff, corrected twice by the user; two pipeline watchers ran ~40 minutes for a project whose CI was switched off; the skill never triggered despite the session being almost entirely rebase and MR work.
- **Cause:** the skill covers rebase *mechanics* (interactive rebase, `--onto`, autosquash, rerere) but not how to know the result is *correct*, nor that a branch-favoured merge resolution is invisible afterwards. `pull-request-workflow.md` verifies behavioural claims but not that the body still matches the branch. `merge-gate-watcher.md` covers watchers whose event is late, not watchers whose event cannot occur.
- **Required behavior:** build a reference merge and assert the rebased tree equals it; re-resolve suspect files against the true ancestor of the earlier merge; re-derive the PR body from `git diff <target>...HEAD` and delete sections for changes that no longer exist; confirm CI is enabled before arming a pipeline watch; verify a split by blob identity.
- **Verification:** `evals/evals.json` — `detect_upstream_work_dropped_by_merge`, `rebase_long_branch_with_reference_merge`, `pr_body_must_match_current_diff`, `check_ci_enabled_before_watching_pipeline`, `verify_branch_split_by_blob_identity`

## Change

| File | Section |
|---|---|
| `references/advanced-git.md` | reference merge for long rebases; detecting upstream work a merge dropped; blob-identity verification of a branch split |
| `references/pull-request-workflow.md` | a long-lived PR body describes the branch it had, not the branch it has |
| `references/merge-gate-watcher.md` | check the producer is switched on before arming the watcher |
| `SKILL.md` | description gains "rebasing a long-lived branch onto a moved base or splitting one into several PRs" |
| `evals/evals.json` | one scenario per new section |

The reference-merge recipe uses `git checkout <REF> -- <path>` against a dirty tree, which `advanced-git.md` otherwise forbids. The new section says why this case is exempt (both sides of a conflicted file are committed objects) so the two do not read as contradicting each other.

## Test plan

- [x] `Build/Scripts/validate-skill.sh` — 0 errors, 0 warnings
- [x] `skill-repo/scripts/validate-evals.sh` — 63 passed, 0 failed
- [x] `tests/test_validate_git_command.py` — 0 failures
- [x] pre-commit hooks ran on every commit (markdownlint, trailing whitespace, EOF)
- [x] SKILL.md at 497/500 words — noted in the commit so the next edit goes to a reference file
- [ ] Reviewer check: the `git merge-file --diff3` recipe reproduces on a branch with a `Merge branch <base>` commit
