### PR TITLE
fix(pr-merge): verify the merge outcome before reporting success

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -38,6 +38,11 @@ were PR-status probing**, the rulesets endpoint was queried exactly once, and
 It reads `pr-status.sh --json` and refuses unless `NEXT` is `merge`, printing
 the gate that is shut instead. When it does merge it uses the method the
 repository allows and drops `--delete-branch` where a merge queue is active.
+Afterwards it reads the PR back and reports only what it observed — `merged`
+when the state says so, `queued` when the PR really holds a queue entry, and a
+failure with exit 2 otherwise. `gh pr merge` exiting 0 proves nothing on a
+merge-queue repo; see *A pending auto-merge request silently swallows the
+enqueue* below.
 
 Both of those are silent traps for a hand-written `gh pr merge --merge
 --delete-branch`. A repository with `allow_merge_commit: false` answers
@@ -1704,6 +1709,35 @@ feature. Reading that `null` as "arming failed" and re-running `--auto` is a
 wasted round-trip (and can error "already queued"). Confirm the PR is enqueued
 via the GraphQL `mergeQueueEntry { state position }` or the timeline
 `added_to_merge_queue` event — never via `autoMergeRequest`.
+
+**A pending auto-merge request silently swallows the enqueue.** The converse of
+the note above, and the more expensive one: when an auto-merge request *is*
+attached to the PR, `gh pr merge <n> --repo <r> --merge` on a merge-queue
+repository prints its usual success line and **exits 0 while adding nothing to
+the queue**. Measured on one PR: immediately after the call `isInMergeQueue` was
+`false` and the queue was empty; after `gh pr merge <n> --repo <r>
+--disable-auto` the identical call put it at position 1. Nothing shows the
+failure — `gh pr checks` is green, `mergeStateStatus` stays `CLEAN`, no timeline
+event is written, and the shell sees a zero exit — so a driver that trusts the
+exit status reports "queued" for a PR that will never merge. This cost several
+hours of misdiagnosis before the queue was read back. Two habits follow: never
+report an enqueue you have not read back, and check `autoMergeRequest` first
+when a queue entry fails to appear.
+
+```bash
+gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){
+  pullRequest(number:NNN){ state isInMergeQueue
+                           autoMergeRequest{ enabledBy{ login } } }}}'
+# state MERGED                        -> it landed.
+# isInMergeQueue true                 -> really queued.
+# neither, autoMergeRequest non-null  -> the request swallowed it: --disable-auto, then retry.
+```
+
+`pr-merge.sh` does exactly this after every merge call, polls a few seconds for
+the entry to register, and exits 2 with the `--disable-auto` remedy rather than
+claiming an enqueue that did not happen. It reports only — clearing someone
+else's auto-merge request is a caller decision, not a side effect of asking to
+merge.
 
 ### Signing Readiness (Preflight — Before Committing)
 

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -18,9 +18,10 @@
 #   pr-merge.sh -R owner/repo 123
 #   pr-merge.sh -R owner/repo 123 --dry-run   # print the command, run nothing
 #
-# Exit codes: 0 merged (or queued), 1 the gate is shut and nothing was
-# attempted, 2 an error — usage, lookup, or the merge call itself failed.
-# 1 is retryable later; 2 needs a human.
+# Exit codes: 0 merged (or queued) AND confirmed by reading the PR back, 1 the
+# gate is shut and nothing was attempted, 2 an error — usage, lookup, the merge
+# call itself failed, or it exited 0 while nothing merged and nothing entered
+# the queue. 1 is retryable later; 2 needs a human.
 set -uo pipefail
 
 REPO=""; PR=""; DRY=0
@@ -97,8 +98,96 @@ if [ "$RC" -ne 0 ]; then
   exit 2
 fi
 
-if [ "$QUEUE" = "true" ]; then
-  printf 'pr-merge: %s#%s queued (%s, strategy set by the queue)\n' "$REPO" "$PR" "$METHOD"
-else
+# Exiting 0 is not proof that anything happened. On a repository with a merge
+# queue, `gh pr merge --merge` prints its usual success line and adds NOTHING to
+# the queue when an auto-merge request is already attached to the PR: the
+# pending request swallows the enqueue. Observed twice on one repository —
+# immediately after the call `isInMergeQueue` was false and the queue was empty;
+# after `gh pr merge <n> --disable-auto` the identical call put the PR at
+# position 1. Relaying the exit status as "queued" asserted a state that did not
+# exist and cost hours of misdiagnosis, so the outcome is read back before it is
+# claimed. This script reports; clearing the auto-merge request is the caller's
+# decision, not a side effect of asking to merge.
+OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
+
+outcome() {
+  # shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
+  gh api graphql -f owner="$OWNER" -f name="$NAME" -F pr="$PR" -f query='
+  query($owner:String!,$name:String!,$pr:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$pr){
+        state isInMergeQueue autoMergeRequest{ enabledBy{ login } }
+      }
+    }
+  }' 2>/dev/null
+}
+
+# A queue entry is registered asynchronously, so the first read can legitimately
+# answer false for an entry that lands a second later. The poll is bounded: a PR
+# that has not appeared by then does not appear on its own, and a longer wait
+# would be paid by every successful merge too.
+STATE=""; INQ=""; AUTOBY="-"; PROBED=0; ATTEMPT=0
+while :; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if Q=$(outcome) && F=$(printf '%s' "$Q" | jq -er '.data.repository.pullRequest
+        | [ .state, (.isInMergeQueue | tostring),
+            (.autoMergeRequest.enabledBy.login // "-") ] | @tsv'); then
+    IFS=$'\t' read -r STATE INQ AUTOBY <<EOF
+$F
+EOF
+    PROBED=1
+    [ "$STATE" = "MERGED" ] && break
+    # Keyed on what the PR reports, not on the repo-level QUEUE flag: an entry
+    # that exists is an entry, whatever the configuration said a moment ago.
+    [ "$INQ" = "true" ] && break
+  fi
+  [ "$ATTEMPT" -ge 5 ] && break
+  sleep 2
+done
+
+if [ "$STATE" = "MERGED" ]; then
   printf 'pr-merge: %s#%s merged (%s)\n' "$REPO" "$PR" "$METHOD"
+  exit 0
 fi
+if [ "$INQ" = "true" ]; then
+  printf 'pr-merge: %s#%s queued (%s, strategy set by the queue)\n' "$REPO" "$PR" "$METHOD"
+  exit 0
+fi
+
+# Nothing landed. A probe that failed is kept apart from a probe that succeeded
+# and saw nothing: an unreachable API says something about the request, not
+# about the PR, and folding the two together would put a transport failure on
+# the record as a fact about GitHub state. Both exit 2 — what this block exists
+# for is to stop reporting an outcome that was never confirmed.
+if [ "$PROBED" = "0" ]; then
+  {
+    printf 'pr-merge: %s#%s: the merge call exited 0 but the outcome could not be\n' "$REPO" "$PR"
+    printf '  read back — %d GraphQL attempt(s) failed. Whether it merged or was\n' "$ATTEMPT"
+    printf '  enqueued is unknown; establish that before reporting anything:\n'
+    printf '    gh pr view %s --repo %s --json state,mergedAt\n' "$PR" "$REPO"
+  } >&2
+  exit 2
+fi
+
+if [ "$QUEUE" = "true" ]; then
+  OBSERVED="not in the merge queue (state=$STATE, isInMergeQueue=$INQ)"
+else
+  OBSERVED="not merged (state=$STATE)"
+fi
+{
+  printf 'pr-merge: %s#%s failed: gh pr merge %s exited 0 but the PR is %s\n' \
+    "$REPO" "$PR" "$METHOD" "$OBSERVED"
+  if [ "$AUTOBY" != "-" ]; then
+    printf '  An auto-merge request enabled by %s is attached to this PR. A pending\n' "$AUTOBY"
+    printf '  auto-merge request swallows the enqueue: the call succeeds, the queue\n'
+    printf '  stays empty, and neither gh pr checks nor mergeStateStatus shows it.\n'
+    printf '  Clear it, then run this script again:\n'
+    printf '    gh pr merge %s --repo %s --disable-auto\n' "$PR" "$REPO"
+  else
+    printf '  No auto-merge request is attached, so the usual cause (a pending one\n'
+    printf '  swallowing the enqueue) is ruled out here. Re-read the gate before\n'
+    printf '  retrying:\n'
+    printf '    pr-status.sh -R %s %s\n' "$REPO" "$PR"
+  fi
+} >&2
+exit 2

--- a/tests/test_pr_merge_verify_outcome.sh
+++ b/tests/test_pr_merge_verify_outcome.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Regression test: pr-merge.sh must not report an outcome it did not observe.
+#
+# `gh pr merge <n> --merge` on a merge-queue repository prints its usual success
+# line and exits 0 while adding nothing to the queue when an auto-merge request
+# is already attached to the PR. pr-merge.sh relayed that as "queued (--merge,
+# strategy set by the queue)" — a state that did not exist, and hours of
+# misdiagnosis. It now reads the PR back and only claims what it saw.
+#
+# Runs pr-merge.sh against a stubbed `gh` and a stubbed pr-status.sh, so it needs
+# no network and no repo. `sleep` is stubbed away too: the bounded poll between
+# probes is real, and waiting it out would add ~8s per failing case here.
+
+set -uo pipefail
+
+REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-merge.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+SCRIPT="$STUB_DIR/pr-merge.sh"
+cp "$REAL" "$SCRIPT"
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+says() { # says <name> <pattern> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *)      echo "  FAIL $1: output does not contain '$2'"; fail=1 ;;
+    esac
+}
+
+says_not() { # says_not <name> <pattern> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: output wrongly contains '$2'"; fail=1 ;;
+        *)      echo "  ok   $1" ;;
+    esac
+}
+
+# pr-status.sh is resolved next to pr-merge.sh, which is why the script under
+# test is copied into the stub directory rather than run in place.
+#   make_status <queue_active>
+make_status() {
+    cat > "$STUB_DIR/status.json" <<JSON
+{
+  "repo": "o/r", "number": 559, "queue_active": $1,
+  "merge_methods": ["merge", "rebase"],
+  "next": {"action": "merge", "why": "clean", "method": "--merge"}
+}
+JSON
+    cat > "$STUB_DIR/pr-status.sh" <<STATUS
+#!/usr/bin/env bash
+cat "$STUB_DIR/status.json"
+STATUS
+    chmod +x "$STUB_DIR/pr-status.sh"
+}
+
+# `gh` stub. Every invocation is appended to calls.log so the poll can be
+# asserted on. `gh pr merge` always succeeds — that is the whole premise of the
+# bug. `gh api graphql` answers the file named by $STUB_DIR/graphql.json, or
+# exits non-zero when that file is absent (the unreachable-API case).
+make_gh() {
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$1 \$2" >> "$STUB_DIR/calls.log"
+if [ "\$1 \$2" = "pr merge" ]; then
+  echo "Merging pull request #559"
+  exit 0
+fi
+n=\$(grep -c '^api graphql\$' "$STUB_DIR/calls.log")
+if [ -f "$STUB_DIR/graphql.\$n.json" ]; then
+  cat "$STUB_DIR/graphql.\$n.json"; exit 0
+fi
+if [ -f "$STUB_DIR/graphql.json" ]; then
+  cat "$STUB_DIR/graphql.json"; exit 0
+fi
+echo "gh: could not reach api.github.com" >&2
+exit 1
+STUB
+    chmod +x "$STUB_DIR/gh"
+    # No-op sleep: the poll's timing is not what these cases are about.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DIR/sleep"
+    chmod +x "$STUB_DIR/sleep"
+    : > "$STUB_DIR/calls.log"
+}
+
+#   make_pr <file> <state> <isInMergeQueue> <autoMergeLogin|->
+make_pr() {
+    local auto='null'
+    [ "$4" = "-" ] || auto="{\"enabledBy\":{\"login\":\"$4\"}}"
+    cat > "$STUB_DIR/$1" <<JSON
+{"data":{"repository":{"pullRequest":{
+  "state":"$2","isInMergeQueue":$3,"autoMergeRequest":$auto}}}}
+JSON
+}
+
+reset() { rm -f "$STUB_DIR"/graphql*.json; }
+
+run() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 559 2>"$STUB_DIR/err"; }
+graphql_calls() { grep -c '^api graphql$' "$STUB_DIR/calls.log"; }
+
+echo "case 1: queue repo, entry really registered — reports queued, exit 0"
+make_status true; make_gh; reset
+make_pr graphql.json OPEN true -
+out=$(run); rc=$?
+check "exit code" "0" "$rc"
+says "reports queued" "559 queued (--merge, strategy set by the queue)" "$out"
+
+echo "case 2: queue repo, nothing enqueued, auto-merge attached — FAILS, exit 2"
+make_status true; make_gh; reset
+make_pr graphql.json OPEN false renovate
+out=$(run); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+check "stdout silent" "" "$out"
+says     "names the failure"      "failed: gh pr merge --merge exited 0" "$err"
+says     "names the observation"  "not in the merge queue (state=OPEN, isInMergeQueue=false)" "$err"
+says     "names the likely cause" "auto-merge request enabled by renovate" "$err"
+says     "offers --disable-auto"  "gh pr merge 559 --repo o/r --disable-auto" "$err"
+says_not "does not claim queued"  "queued (--merge" "$out$err"
+
+echo "case 3: queue repo, nothing enqueued, NO auto-merge request — no false cause"
+make_status true; make_gh; reset
+make_pr graphql.json OPEN false -
+out=$(run); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says     "rules the cause out" "No auto-merge request is attached" "$err"
+says_not "does not invent an enabler" "enabled by" "$err"
+
+echo "case 4: no queue, PR really merged — reports merged, exit 0"
+make_status false; make_gh; reset
+make_pr graphql.json MERGED false -
+out=$(run); rc=$?
+check "exit code" "0" "$rc"
+says "reports merged" "559 merged (--merge)" "$out"
+
+# The same swallowed-call shape without a queue: exit 0 from gh, PR still open.
+echo "case 5: no queue, PR still OPEN — must not claim merged"
+make_status false; make_gh; reset
+make_pr graphql.json OPEN false -
+out=$(run); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says_not "does not claim merged" "merged (--merge)" "$out"
+says     "names the observation" "not merged (state=OPEN)" "$err"
+
+# A queue entry is registered asynchronously. Giving up on the first read would
+# report a failure for a PR that is on its way into the queue.
+echo "case 6: entry appears on the third probe — polled, then reported queued"
+make_status true; make_gh; reset
+make_pr graphql.1.json OPEN false -
+make_pr graphql.2.json OPEN false -
+make_pr graphql.3.json OPEN true  -
+out=$(run); rc=$?
+check "exit code"      "0" "$rc"
+check "probed 3 times" "3" "$(graphql_calls)"
+says  "reports queued" "559 queued" "$out"
+
+# The poll must stop on its own. Nothing here ever enqueues, so an unbounded
+# loop would hang the suite rather than fail it.
+echo "case 7: never enqueued — the poll is bounded"
+make_status true; make_gh; reset
+make_pr graphql.json OPEN false -
+run >/dev/null; rc=$?
+check "exit code"  "2" "$rc"
+check "5 attempts" "5" "$(graphql_calls)"
+
+# An unreachable API says something about the request, not about the PR. Folding
+# it into "not enqueued" would put a transport failure on the record as a fact
+# about GitHub state — and naming --disable-auto there sends the operator to
+# mutate a PR whose state was never read.
+echo "case 8: GraphQL unreachable — reported as unknown, not as not-enqueued"
+make_status true; make_gh; reset
+run >/dev/null; rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says     "says the outcome is unknown" "the outcome could not be" "$err"
+says_not "does not assert queue state" "isInMergeQueue=" "$err"
+says_not "does not suggest --disable-auto" "--disable-auto" "$err"
+
+# The gate check runs before anything is called; verification must not have
+# moved it or added an API call to a refusal.
+echo "case 9: gate shut — still exit 1, and gh is never called"
+make_gh; reset
+cat > "$STUB_DIR/status.json" <<'JSON'
+{
+  "repo": "o/r", "number": 559, "queue_active": false,
+  "merge_methods": ["merge"],
+  "next": {"action": "fix-ci", "why": "required check(s) failing: build"}
+}
+JSON
+run >/dev/null; rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code"    "1" "$rc"
+check "no gh calls"  "0" "$(wc -l < "$STUB_DIR/calls.log")"
+says  "names the gate" "not merging o/r#559 — fix-ci" "$err"
+
+echo "case 10: --dry-run prints the command and calls nothing"
+make_status true; make_gh; reset
+out=$(PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 559 --dry-run 2>&1); rc=$?
+check "exit code"   "0" "$rc"
+check "no gh calls" "0" "$(wc -l < "$STUB_DIR/calls.log")"
+says  "prints the merge command" "gh pr merge 559 --repo o/r --merge" "$out"
+
+if [ "$fail" -eq 0 ]; then
+    echo "all pass"
+else
+    echo "FAILURES"
+    exit 1
+fi


### PR DESCRIPTION
## The defect

`gh pr merge <n> --repo <r> --merge` on a repository with a merge queue prints its usual success line and exits 0 while adding **nothing** to the queue, when an auto-merge request is already attached to the PR — the pending request swallows the enqueue. `pr-merge.sh` relayed that exit status as `queued (--merge, strategy set by the queue)`.

Observed twice on `netresearch/t3x-nr-llm`. Measured on PR #559: immediately after the call `isInMergeQueue` was `false` and the merge queue was empty; after `gh pr merge 559 --disable-auto` the identical enqueue put it at position 1. Nothing else exposes the failure — `gh pr checks` is green, `mergeStateStatus` stays `CLEAN`, no `added_to_merge_queue` timeline event is written, and the shell sees a zero exit. The tool asserted a state that did not exist, and that cost several hours of misdiagnosis.

## The change

After the merge call succeeds, the script reads the PR back with one GraphQL query for `state`, `isInMergeQueue` and `autoMergeRequest { enabledBy { login } }`, and reports only what it observed: `merged` when the state says so, `queued` when the PR really holds a queue entry, and a failure with exit 2 otherwise. The queued branch keys on `isInMergeQueue` rather than on the repo-level `queue_active` flag from `pr-status.sh` — an entry that exists is an entry, whatever the configuration said a moment earlier.

A queue entry is registered asynchronously, so the first read can legitimately answer `false` for an entry that lands a second later. The read is therefore retried a bounded five times at 2s (~8s worst case) rather than trusted on its first answer or waited out with a fixed sleep; it breaks as soon as the outcome is decided, so a successful merge pays one query.

A probe that failed is kept apart from a probe that succeeded and saw nothing. An unreachable API says something about the request, not about the PR, so that case reports the outcome as **unknown** and does not name a cause — naming `--disable-auto` there would send the operator to mutate a PR whose state was never read. Both cases exit 2, because the point of the block is to stop reporting an outcome that was never confirmed.

Where `autoMergeRequest` is non-null, the failure names the enabler and offers `gh pr merge <n> --repo <r> --disable-auto` plus a retry. The script does not clear the request itself: it reports, and does not mutate state the caller did not ask for.

Exit-code semantics are unchanged in shape — 0 merged or queued, 1 the gate is shut and nothing was attempted, 2 needs a human — with 2 extended to cover "the call exited 0 while nothing merged and nothing entered the queue". The header comment says so.

## Validation

`tests/test_pr_merge_verify_outcome.sh` — 10 cases against a stubbed `gh` and a stubbed `pr-status.sh`, no network and no repo, ~0.6s. It covers the real enqueue, the swallowed enqueue with and without an attached auto-merge request, the non-queue merged and still-open cases, an entry that only appears on the third probe (asserting three GraphQL calls, so the retry is actually exercised), the bounded poll (five attempts, no hang), the unreachable API, and two regression guards that the gate-shut path still exits 1 without calling `gh` and that `--dry-run` still calls nothing.

Because green on a first run is not evidence, the suite was also run against the pre-fix `pr-merge.sh` from `main`: every new assertion fails there (case 2 reports `queued` and exits 0), and the four guards for existing behaviour pass on both. `shellcheck` clean on the script and the test; `pre-commit run --files` on all three paths passes; the full `tests/` suite (2 shell, 1 python) passes the way `tests.yml` runs it.

## Docs

`references/pull-request-workflow.md` gains the failure mode as a named subsection directly beside its converse, the existing "`autoMergeRequest: null` does NOT mean not armed" note, with the GraphQL probe and the three readings of it. The `## Then Merge: scripts/pr-merge.sh` section gains two sentences saying the outcome is now read back and pointing there.
