### PR TITLE
feat(merge-queue): diagnose a silent dequeue and batch PRs through the queue

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -162,6 +162,30 @@
       "name": "blocked-with-everything-green",
       "prompt": "My PR is mergeStateStatus BLOCKED. Every check passes, no review thread is open, the ruleset needs zero approvals and every required context is present. What is holding it?",
       "expected_output": "Should suspect an unsigned commit rather than re-reading branch protection: a required_signatures ruleset is shut by one commit anywhere on the branch that carries no valid signature, and GitHub surfaces that only as BLOCKED, never as a failing check or a rollup entry, so nothing visible names it; should check every commit on the branch, not just the head, and re-sign the branch with a rebase that amends each commit rather than only the tip"
+    },
+    {
+      "id": 28,
+      "name": "merge-queue-dequeued-no-comment",
+      "prompt": "My PR entered the merge queue and left it 85 seconds later. It is still OPEN, mergeStateStatus is CLEAN, there is no bot comment and no failing check on the PR. Why was it dequeued?",
+      "expected_output": "Should look for the answer on the queue's own branch rather than on the PR: the required checks run on gh-readonly-queue/<base>/pr-<n>-<sha> and a failure there dequeues silently, invisible to every PR-scoped query; should list the workflow runs whose head_branch starts with that prefix, open the failing run's jobs and read the failing step's log; should time-box the branch filter to after the re-queue so an earlier failed run is not read as the current one; should not conclude the PR itself is defective before reading that log, since a network-dependent step in a required check (e.g. composer audit against an unreachable advisory endpoint) dequeues an otherwise sound PR"
+    },
+    {
+      "id": 29,
+      "name": "is-red-check-blocking",
+      "prompt": "A check on my PR is red and the PR is BLOCKED. Should I fix the red check first?",
+      "expected_output": "Should establish whether that check is required before acting, because neither gh pr checks nor statusCheckRollup says so; should query isRequired(pullRequestNumber:) on the rollup contexts via GraphQL and note the PR number is passed both to pullRequest(number:) and to each isRequired call; should treat a null conclusion among the required contexts as a still-running check and identify that, not the red non-required one, as what BLOCKED is waiting on"
+    },
+    {
+      "id": 30,
+      "name": "many-prs-one-merge-queue",
+      "prompt": "I have ten independent PRs, all green, on a repo with a merge queue. They all touch CHANGELOG.md so each merge conflicts the next. How do I get them in?",
+      "expected_output": "Should merge them locally into one integration branch and send that single branch through the queue instead of queueing ten times; should resolve the accumulator file once and then verify the merged result rather than trusting a keep-both-sides resolution, which duplicates entries and flattens section assignment; should run the full gate on the integration branch because combination breaks exist that no individual PR can show; should prove each PR's work landed with git merge-base --is-ancestor before closing anything; should note the batched PRs close as CLOSED not MERGED, so their Closes-keywords never fire and the issues need closing by hand; should not use this for a stacked chain, where merging the tip is the answer"
+    },
+    {
+      "id": 31,
+      "name": "commit-after-failed-conflict-resolver",
+      "prompt": "My resolver script exits 1 when it finds a conflict it cannot handle. I run it and then `git add -A && git commit` in the same command. Is that safe?",
+      "expected_output": "Should say no: the && chain starts fresh after the failed command, so the commit runs anyway and lands conflict markers in the tree, reported by nothing until a later gate run; should propose a commit-time gate rather than more care — a PreToolUse Bash hook that denies git commit when staged blobs carry a marker; should note the check must be anchored at line start on <<<<<<< and >>>>>>> and must not treat a bare ======= as a marker, since that is an ordinary RST section underline"
     }
   ]
 }

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -152,6 +152,34 @@ jq -e '.hooks' .claude/settings.json
 
 The settings watcher only picks up new hook files if `.claude/` existed at session start. If you created `.claude/settings.json` during a session, open `/hooks` once to reload.
 
+## Recipe 6: Block `git commit` While Staged Content Has Conflict Markers
+
+A resolver that exits non-zero does **not** stop a following `git add -A && git commit` in the same Bash call — the `&&` chain starts fresh after the failed command, so the commit lands with `<<<<<<<` in the tree and nothing reports it until a later gate run. `verify-git-workflow.sh` finds markers on demand; this denies the commit that would create them.
+
+```bash
+cp <skill>/scripts/conflict-marker-gate.py ~/.claude/hooks/
+chmod +x ~/.claude/hooks/conflict-marker-gate.py
+```
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "python3 $HOME/.claude/hooks/conflict-marker-gate.py" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+It fires only when the command actually runs `git commit` (`git -C <dir> commit` and `git -c k=v commit` included) and only when staged blobs carry a marker. It matches `<<<<<<<` and `>>>>>>>` (each followed by a space) at line start but deliberately **not** a bare `=======`, which is an ordinary RST section underline and would otherwise deny every docs commit. Any error, non-repo cwd or unreadable diff allows the command — the gate never blocks on its own failure.
+
+Verify it against both directions before relying on it: stage a file containing a real marker (must deny) and a `.rst` file with a `=======` underline (must allow).
+
 ## Anti-Patterns
 
 | Anti-pattern | Why wrong | Fix |

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -154,3 +154,57 @@ branch is often auto-deleted). The discipline is cheaper than the recovery:
 ## A queued PR can silently leave the merge queue
 
 A PR queued via `gh pr merge --auto` on a merge-queue repo can drop back out with no visible event: `isInMergeQueue` flips to `false`, `mergeStateStatus` reads `CLEAN`, and nothing merges. Verify the real queue state via GraphQL (`state` / `merged` / `isInMergeQueue` / `mergeStateStatus`) — a status read that only looks at `mergeStateStatus` reports a dropped PR as merge-ready. Re-arm once (`gh pr merge --disable-auto`, then `--auto`, which forces the queue to re-evaluate); if it drops again, diagnose the queue's required contexts instead of re-arming repeatedly.
+
+### The dequeue reason is on the `gh-readonly-queue` branch, never on the PR
+
+The queue runs the required checks on its own branch, `gh-readonly-queue/<base>/pr-<n>-<sha>`, and a failure there dequeues the entry **silently**: no bot comment, no failed check on the PR, `mergeStateStatus` unchanged. Every PR-scoped query therefore answers "ready and waiting" for a PR that was already thrown out. The runs on that branch are the only record:
+
+```bash
+R=owner/repo; PR=123
+# --jq is gh's built-in filter and takes no --arg; pipe to real jq when you need one.
+gh api "repos/$R/actions/runs?per_page=40" \
+  | jq -r --arg p "gh-readonly-queue/main/pr-$PR-" '
+      .workflow_runs[] | select(.head_branch | startswith($p))
+      | "\(.created_at) \(.name) \(.status)/\(.conclusion)"' | sort -r
+```
+
+Then open the failing run's jobs and steps:
+
+```bash
+RID=<id from above>
+gh api "repos/$R/actions/runs/$RID/jobs" --jq '.jobs[] | select(.conclusion=="failure") | .name'
+gh api "repos/$R/actions/jobs/<job-id>/logs"      # the step output, for the actual cause
+```
+
+Two consequences for the diagnosis:
+
+- **Time-box the branch filter.** A re-queued PR produces a *second* run set on a branch whose name shares the `pr-<n>-` prefix. A filter matching only the prefix returns the old failed run alongside the new one and reads as a fresh failure. Add `select(.created_at > $since)` with the re-queue time.
+- **A dequeue is not evidence of a defect in the PR.** Observed 2026-08-09 (netresearch/t3x-nr-llm#686): five of six workflows green, `Checks` red on one job — `composer audit` exited 100 because `https://packagist.org/api/security-advisories/` answered HTTP 502. The identical workflow had passed on the previous queue branch 30 minutes earlier. Read the step log before concluding anything about the branch; a network-dependent step in a required check turns any upstream outage into a dequeue.
+
+## Watcher cost: GraphQL and REST rate limits are separate budgets
+
+`gh pr view --json statusCheckRollup` is a GraphQL query and an expensive one. Two watchers polling it every 60 s exhausted the **GraphQL** budget (29 of 5000 left) while the REST **core** budget still showed 4614 of 5000 — and once that happened, plain REST calls also began returning `403 API rate limit exceeded`. That combination (one resource drained, the other healthy, both refused) is the **secondary** limit reacting to request density, not the quota. Read the resources separately rather than trusting a single number:
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | "\(.key): \(.value.remaining)/\(.value.limit)"'
+```
+
+Three rules follow, and they cost nothing:
+
+- **One watcher per subject.** Two loops on the same PR double the spend and tell you the same thing.
+- **Poll REST, not GraphQL, for liveness.** `gh api repos/$R/pulls/$PR` and `gh api repos/$R/commits/$SHA/check-runs` answer state and checks from the cheaper budget.
+- **180 s, not 60 s.** A merge queue does not resolve in a minute; the faster interval buys nothing and is what drains the budget.
+
+Recovery is waiting: `gh api rate_limit --jq '.resources.graphql.reset'` is an epoch timestamp — sleep to it in **one** background command rather than retrying into the limit.
+
+### `gh api` writes its error to stdout — test a field, never emptiness
+
+On a 404 (or any error) `gh api` prints a JSON error object to **stdout** and exits non-zero. A watcher that decides on "did I get output?" reads the error as the answer:
+
+```bash
+rel=$(gh api repos/$R/releases/tags/$TAG --jq '.tag_name' 2>/dev/null)
+[ -n "$rel" ] && echo "release exists"       # WRONG — fires on the 404 body
+case "$rel" in "$TAG") echo "release exists";; esac   # right — tests the value
+```
+
+Observed 2026-08-09: a release watcher announced "release published" while the API was still answering 404 and the workflow was mid-run. Match the value you expect, or add `-q` handling that distinguishes exit status from output.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1380,10 +1380,87 @@ gh pr merge <CHILD_NUMBER> --merge       # NO --delete-branch mid-stack
 Delete all stack branches in one pass **after the last PR merged** (a repo
 with "automatically delete head branches" usually does it for you).
 
+#### GitHub-native stacked PRs: merge the tip, not each PR in turn
+
+The sequence above is for a **hand-built** chain. GitHub's native Stacked PRs
+feature (public preview, `gh stack`) behaves differently and the difference is
+the whole point of using it: **merging the top PR merges every PR beneath it in
+one operation.** Walking the stack bottom-up there is not merely slower — on a
+merge-queue repo it is actively worse, because each PR costs its own queue cycle
+and the queue's merge-correctness validation rejects two chained entries that are
+in flight at the same time ("invalid changes in the merge commit").
+
+```bash
+gh pr merge <TIP_NUMBER> --merge --auto     # the whole stack lands
+```
+
+Verify containment before assuming a lower PR is covered, rather than reading it
+off the UI:
+
+```bash
+git merge-base --is-ancestor "$(gh pr view <LOWER> --json headRefOid --jq .headRefOid)" \
+                             "$(gh pr view <TIP>   --json headRefOid --jq .headRefOid)" \
+  && echo "LOWER is contained in TIP"
+```
+
+Observed 2026-08-09 (netresearch/t3x-nr-llm): merging only #665 landed #663, #664 and #665 together; the preceding attempt to queue all three separately was rejected by the queue three times. The PRs that were merged this way close as
+`MERGED`; PRs whose commits reach `main` through a *different* PR (see batching,
+below) close as `CLOSED` and need their issues closed by hand.
+
+One preview-era caveat worth knowing before relying on it: deleting a lower
+branch can **close** the PR above it rather than retarget it, and a closed PR of
+this kind cannot be reopened. Leave `--delete-branch` off until the stack is
+fully merged.
+
 Related: a workflow **rerun executes the frozen merge commit** — it does not
 re-resolve `refs/pull/N/merge` against the moved base. A check that depends
 on base state (template drift, conflict detection) stays wrong after main
 moved; push a base-merge into the PR branch instead of rerunning.
+
+### Many independent PRs, one queue: batch them into an integration branch
+
+A merge queue serializes by design, so N ready PRs cost N queue cycles — and if
+they all touch one accumulating file (`CHANGELOG.md`, a docs index), each merge
+also invalidates the next one's merge commit, so every PR needs a forward-merge
+before its turn. Thirteen PRs took several hours this way and merged one per
+hour at best.
+
+When the PRs are genuinely independent, merge them locally into one integration
+branch and send that through the queue instead. Two cycles replaced thirteen
+(netresearch/t3x-nr-llm#685 with ten PRs, #686 with three chain tips, both
+2026-08-09).
+
+```bash
+git -C .bare worktree add ../integration -b integration/batch-$(date +%F) origin/main
+cd ../integration
+for pr in 648 653 676 677; do
+  git merge --no-edit "$(gh pr view $pr --json headRefOid --jq .headRefOid)"
+done
+```
+
+Four things decide whether this pays off, and skipping any of them costs more
+than the batching saved:
+
+- **Resolve the accumulator files once, deliberately.** The conflicts are almost
+  always confined to append-only files. Auto-resolving them by keeping *both*
+  sides works for the content but **duplicates entries and flattens section
+  assignment** when the same entry was reworded on both sides — verify the
+  merged file afterwards (count entries, check for duplicates) instead of
+  trusting the resolver. Anything outside that known set is a real conflict:
+  stop and resolve it by hand.
+- **Run the full gate on the integration branch, not on the individual PRs.**
+  Combination breaks exist that no single PR can show: a constructor argument
+  another PR makes mandatory, two PRs extending the same factory differently.
+  Three such breaks appeared across two batches here — all invisible per-PR,
+  all caught by the batch gate.
+- **Prove containment before closing anything.** `git merge-base --is-ancestor
+  <pr-head> origin/main` per PR, after the batch merges. This is the only
+  evidence that a PR's work actually landed.
+- **The batched PRs close as `CLOSED`, not `MERGED`,** so GitHub does not run
+  their `Closes #N` keywords. Close those issues explicitly and say which PR
+  carried them, or the backlog silently keeps them open.
+
+Do not batch PRs that are chained (a stack) — merge the tip instead, see above.
 
 ### Follow-up pushes to an armed PR branch: confirm the PR is still OPEN
 
@@ -1787,6 +1864,36 @@ gh api repos/{owner}/{repo}/pulls/NUMBER/requested_reviewers \
 
 (`gh pr edit --add-reviewer` rejects the bot login with "Could not resolve
 user"; the REST `requested_reviewers` endpoint is the working path.)
+
+#### Is that red check actually blocking? `isRequired` is the only answer
+
+A failing check is not automatically a blocker, and neither `gh pr checks` nor
+`statusCheckRollup` says which ones the base branch requires — so a red
+non-required check gets chased for nothing while the real blocker stays
+invisible. `isRequired(pullRequestNumber:)` on the rollup contexts answers it
+directly, and unlike `repos/{owner}/{repo}/rules/branches/BASE` it does not need
+permissions that a token may lack:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"OWNER", name:"REPO") {
+    pullRequest(number:NUMBER) {
+      mergeable mergeStateStatus
+      commits(last:1){nodes{commit{statusCheckRollup{contexts(last:100){nodes{
+        ...on CheckRun{name conclusion isRequired(pullRequestNumber:NUMBER)}
+        ...on StatusContext{context state isRequired(pullRequestNumber:NUMBER)}}}}}}}
+    } } }' --jq '
+  [.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]
+   | select(.isRequired==true) | "\(.name // .context) = \(.conclusion // .state)"] | .[]'
+```
+
+A `null` in that output is a required check still running — that, not the red
+one, is what `BLOCKED` is waiting on. Observed 2026-08-09
+(netresearch/t3x-nr-llm#687): `copilot-pull-request-reviewer` was red for the
+whole run and never appeared in the required list; the PR merged on it. Note the
+number is passed twice — once to `pullRequest(number:)` and once to each
+`isRequired(pullRequestNumber:)`; omitting the second yields a schema error, not
+a default.
 
 **Always check for an ongoing review before merging — don't merge on a
 transient `CLEAN`.** A bot review can be *in progress* (after a re-request, and

--- a/skills/git-workflow/scripts/conflict-marker-gate.py
+++ b/skills/git-workflow/scripts/conflict-marker-gate.py
@@ -67,6 +67,7 @@ def staged_conflict_files():
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
         )
         if names.returncode != 0:
             return []
@@ -80,6 +81,7 @@ def staged_conflict_files():
                 capture_output=True,
                 text=True,
                 timeout=10,
+                check=False,
             )
             if blob.returncode == 0 and MARKER.search(blob.stdout):
                 hits.append(name)

--- a/skills/git-workflow/scripts/conflict-marker-gate.py
+++ b/skills/git-workflow/scripts/conflict-marker-gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""PreToolUse hook for Bash: deny `git commit` while staged content still carries
+merge-conflict markers.
+
+Why this exists: a resolver script that aborts does NOT stop a following
+`git add -A && git commit` in the same Bash call — the `&&` chain starts fresh
+after the failed command, so the commit lands with `<<<<<<<` in the tree.
+Observed twice in one session (2026-08-09, netresearch/t3x-nr-llm) during a
+batch-merge, caught only by a later gate run and costing a full test cycle each
+time.
+
+verify-git-workflow.sh checks the working tree on demand; this is the
+commit-time gate, and it looks at staged content for every file extension.
+
+Wire it as a PreToolUse hook with matcher "Bash" — see
+references/claude-code-hooks.md, Recipe 6.
+
+Fails open: any error, non-repo cwd, or unreadable diff allows the command.
+"""
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+
+# Real markers are at line start. `=======` alone is excluded on purpose: it is
+# a legitimate RST section underline and would fire on every docs commit.
+MARKER = re.compile(r"^(<<<<<<< |>>>>>>> )", re.MULTILINE)
+
+GUIDANCE = (
+    "Staged content still contains merge-conflict markers ({files}). "
+    "A resolver that exits non-zero does not stop a following `git add && git commit` "
+    "— the chain starts fresh. Resolve the markers, re-stage, then commit. "
+    "Check with: git diff --cached | grep -n '^<<<<<<< \\|^>>>>>>> '"
+)
+
+
+def is_git_commit(command):
+    """True when the command runs `git commit` in any segment of the shell line."""
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:  # unbalanced quotes — nothing reliable to say
+        return False
+
+    for i, token in enumerate(tokens):
+        if token != "git":
+            continue
+        # Skip global options and their values (-C <dir>, -c <k=v>, --git-dir=…)
+        j = i + 1
+        while j < len(tokens) and tokens[j].startswith("-"):
+            if tokens[j] in ("-C", "-c", "--git-dir", "--work-tree"):
+                j += 1
+            j += 1
+        if j < len(tokens) and tokens[j] == "commit":
+            return True
+    return False
+
+
+def staged_conflict_files():
+    """Names of staged files whose staged content carries conflict markers."""
+    try:
+        names = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if names.returncode != 0:
+            return []
+        hits = []
+        for name in names.stdout.split("\n"):
+            name = name.strip()
+            if not name:
+                continue
+            blob = subprocess.run(
+                ["git", "show", f":{name}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if blob.returncode == 0 and MARKER.search(blob.stdout):
+                hits.append(name)
+            if len(hits) >= 5:
+                break
+        return hits
+    except (subprocess.SubprocessError, OSError):
+        return []
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command or not is_git_commit(command):
+        return 0
+
+    files = staged_conflict_files()
+    if not files:
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": GUIDANCE.format(files=", ".join(files)),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/git-workflow/scripts/verify-git-workflow.sh
+++ b/skills/git-workflow/scripts/verify-git-workflow.sh
@@ -236,10 +236,17 @@ fi
 # Check for merge conflicts markers
 echo ""
 echo "=== Conflict Markers ==="
-CONFLICT_FILES=$(grep -rln "<<<<<<< \|======= \|>>>>>>> " --include="*.js" --include="*.ts" --include="*.php" --include="*.py" . 2>/dev/null | grep -v node_modules | grep -v vendor | head -5)
+# Tracked files of ANY type: markers land in .md/.rst/.yaml just as often as in
+# code, and an extension allow-list silently passes those. Anchored at line
+# start, and WITHOUT a bare "=======" branch — that is an ordinary RST section
+# underline and would report every docs tree as conflicted.
+CONFLICT_FILES=$(git grep -lE '^(<<<<<<< |>>>>>>> )' -- . 2>/dev/null | head -5)
+if [[ -z "$CONFLICT_FILES" ]] && ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    CONFLICT_FILES=$(grep -rlE '^(<<<<<<< |>>>>>>> )' . 2>/dev/null | grep -v node_modules | grep -v vendor | head -5)
+fi
 if [[ -n "$CONFLICT_FILES" ]]; then
     echo "❌ Conflict markers found in files:"
-    echo "$CONFLICT_FILES" | sed 's/^/   /'
+    while IFS= read -r conflict_file; do echo "   $conflict_file"; done <<< "$CONFLICT_FILES"
     ((ERRORS++))
 else
     echo "✅ No conflict markers found"


### PR DESCRIPTION
## Summary

Six merge-queue and watcher gaps found by a `/retro` sweep, plus a commit-time gate for the failure that put conflict markers on `main` twice. Every recipe was executed against the live repo before being written down.

## Came from

`/retro` session on 2026-08-09/10. Source: netresearch/t3x-nr-llm — 26 PRs merged and one release cut in one session.

- **Symptom:** A PR entered the merge queue and left it 85 seconds later with no bot comment, no failing check on the PR and `mergeStateStatus` unchanged. Diagnosis took multiple rounds and the user escalated twice.
- **Cause:** The queue runs required checks on `gh-readonly-queue/<base>/pr-<n>-<sha>`; a failure there dequeues silently and is invisible to every PR-scoped query. The actual failure was `composer audit` exiting 100 on an HTTP 502 from Packagist's advisory endpoint — an upstream outage, not a defect in the PR.
- **Required behavior:** Query the runs on that branch, drill into the failing job's step log, and time-box the filter so an earlier failed run is not read as the current one.
- **Verification:** `evals/evals.json` → `merge-queue-dequeued-no-comment`, `is-red-check-blocking`, `many-prs-one-merge-queue`, `commit-after-failed-conflict-resolver`.

## Change

`references/merge-gate-watcher.md`

- Dequeue diagnosis on the `gh-readonly-queue` branch, with the run query, the job/step drill-down and the re-queue time-box.
- Watcher cost: GraphQL and REST are separate budgets. Two 60s `statusCheckRollup` watchers drained GraphQL to 29/5000 while REST core sat at 4614/5000 — and REST then also answered 403. That combination is the secondary limit, not the quota. Rules: one watcher per subject, poll REST, 180s.
- `gh api` writes its error object to **stdout** (verified: 133 bytes on a 404, exit 1), so a watcher testing for non-empty output reads a 404 as success. Observed announcing a release while the workflow was still running.

`references/pull-request-workflow.md`

- `isRequired(pullRequestNumber:)` as the only answer to "is this red check blocking?". A red non-required `copilot-pull-request-reviewer` was chased while a still-running required check was the actual blocker.
- GitHub-native stacked PRs merge from the **tip**; the existing section covers hand-built chains only. Walking a native stack bottom-up costs one queue cycle per PR and gets rejected by merge-correctness validation.
- Batching independent PRs into one integration branch — two queue cycles replaced thirteen — with the four checks that make it safe (resolve accumulators once *and verify*, gate the batch not the PRs, prove containment, close the issues by hand because batched PRs close as `CLOSED`).

`references/claude-code-hooks.md` + `scripts/conflict-marker-gate.py` (new)

Recipe 6: deny `git commit` while staged blobs carry conflict markers. A resolver exiting non-zero does not stop a following `git add -A && git commit` — the `&&` chain starts fresh — so the commit lands with `<<<<<<<` in the tree, reported by nothing until a later gate run. Tested in four directions: real marker denies, RST `=======` underline allows, non-commit command allows, `git -C <dir> commit` denies.

`scripts/verify-git-workflow.sh`

Conflict-marker check now covers tracked files of **any** type. The `js|ts|php|py` allow-list found nothing on the `.md`/`.rst` files that actually carried the markers — verified with a controlled before/after on a repo whose only marker was in `CHANGELOG.md`. The bare `=======` branch is dropped on purpose (RST underline). One pre-existing `SC2001` on an adjacent line fixed because the changed file now fails `shellcheck` in the pre-commit hook.

## Note for review

This repo carries **two** `evals.json` in different formats: `evals/evals.json` (maintained, last change 2026-08-05, `expected_output`) and `skills/git-workflow/evals/evals.json` (unchanged since 2026-06-16, `assertions`) — and the shared validator finds the latter first. The four new evals go in the maintained one. Not reconciled here; flagged rather than fixed.

## Test plan

- [x] Every `gh` recipe executed verbatim against netresearch/t3x-nr-llm (dequeue query, `isRequired`, `rate_limit`, the 404 stdout case)
- [x] `conflict-marker-gate.py` tested in four directions incl. the RST false-positive
- [x] Old vs. new conflict-marker detection compared on a repo whose only marker is in `CHANGELOG.md`
- [x] `Build/Scripts/validate-skill.sh` — 0 errors, 0 warnings
- [x] `validate-evals.sh` — 53 passed, 0 failed
- [x] pre-commit (markdownlint, ruff, shellcheck) green; commit signed and DCO signed-off
