### PR TITLE
fix(advanced-git): correct the dropped-work check from #158, and make the recipes testable

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -384,15 +384,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(merge-base|merge-file|--diff3)"
+        "pattern": "(merge-file|--diff3)"
       },
       {
         "type": "content",
-        "pattern": "(revert|dropped|discard|silently)"
+        "pattern": "(rev-list --merges|\\^1|\\^2|parents of (that|the) merge|per merge commit)"
       },
       {
         "type": "content",
-        "pattern": "(merge-base|true ancestor|parents of (that|the) merge)"
+        "pattern": "(dropped|discarded|reverted|silently)"
       }
     ]
   },
@@ -402,15 +402,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(reference merge|merge the base into the branch|resolve (each |every )?conflict from)"
+        "pattern": "(reference merge|resolve .{0,20}from (the )?(REF|reference)|against (the )?(REF|reference))"
       },
       {
         "type": "content",
-        "pattern": "git diff.*--stat.*(must (print|be) (nothing|empty)|no output|is empty)"
+        "pattern": "git diff.*--stat.*(ref|head)"
       },
       {
         "type": "content",
-        "pattern": "(worktree add|--detach|throwaway worktree)"
+        "pattern": "((must|should|has to).{0,25}(print|be).{0,12}(nothing|empty)|no output|is empty)"
       }
     ]
   },
@@ -420,15 +420,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "git diff.*(target|base|origin/)\\.\\.\\.?(HEAD|head)"
+        "pattern": "git diff [^ ]*\\.\\.\\.?(head)"
       },
       {
         "type": "content",
-        "pattern": "(re-?derive|re-?check|verify each|against the (current )?diff)"
+        "pattern": "(re-?derive|verify each|against the (current )?diff|no longer (true|matches))"
       },
       {
         "type": "content",
-        "pattern": "(delete|drop|remove) the (section|row|entry).{0,60}(no longer|reverted|gone|does not)"
+        "pattern": "(delete|drop|remove)s? (the|its|any|that|these) sections?"
       }
     ]
   },
@@ -442,11 +442,11 @@
       },
       {
         "type": "content",
-        "pattern": "(CI/CD is|CI is) (disabled|switched off|turned off)"
+        "pattern": "ci( ?/ ?cd)? (is |was |be )?(switched off|disabled|turned off)"
       },
       {
         "type": "content",
-        "pattern": "(cannot|never|will not|won't).{0,30}(be created|occur|arrive|run)"
+        "pattern": "(nothing will run|no pipeline,? (will )?ever|never .{0,30}(created|occur|arrive)|cannot .{0,30}(be created|occur))"
       }
     ]
   },
@@ -456,15 +456,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(rev-parse|blob|object id)"
+        "pattern": "rev-parse( --verify)?[^|]*:\\$?f"
       },
       {
         "type": "content",
-        "pattern": "(each file|every changed file|not carried)"
+        "pattern": "(blob|object id)"
       },
       {
         "type": "content",
-        "pattern": "(NOT CARRIED|deliberate drop|left behind)"
+        "pattern": "not carried"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -389,6 +389,10 @@
       {
         "type": "content",
         "pattern": "(revert|dropped|discard|silently)"
+      },
+      {
+        "type": "content",
+        "pattern": "(merge-base|true ancestor|parents of (that|the) merge)"
       }
     ]
   },
@@ -398,11 +402,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(reference merge|REF|merge the base into)"
+        "pattern": "(reference merge|merge the base into the branch|resolve (each |every )?conflict from)"
       },
       {
         "type": "content",
-        "pattern": "git diff.*(REF|HEAD)"
+        "pattern": "git diff.*--stat.*(must (print|be) (nothing|empty)|no output|is empty)"
+      },
+      {
+        "type": "content",
+        "pattern": "(worktree add|--detach|throwaway worktree)"
       }
     ]
   },
@@ -412,11 +420,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(git diff|re-derive|verify).*(target|HEAD|base)"
+        "pattern": "git diff.*(target|base|origin/)\\.\\.\\.?(HEAD|head)"
       },
       {
         "type": "content",
-        "pattern": "(stale|no longer|delete the section|remove)"
+        "pattern": "(re-?derive|re-?check|verify each|against the (current )?diff)"
+      },
+      {
+        "type": "content",
+        "pattern": "(delete|drop|remove) the (section|row|entry).{0,60}(no longer|reverted|gone|does not)"
       }
     ]
   },
@@ -426,11 +438,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(jobs_enabled|builds_access_level|CI.*(disabled|switched off))"
+        "pattern": "(jobs_enabled|builds_access_level)"
       },
       {
         "type": "content",
-        "pattern": "(403|projects/)"
+        "pattern": "(CI/CD is|CI is) (disabled|switched off|turned off)"
+      },
+      {
+        "type": "content",
+        "pattern": "(cannot|never|will not|won't).{0,30}(be created|occur|arrive|run)"
       }
     ]
   },
@@ -445,6 +461,10 @@
       {
         "type": "content",
         "pattern": "(each file|every changed file|not carried)"
+      },
+      {
+        "type": "content",
+        "pattern": "(NOT CARRIED|deliberate drop|left behind)"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -402,11 +402,11 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(reference (merge|commit)|from (that|the) reference|against (the )?(ref-target|reference))"
+        "pattern": "(worktree|scratch|throwaway|up front|end state|target (tree|state)|reference (merge|commit))"
       },
       {
         "type": "content",
-        "pattern": "git diff[^|]*ref"
+        "pattern": "git diff[^|]*(ref-target|reference|target-state|REF )"
       },
       {
         "type": "content",
@@ -428,7 +428,7 @@
       },
       {
         "type": "content",
-        "pattern": "((delete|drop|remove)s?d? (the|its|any|that|these) sections?|sections? [^.]{0,25}(deleted|dropped|removed))"
+        "pattern": "((delete|drop|remove)[a-z]*[^.]{0,60}sections?|sections?[^.]{0,60}(delete|drop|remove))"
       }
     ]
   },
@@ -456,7 +456,7 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "rev-parse[^|]*:"
+        "pattern": "rev-parse[^|]*:[^ |]"
       },
       {
         "type": "content",
@@ -464,7 +464,7 @@
       },
       {
         "type": "content",
-        "pattern": "(not carried|left behind|missing from (every|all|any))"
+        "pattern": "(not carried|carried by (no|none)|missing from (every|all|any)|nobody has)"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -402,11 +402,11 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(reference merge|resolve .{0,20}from (the )?(REF|reference)|against (the )?(REF|reference))"
+        "pattern": "(reference (merge|commit)|from (that|the) reference|against (the )?(ref-target|reference))"
       },
       {
         "type": "content",
-        "pattern": "git diff.*--stat.*(ref|head)"
+        "pattern": "git diff[^|]*ref"
       },
       {
         "type": "content",
@@ -420,7 +420,7 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "git diff [^ ]*\\.\\.\\.?(head)"
+        "pattern": "git diff .*\\.\\.\\.?(head)"
       },
       {
         "type": "content",
@@ -428,7 +428,7 @@
       },
       {
         "type": "content",
-        "pattern": "(delete|drop|remove)s? (the|its|any|that|these) sections?"
+        "pattern": "((delete|drop|remove)s?d? (the|its|any|that|these) sections?|sections? [^.]{0,25}(deleted|dropped|removed))"
       }
     ]
   },
@@ -456,7 +456,7 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "rev-parse( --verify)?[^|]*:\\$?f"
+        "pattern": "rev-parse[^|]*:"
       },
       {
         "type": "content",
@@ -464,7 +464,7 @@
       },
       {
         "type": "content",
-        "pattern": "not carried"
+        "pattern": "(not carried|left behind|missing from (every|all|any))"
       }
     ]
   }

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -972,6 +972,10 @@ for the merge-base–relative diff).
 
 ### Never `git checkout <ref> -- <path>` while the change is uncommitted
 
+One exemption, stated where it applies: resolving a *still-unedited* conflicted
+path from a reference merge — see "A long rebase needs a reference merge to
+resolve against" below.
+
 `git checkout <ref> -- <path>` overwrites the working-tree file **without
 warning and without a reflog entry**. Uncommitted content is never written to
 the object store, so there is usually nothing in Git to recover from — only an
@@ -1127,27 +1131,37 @@ it:
 #    and resolve the (few) genuine conflicts by hand.
 git -C .bare worktree add --detach /tmp/ref <branch>
 git -C /tmp/ref merge --no-commit --no-ff origin/<base>   # resolve by hand, then
-git -C /tmp/ref commit -m REF                             # REF = the tree to land on
+git -C /tmp/ref add -A                                    # required: unmerged paths block the commit
+git -C /tmp/ref commit -m REF
+git tag ref-target "$(git -C /tmp/ref rev-parse HEAD)"    # pin it: /tmp is not a safe home for the only ref
 
 # 2. Rebase for real; resolve each conflict from REF instead of re-deciding it.
-git checkout <REF-sha> -- <conflicted-path>
+git checkout ref-target -- <conflicted-path>
 
 # 3. The assertion that makes the detour worth it.
-git diff --stat <REF-sha> HEAD    # must print nothing
+git diff --stat ref-target HEAD    # must print nothing
+
+# 4. Afterwards.
+git worktree remove /tmp/ref && git tag -d ref-target
 ```
 
 Step 3 is the point. It catches what conflict markers cannot: in one 35-commit
 rebase it surfaced a duplicated `autoload-dev` block in `composer.json` that Git
-had merged cleanly from two sides. Commits that come out empty are branch
-fixups already contained in REF — `git rebase --skip` them, or fold them with
-`--autosquash` afterwards.
+had merged cleanly from two sides. Commits that come out empty are branch fixups
+already contained in REF — `git rebase --skip` them. (`--autosquash` does not
+help here: it only reorders commits whose messages start with `fixup!`/`squash!`.)
 
 Two caveats. Resolving from REF puts final content into intermediate commits, so
 individual commits are no longer independently green — acceptable when the
 branch is reviewed as a whole or about to be fixup-folded, not when it must stay
-bisectable. And this is the one safe use of `git checkout <ref> -- <path>`
-against a dirty tree (see the rule above): a conflicted file's content lives in
-committed objects on both sides, so nothing unrecoverable is overwritten.
+bisectable.
+
+And step 2 is the one sanctioned use of `git checkout <ref> -- <path>` against a
+dirty tree (see the rule above), but only on a path **still carrying conflict
+markers, before you edit it**: both sides then live in committed objects, so
+nothing unrecoverable is overwritten. Once you have hand-written a resolution
+into that file, the rule applies again in full — the checkout discards your edit
+with no reflog entry and no way back.
 
 ## A merge resolved in favour of the branch silently reverts upstream work
 
@@ -1160,24 +1174,36 @@ upstream "raise phpstan to level 1" commit, reinstating an
 `ObjectStorage` that is never true. Both survived a rebase, because the rebase
 faithfully replayed the bad resolution.
 
-Cheap check first — which files upstream touched since the merge still differ:
+The candidate set is what upstream changed **before** the merge — that is the
+work the resolution could have dropped. Deriving it from what upstream changed
+*since* the merge is the trap: those are different files, so the loop prints
+unrelated names and, whenever upstream has not touched the dropped files again,
+prints nothing at all and reads as an all-clear.
 
 ```bash
-for f in $(git diff --name-only <upstream-parent-of-merge> origin/<base>); do
+# The true ancestor of that merge — not today's merge base, which already
+# contains the bad resolution.
+BASE=$(git merge-base <branch-parent-of-merge> <upstream-parent-of-merge>)
+
+# Cheap check: upstream's own changes up to the merge, still differing today.
+for f in $(git diff --name-only "$BASE" <upstream-parent-of-merge>); do
   git diff --quiet origin/<base> HEAD -- "$f" || echo "DIFFERS: $f"
 done
 ```
 
-Then redo the resolution properly per suspect file, with the *true* ancestor of
-that merge — not today's merge base, which already contains the bad resolution:
+Then redo the resolution properly for each file the check named:
 
 ```bash
-BASE=$(git merge-base <branch-parent-of-merge> <upstream-parent-of-merge>)
 git show "$BASE:$f" > /tmp/base && git show <branch>:"$f" > /tmp/ours \
   && git show origin/<base>:"$f" > /tmp/theirs
 git merge-file -p --diff3 /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
-diff -u "$f" /tmp/merged      # differences here are upstream work the merge dropped
+diff -u "$f" /tmp/merged
 ```
+
+Read that diff rather than trusting it wholesale: on a branch with post-merge
+work it also contains legitimate branch changes, and conflict markers where both
+sides moved. What you are looking for is upstream hunks present in `/tmp/merged`
+and absent from the file.
 
 Worth running on any branch that carries a `Merge branch '<base>'` commit and is
 about to be merged back.
@@ -1189,10 +1215,12 @@ easy parts — invites silently leaving something behind. Reading the diffs cann
 prove coverage; comparing object ids can:
 
 ```bash
-for f in $(git diff --name-only origin/<base> <umbrella>); do
-  u=$(git rev-parse "<umbrella>:$f")
+# -z / read -d '' so paths with spaces survive; a deleted path resolves to
+# empty on both sides and compares equal, which is the right answer.
+git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; do
+  u=$(git rev-parse "<umbrella>:$f" 2>/dev/null)
   carried=""
-  for b in <branch-1> <branch-2> …; do
+  for b in <branch-1> <branch-2>; do    # list every split branch here
     [ "$(git rev-parse "$b:$f" 2>/dev/null)" = "$u" ] && carried=$b && break
   done
   [ -n "$carried" ] || echo "NOT CARRIED: $f"

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1126,34 +1126,44 @@ several times, each time in a different intermediate state, with nothing at the
 end that says the result is right. Build the answer once, then resolve against
 it:
 
-```bash
-# 1. Target state, in a throwaway worktree. Run from the project root of a bare
-#    layout (or drop the -C .bare in a normal clone).
-git -C .bare worktree add --detach /tmp/ref <branch>
+Steps 1 and 4 run from the project root of a bare layout (drop the `-C .bare` in
+a normal clone); steps 2 and 3 run in the branch worktree. `tests/test_advanced_git_recipes.sh`
+executes all of it against a fixture, so the commands below are the ones that
+are known to run.
 
-# Everything else is -C /tmp/ref, so it works from any cwd.
+```bash
+# 1. Target state, in a throwaway worktree.
+git -C .bare worktree add --detach /tmp/ref <branch>
 git -C /tmp/ref merge --no-commit --no-ff origin/<base>   # resolve by hand, then
-git -C /tmp/ref add -u                                    # required: unmerged paths block the commit
+git -C /tmp/ref add -- <each path you resolved>           # unmerged paths block the commit
+git -C /tmp/ref status --porcelain                        # nothing unexpected left?
 git -C /tmp/ref commit -m REF
 git -C /tmp/ref branch ref-target                         # pin it: /tmp is no home for the only ref
 
-# 2. Back in the branch worktree: rebase, resolving each conflict from REF
-#    instead of re-deciding it.
+# 2. In the branch worktree: rebase, resolving each conflict from REF instead
+#    of re-deciding it.
 git checkout ref-target -- <conflicted-path>
 
 # 3. The assertion that makes the detour worth it.
 git diff --stat ref-target HEAD    # must print nothing
 
-# 4. Afterwards.
-git worktree remove /tmp/ref && git branch -D ref-target
+# 4. Afterwards, from the project root.
+git -C <branch-worktree> worktree remove --force /tmp/ref
+git -C <branch-worktree> branch -D ref-target
 ```
 
-`add -u` rather than `add -A`: it stages the resolution without sweeping
-untracked files into REF (see the staging rule above — an untracked file pulled
-in here makes step 3 fail spuriously). A branch rather than a tag, because a
-*lightweight* tag dies under a global `tag.gpgsign=true` with the unhelpful
-`fatal: no tag message?`, and `git checkout ref-target -- <path>` accepts a
-branch name just as well.
+Stage by name, as the rule above says. `add -A` sweeps untracked files into REF
+and step 3 then fails spuriously; `add -u` skips paths the resolution *creates*
+(splitting a file, extracting a helper) and drops them silently — the commit
+still succeeds because unmerged paths were staged, and REF is quietly wrong. The
+`status --porcelain` line is what catches both.
+
+`--force` on the removal because a resolution leaves `.orig` files behind and
+`worktree remove` refuses an untracked-dirty worktree; everything worth keeping
+is already in `ref-target`. Two statements, not `&&`, so the pin is deleted even
+if the removal complains. A branch rather than a tag, because a *lightweight* tag
+dies under a global `tag.gpgsign=true` with the unhelpful `fatal: no tag
+message?`, and `git checkout ref-target -- <path>` accepts a branch name.
 
 Step 3 is the point. It catches what conflict markers cannot: in one 35-commit
 rebase it surfaced a duplicated `autoload-dev` block in `composer.json` that Git
@@ -1194,23 +1204,31 @@ only covers the window between them and a drop from the first merge stays
 invisible. Run it **per merge commit**:
 
 ```bash
-# Every merge on the branch, each checked against its own two parents.
-for m in $(git rev-list --merges origin/<base>..<branch>); do
+# bash. Run before merging the branch back: once origin/<base> contains it the
+# range is empty and the loop prints nothing, which reads as an all-clear.
+merges=$(git rev-list --merges origin/<base>..<branch>)
+[ -n "$merges" ] || echo "no merges in range — did the branch already land?"
+
+for m in $merges; do
+  # ^2 is the merged-in side of a merge made ON the branch. A merge made the
+  # other way round, or a merge of a sibling branch, fails this and is skipped
+  # rather than reported as six false positives.
+  git merge-base --is-ancestor "$m^2" origin/<base> \
+    || { echo "$m SKIP: ^2 is not upstream (sibling merge, or parents swapped)"; continue; }
+  [ "$(git rev-list --parents -n1 "$m" | wc -w)" -gt 3 ] \
+    && echo "$m OCTOPUS: parents 3+ not checked"
+
   BASE=$(git merge-base "$m^1" "$m^2")
   git diff -z --name-only "$BASE" "$m^2" | while IFS= read -r -d '' f; do
-    git diff --quiet origin/<base> HEAD -- "$f" || echo "$m DIFFERS: $f"
+    git diff --quiet origin/<base> <branch> -- "$f" || echo "$m DIFFERS: $f"
   done
 done
 ```
 
-`$m^2` is the merged-in side for a `git merge` run on the branch; on a merge made
-the other way round the parents are swapped, so check `git log -1 --format=%p $m`
-if the output looks inverted.
-
 Then redo the resolution for each file the check named, with **that merge's own
 sides** — not today's tips, which is a second way to manufacture false
 positives: anything upstream changed after the merge then shows up as dropped
-work:
+work.
 
 ```bash
 m=<the merge the check named>; f=<the path it named>
@@ -1218,8 +1236,9 @@ BASE=$(git merge-base "$m^1" "$m^2")
 git show "$BASE:$f" > /tmp/base
 git show "$m^1:$f"  > /tmp/ours
 git show "$m^2:$f"  > /tmp/theirs
+git show "$m:$f"    > /tmp/result
 git merge-file -p --diff3 /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
-diff -u <(git show "$m:$f") /tmp/merged
+diff -u /tmp/result /tmp/merged
 ```
 
 Read that diff rather than trusting it wholesale: it also contains conflict
@@ -1234,13 +1253,21 @@ prove coverage; comparing object ids can:
 
 ```bash
 # bash (read -d is not POSIX). -z survives paths with spaces or newlines.
-# --verify -q so a path missing on one side yields empty + rc=1 instead of
-# git echoing the argument back — two different echoes never compare equal, so
+branches="<branch-1> <branch-2>"    # every split branch
+
+# Not optional: an unresolvable name makes every lookup ABSENT, which equals the
+# umbrella's ABSENT on a deleted path and reports a genuine miss as carried.
+for b in $branches; do
+  git rev-parse --verify -q "$b^{commit}" >/dev/null || { echo "no such branch: $b" >&2; exit 1; }
+done
+
+# --verify -q so a path missing on one side yields empty + rc=1 instead of git
+# echoing the argument back — two different echoes never compare equal, so
 # without this a path DELETED by the umbrella is always reported NOT CARRIED.
 git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; do
   u=$(git rev-parse --verify -q "<umbrella>:$f") || u=ABSENT
   carried=""
-  for b in <branch-1> <branch-2>; do    # list every split branch here
+  for b in $branches; do
     v=$(git rev-parse --verify -q "$b:$f") || v=ABSENT
     [ "$v" = "$u" ] && carried=$b && break
   done
@@ -1248,8 +1275,10 @@ git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; d
 done
 ```
 
-Verify the branch names first: a typo makes every lookup `ABSENT`, which equals
-the umbrella's `ABSENT` on deleted paths and reads as carried.
+The guard is what keeps a typo from masking a miss. One wrong name is enough:
+its lookups all return `ABSENT`, which matches the umbrella's `ABSENT` on a
+deleted path, so that path is credited as carried and disappears from the
+output.
 
 Everything the loop prints is either a deliberate drop — name each one — or an
 oversight. Files that several branches change by hunk (`composer.json`, a CI

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1210,16 +1210,18 @@ merges=$(git rev-list --merges origin/<base>..<branch>)
 [ -n "$merges" ] || echo "no merges in range — did the branch already land?"
 
 for m in $merges; do
-  # ^2 is the merged-in side of a merge made ON the branch. A merge made the
-  # other way round, or a merge of a sibling branch, fails this and is skipped
-  # rather than reported as six false positives.
-  git merge-base --is-ancestor "$m^2" origin/<base> \
-    || { echo "$m SKIP: ^2 is not upstream (sibling merge, or parents swapped)"; continue; }
   [ "$(git rev-list --parents -n1 "$m" | wc -w)" -gt 3 ] \
     && echo "$m OCTOPUS: parents 3+ not checked"
 
-  BASE=$(git merge-base "$m^1" "$m^2")
-  git diff -z --name-only "$BASE" "$m^2" | while IFS= read -r -d '' f; do
+  # Which parent is upstream? ^2 for a merge made ON the branch, ^1 for one
+  # made the other way round. A sibling-branch merge has neither and is skipped
+  # rather than reported as one false positive per file the sibling touched.
+  if git merge-base --is-ancestor "$m^2" origin/<base>; then up=$m^2; base_side=$m^1
+  elif git merge-base --is-ancestor "$m^1" origin/<base>; then up=$m^1; base_side=$m^2
+  else echo "$m SKIP: neither parent is upstream (sibling merge)"; continue; fi
+
+  BASE=$(git merge-base "$base_side" "$up")
+  git diff -z --name-only "$BASE" "$up" | while IFS= read -r -d '' f; do
     git diff --quiet origin/<base> <branch> -- "$f" || echo "$m DIFFERS: $f"
   done
 done
@@ -1255,15 +1257,19 @@ prove coverage; comparing object ids can:
 # bash (read -d is not POSIX). -z survives paths with spaces or newlines.
 branches="<branch-1> <branch-2>"    # every split branch
 
+# Run the whole check in a subshell so the guard's exit does not close your
+# shell when this is pasted in.
+(
 # Not optional: an unresolvable name makes every lookup ABSENT, which equals the
 # umbrella's ABSENT on a deleted path and reports a genuine miss as carried.
 for b in $branches; do
   git rev-parse --verify -q "$b^{commit}" >/dev/null || { echo "no such branch: $b" >&2; exit 1; }
 done
 
-# --verify -q so a path missing on one side yields empty + rc=1 instead of git
-# echoing the argument back — two different echoes never compare equal, so
-# without this a path DELETED by the umbrella is always reported NOT CARRIED.
+# The `|| ABSENT` is what makes deletions work: git rev-parse ECHOES its
+# argument on failure, and two different echoes never compare equal, so without
+# the sentinel a path deleted by the umbrella is always reported NOT CARRIED.
+# --verify -q keeps the accompanying `fatal:` lines off stderr.
 git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; do
   u=$(git rev-parse --verify -q "<umbrella>:$f") || u=ABSENT
   carried=""
@@ -1273,6 +1279,7 @@ git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; d
   done
   [ -n "$carried" ] || echo "NOT CARRIED: $f"
 done
+)
 ```
 
 The guard is what keeps a typo from masking a miss. One wrong name is enough:

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1127,29 +1127,39 @@ end that says the result is right. Build the answer once, then resolve against
 it:
 
 ```bash
-# 1. Target state, in a throwaway worktree: merge the base into the branch tip
-#    and resolve the (few) genuine conflicts by hand.
+# 1. Target state, in a throwaway worktree. Run from the project root of a bare
+#    layout (or drop the -C .bare in a normal clone).
 git -C .bare worktree add --detach /tmp/ref <branch>
-git -C /tmp/ref merge --no-commit --no-ff origin/<base>   # resolve by hand, then
-git -C /tmp/ref add -A                                    # required: unmerged paths block the commit
-git -C /tmp/ref commit -m REF
-git tag ref-target "$(git -C /tmp/ref rev-parse HEAD)"    # pin it: /tmp is not a safe home for the only ref
 
-# 2. Rebase for real; resolve each conflict from REF instead of re-deciding it.
+# Everything else is -C /tmp/ref, so it works from any cwd.
+git -C /tmp/ref merge --no-commit --no-ff origin/<base>   # resolve by hand, then
+git -C /tmp/ref add -u                                    # required: unmerged paths block the commit
+git -C /tmp/ref commit -m REF
+git -C /tmp/ref branch ref-target                         # pin it: /tmp is no home for the only ref
+
+# 2. Back in the branch worktree: rebase, resolving each conflict from REF
+#    instead of re-deciding it.
 git checkout ref-target -- <conflicted-path>
 
 # 3. The assertion that makes the detour worth it.
 git diff --stat ref-target HEAD    # must print nothing
 
 # 4. Afterwards.
-git worktree remove /tmp/ref && git tag -d ref-target
+git worktree remove /tmp/ref && git branch -D ref-target
 ```
+
+`add -u` rather than `add -A`: it stages the resolution without sweeping
+untracked files into REF (see the staging rule above — an untracked file pulled
+in here makes step 3 fail spuriously). A branch rather than a tag, because a
+*lightweight* tag dies under a global `tag.gpgsign=true` with the unhelpful
+`fatal: no tag message?`, and `git checkout ref-target -- <path>` accepts a
+branch name just as well.
 
 Step 3 is the point. It catches what conflict markers cannot: in one 35-commit
 rebase it surfaced a duplicated `autoload-dev` block in `composer.json` that Git
 had merged cleanly from two sides. Commits that come out empty are branch fixups
 already contained in REF — `git rebase --skip` them. (`--autosquash` does not
-help here: it only reorders commits whose messages start with `fixup!`/`squash!`.)
+help here: it only acts on commits whose messages start with `fixup!`/`squash!`.)
 
 Two caveats. Resolving from REF puts final content into intermediate commits, so
 individual commits are no longer independently green — acceptable when the
@@ -1174,39 +1184,47 @@ upstream "raise phpstan to level 1" commit, reinstating an
 `ObjectStorage` that is never true. Both survived a rebase, because the rebase
 faithfully replayed the bad resolution.
 
-The candidate set is what upstream changed **before** the merge — that is the
-work the resolution could have dropped. Deriving it from what upstream changed
-*since* the merge is the trap: those are different files, so the loop prints
-unrelated names and, whenever upstream has not touched the dropped files again,
-prints nothing at all and reads as an all-clear.
+The candidate set is what upstream changed **before** each merge — that is the
+work that merge's resolution could have dropped. Two traps: deriving it from
+what upstream changed *since* the merge (different files, so the check prints
+unrelated names, or nothing at all and reads as an all-clear), and running it
+once on a branch that merged the base more than once. `merge-base` of the *later*
+merge's parents resolves to the earlier merge's upstream parent, so a single run
+only covers the window between them and a drop from the first merge stays
+invisible. Run it **per merge commit**:
 
 ```bash
-# The true ancestor of that merge — not today's merge base, which already
-# contains the bad resolution.
-BASE=$(git merge-base <branch-parent-of-merge> <upstream-parent-of-merge>)
-
-# Cheap check: upstream's own changes up to the merge, still differing today.
-for f in $(git diff --name-only "$BASE" <upstream-parent-of-merge>); do
-  git diff --quiet origin/<base> HEAD -- "$f" || echo "DIFFERS: $f"
+# Every merge on the branch, each checked against its own two parents.
+for m in $(git rev-list --merges origin/<base>..<branch>); do
+  BASE=$(git merge-base "$m^1" "$m^2")
+  git diff -z --name-only "$BASE" "$m^2" | while IFS= read -r -d '' f; do
+    git diff --quiet origin/<base> HEAD -- "$f" || echo "$m DIFFERS: $f"
+  done
 done
 ```
 
-Then redo the resolution properly for each file the check named:
+`$m^2` is the merged-in side for a `git merge` run on the branch; on a merge made
+the other way round the parents are swapped, so check `git log -1 --format=%p $m`
+if the output looks inverted.
+
+Then redo the resolution for each file the check named, with **that merge's own
+sides** — not today's tips, which is a second way to manufacture false
+positives: anything upstream changed after the merge then shows up as dropped
+work:
 
 ```bash
-git show "$BASE:$f" > /tmp/base && git show <branch>:"$f" > /tmp/ours \
-  && git show origin/<base>:"$f" > /tmp/theirs
+m=<the merge the check named>; f=<the path it named>
+BASE=$(git merge-base "$m^1" "$m^2")
+git show "$BASE:$f" > /tmp/base
+git show "$m^1:$f"  > /tmp/ours
+git show "$m^2:$f"  > /tmp/theirs
 git merge-file -p --diff3 /tmp/ours /tmp/base /tmp/theirs > /tmp/merged
-diff -u "$f" /tmp/merged
+diff -u <(git show "$m:$f") /tmp/merged
 ```
 
-Read that diff rather than trusting it wholesale: on a branch with post-merge
-work it also contains legitimate branch changes, and conflict markers where both
-sides moved. What you are looking for is upstream hunks present in `/tmp/merged`
-and absent from the file.
-
-Worth running on any branch that carries a `Merge branch '<base>'` commit and is
-about to be merged back.
+Read that diff rather than trusting it wholesale: it also contains conflict
+markers where both sides moved. What you are looking for is upstream hunks
+present in `/tmp/merged` and absent from the merge result.
 
 ## Verify a branch split by blob identity, not by reading the diffs
 
@@ -1215,17 +1233,23 @@ easy parts — invites silently leaving something behind. Reading the diffs cann
 prove coverage; comparing object ids can:
 
 ```bash
-# -z / read -d '' so paths with spaces survive; a deleted path resolves to
-# empty on both sides and compares equal, which is the right answer.
+# bash (read -d is not POSIX). -z survives paths with spaces or newlines.
+# --verify -q so a path missing on one side yields empty + rc=1 instead of
+# git echoing the argument back — two different echoes never compare equal, so
+# without this a path DELETED by the umbrella is always reported NOT CARRIED.
 git diff -z --name-only origin/<base> <umbrella> | while IFS= read -r -d '' f; do
-  u=$(git rev-parse "<umbrella>:$f" 2>/dev/null)
+  u=$(git rev-parse --verify -q "<umbrella>:$f") || u=ABSENT
   carried=""
   for b in <branch-1> <branch-2>; do    # list every split branch here
-    [ "$(git rev-parse "$b:$f" 2>/dev/null)" = "$u" ] && carried=$b && break
+    v=$(git rev-parse --verify -q "$b:$f") || v=ABSENT
+    [ "$v" = "$u" ] && carried=$b && break
   done
   [ -n "$carried" ] || echo "NOT CARRIED: $f"
 done
 ```
+
+Verify the branch names first: a typo makes every lookup `ABSENT`, which equals
+the umbrella's `ABSENT` on deleted paths and reads as carried.
 
 Everything the loop prints is either a deliberate drop — name each one — or an
 oversight. Files that several branches change by hunk (`composer.json`, a CI

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -106,20 +106,22 @@ confirm the host will create one at all — a project can have CI switched off
 entirely, and then no push, force-push or retarget produces anything to watch.
 
 A `403` confined to one endpoint family while everything else answers `200` with
-the same token is *consistent with* that feature being switched off — and with
-the token simply lacking the scope for it. Those two are the candidates an
-endpoint-scoped 403 leaves; org-wide rejections (SAML, IP allowlist) and the
-rate limits refuse everything, not one family. The flags separate the two:
+the same token is *consistent with* that feature being switched off, and equally
+with the token lacking the scope for it. Rule the rate limits out by their body
+first — `API rate limit exceeded` or `You have exceeded a secondary rate limit`,
+per "Watcher cost" below, which is also a 403 and is *not* always global. Then
+read the flags, which separate the remaining two:
 
 ```bash
-glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}' \
-  || echo "probe failed — that is the access case, not the feature case"
+# Capture, then parse: `glab … | jq …` exits with jq's status, and jq on empty
+# input exits 0, so a || fallback on the pipeline can never fire.
+out=$(glab api "projects/:id") \
+  || { echo "probe refused — that is the access case, not the feature case"; }
+printf '%s' "$out" | jq '{jobs_enabled, builds_access_level}'
 # {"jobs_enabled": false, "builds_access_level": "disabled"} -> nothing will run
 ```
 
 `projects/:id` resolves from the current clone's remote, so run it inside one.
-Note the fallback: with a token that cannot read the project at all the pipeline
-prints nothing rather than `null`, which is easy to misread as "flags not set".
 
 Observed cost: two watchers armed across ~40 minutes for a merge request whose
 project had `builds_access_level: disabled`, reported to the user as "no

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -105,14 +105,21 @@ event has not arrived yet: both are silence. Before waiting on a pipeline,
 confirm the host will create one at all — a project can have CI switched off
 entirely, and then no push, force-push or retarget produces anything to watch.
 
-The tell is a `403` scoped to the CI endpoints while everything else answers
-`200` with the same token — a disabled project feature, not a missing scope.
-Distinguish it from the rate-limit `403` below: that one carries
-`API rate limit exceeded` and hits every endpoint; this one is a bare
-`403 Forbidden` on the CI family only. On GitLab the flags are
-`jobs_enabled` / `builds_access_level` on `projects/:id`; the netresearch-gitlab
-skill's `references/troubleshooting.md` has the full recipe and the traps in
-reading the state back.
+A `403` confined to the CI endpoints while everything else answers `200` with
+the same token is *consistent with* a disabled project feature — but it is also
+what an insufficient token scope, a SAML or IP-allowlist rule, and (on GitHub)
+the secondary rate limit produce. The symptom narrows the field; only the flags
+settle it. On GitLab, read them:
+
+```bash
+glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}'
+# {"jobs_enabled": false, "builds_access_level": "disabled"} -> nothing will run
+```
+
+(`projects/:id` resolves from the current clone's remote, so run it inside one.)
+The netresearch-gitlab skill's `references/troubleshooting.md` carries the same
+check with the token-vs-feature probe next to it and the traps in reading the
+state back afterwards.
 
 Observed cost: two watchers armed across ~40 minutes for a merge request whose
 project had `builds_access_level: disabled`, reported to the user as "no
@@ -206,7 +213,7 @@ Two consequences for the diagnosis:
 
 ## Watcher cost: GraphQL and REST rate limits are separate budgets
 
-`gh pr view --json statusCheckRollup` is a GraphQL query and an expensive one. Two watchers polling it every 60 s exhausted the **GraphQL** budget (29 of 5000 left) while the REST **core** budget still showed 4614 of 5000 — and once that happened, plain REST calls also began returning `403 API rate limit exceeded`. That combination (one resource drained, the other healthy, both refused) is the **secondary** limit reacting to request density, not the quota. This 403 says `API rate limit exceeded` and refuses every endpoint — a bare `403 Forbidden` confined to the CI endpoints is the disabled-feature case instead (see "Check the producer is switched on" above). Read the resources separately rather than trusting a single number:
+`gh pr view --json statusCheckRollup` is a GraphQL query and an expensive one. Two watchers polling it every 60 s exhausted the **GraphQL** budget (29 of 5000 left) while the REST **core** budget still showed 4614 of 5000 — and once that happened, plain REST calls also began returning `403 API rate limit exceeded`. That combination (one resource drained, the other healthy, both refused) is the **secondary** limit reacting to request density, not the quota. Its 403 body says `API rate limit exceeded` or `You have exceeded a secondary rate limit`, which is what tells it apart from an authorization 403 — read the body, not just the status. Read the resources separately rather than trusting a single number:
 
 ```bash
 gh api rate_limit --jq '.resources | to_entries[] | "\(.key): \(.value.remaining)/\(.value.limit)"'

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -105,21 +105,21 @@ event has not arrived yet: both are silence. Before waiting on a pipeline,
 confirm the host will create one at all — a project can have CI switched off
 entirely, and then no push, force-push or retarget produces anything to watch.
 
-A `403` confined to the CI endpoints while everything else answers `200` with
-the same token is *consistent with* a disabled project feature — but it is also
-what an insufficient token scope, a SAML or IP-allowlist rule, and (on GitHub)
-the secondary rate limit produce. The symptom narrows the field; only the flags
-settle it. On GitLab, read them:
+A `403` confined to one endpoint family while everything else answers `200` with
+the same token is *consistent with* that feature being switched off — and with
+the token simply lacking the scope for it. Those two are the candidates an
+endpoint-scoped 403 leaves; org-wide rejections (SAML, IP allowlist) and the
+rate limits refuse everything, not one family. The flags separate the two:
 
 ```bash
-glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}'
+glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}' \
+  || echo "probe failed — that is the access case, not the feature case"
 # {"jobs_enabled": false, "builds_access_level": "disabled"} -> nothing will run
 ```
 
-(`projects/:id` resolves from the current clone's remote, so run it inside one.)
-The netresearch-gitlab skill's `references/troubleshooting.md` carries the same
-check with the token-vs-feature probe next to it and the traps in reading the
-state back afterwards.
+`projects/:id` resolves from the current clone's remote, so run it inside one.
+Note the fallback: with a token that cannot read the project at all the pipeline
+prints nothing rather than `null`, which is easy to misread as "flags not set".
 
 Observed cost: two watchers armed across ~40 minutes for a merge request whose
 project had `builds_access_level: disabled`, reported to the user as "no

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -105,15 +105,14 @@ event has not arrived yet: both are silence. Before waiting on a pipeline,
 confirm the host will create one at all — a project can have CI switched off
 entirely, and then no push, force-push or retarget produces anything to watch.
 
-On GitLab the give-away is that pipeline endpoints alone refuse a token that
-works everywhere else — `GET /projects/:id/pipelines` and `/jobs` return `403`
-while `/projects/:id` and the merge-request endpoints return `200`. That is not a
-scope problem:
-
-```bash
-glab api "projects/:id" | jq '{jobs_enabled, builds_access_level}'
-# {"jobs_enabled": false, "builds_access_level": "disabled"} -> nothing will run
-```
+The tell is a `403` scoped to the CI endpoints while everything else answers
+`200` with the same token — a disabled project feature, not a missing scope.
+Distinguish it from the rate-limit `403` below: that one carries
+`API rate limit exceeded` and hits every endpoint; this one is a bare
+`403 Forbidden` on the CI family only. On GitLab the flags are
+`jobs_enabled` / `builds_access_level` on `projects/:id`; the netresearch-gitlab
+skill's `references/troubleshooting.md` has the full recipe and the traps in
+reading the state back.
 
 Observed cost: two watchers armed across ~40 minutes for a merge request whose
 project had `builds_access_level: disabled`, reported to the user as "no
@@ -207,7 +206,7 @@ Two consequences for the diagnosis:
 
 ## Watcher cost: GraphQL and REST rate limits are separate budgets
 
-`gh pr view --json statusCheckRollup` is a GraphQL query and an expensive one. Two watchers polling it every 60 s exhausted the **GraphQL** budget (29 of 5000 left) while the REST **core** budget still showed 4614 of 5000 — and once that happened, plain REST calls also began returning `403 API rate limit exceeded`. That combination (one resource drained, the other healthy, both refused) is the **secondary** limit reacting to request density, not the quota. Read the resources separately rather than trusting a single number:
+`gh pr view --json statusCheckRollup` is a GraphQL query and an expensive one. Two watchers polling it every 60 s exhausted the **GraphQL** budget (29 of 5000 left) while the REST **core** budget still showed 4614 of 5000 — and once that happened, plain REST calls also began returning `403 API rate limit exceeded`. That combination (one resource drained, the other healthy, both refused) is the **secondary** limit reacting to request density, not the quota. This 403 says `API rate limit exceeded` and refuses every endpoint — a bare `403 Forbidden` confined to the CI endpoints is the disabled-feature case instead (see "Check the producer is switched on" above). Read the resources separately rather than trusting a single number:
 
 ```bash
 gh api rate_limit --jq '.resources | to_entries[] | "\(.key): \(.value.remaining)/\(.value.limit)"'

--- a/tests/test_advanced_git_recipes.sh
+++ b/tests/test_advanced_git_recipes.sh
@@ -16,12 +16,18 @@
 set -uo pipefail
 
 failures=0
-pass() { printf '  OK   %s\n' "$1"; }
-fail() { printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); }
+ran=0
+pass() { ran=$((ran + 1)); printf '  OK   %s\n' "$1"; }
+fail() { ran=$((ran + 1)); printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); }
 check() { # check <label> <expected> <actual>
   if [ "$2" = "$3" ]; then pass "$1"; else
     fail "$1"; printf '       expected: %s\n       actual:   %s\n' "$2" "$3"
   fi
+}
+# `cmd && pass X` silently runs neither pass nor fail when cmd fails, so a
+# broken step disappears instead of failing. Always go through this.
+try() { # try <label> <cmd...>
+  if "${@:2}" >/dev/null 2>&1; then pass "$1"; else fail "$1 (command failed)"; fi
 }
 
 TMP=$(mktemp -d)
@@ -54,8 +60,16 @@ git -C .bare worktree add -q ../wt feature          # the branch worktree
 git -C .bare worktree add -q --detach "$TMP/ref" feature
 
 git -C "$TMP/ref" merge --no-commit --no-ff origin/main >/dev/null 2>&1
+# A resolution that both edits a tracked file AND creates one. The created path
+# is what separates the three staging forms: -A sweeps the .orig too, -u skips
+# helper.txt silently, staging by name gets exactly both.
 printf 'l1\nRESOLVED\nl3\n' > "$TMP/ref"/f.txt
-printf 'leftover\n' > "$TMP/ref"/f.txt.orig        # what mergetool leaves behind
+printf 'extracted\n'       > "$TMP/ref"/helper.txt
+printf 'leftover\n'        > "$TMP/ref"/f.txt.orig   # what mergetool leaves behind
+
+# A lightweight tag is the alternative the recipe rejects; prove why.
+git -C "$TMP/ref" tag lightweight-probe HEAD >/dev/null 2>&1
+check "lightweight tag refused under tag.gpgsign=true" "128" "$?"
 
 out=$(git -C "$TMP/ref" commit -m REF 2>&1); rc=$?
 if [ "$rc" -ne 0 ]; then pass "commit before staging refuses (rc=$rc)"; else fail "commit before staging succeeded"; fi
@@ -68,26 +82,42 @@ case "$out" in
   *) fail "unexpected message: $out" ;;
 esac
 
-git -C "$TMP/ref" add -- f.txt
+git -C "$TMP/ref" add -- f.txt helper.txt
 dirty=$(git -C "$TMP/ref" status --porcelain | grep -c '^??')
 check "status --porcelain still shows the untracked leftover" "1" "$dirty"
 
-git -C "$TMP/ref" commit -qm REF && pass "commit after staging by name"
-git -C "$TMP/ref" branch ref-target && pass "branch pins REF under tag.gpgsign=true"
+try "commit after staging by name" git -C "$TMP/ref" commit -qm REF
+try "branch pins REF" git -C "$TMP/ref" branch ref-target
 
-# The untracked leftover must NOT be in REF — that is why we stage by name.
-in_ref=$(git -C "$TMP/ref" ls-tree --name-only ref-target | grep -c 'f.txt.orig' || true)
-check "leftover kept out of REF" "0" "$in_ref"
+tree=$(git -C "$TMP/ref" ls-tree -r --name-only ref-target | sort | tr '\n' ' ')
+# helper.txt catches `add -u` (which skips paths the resolution creates);
+# f.txt.orig catches `add -A` (which sweeps untracked files in).
+check "REF holds exactly the resolution" "f.txt helper.txt " "$tree"
 
 # Step 2/3 from the branch worktree.
-( cd "$proj/wt" && git checkout ref-target -- f.txt ) && pass "checkout from a branch ref"
+try "checkout from a branch ref" git -C "$proj/wt" checkout ref-target -- f.txt helper.txt
 got=$(tr '\n' ' ' < "$proj/wt/f.txt")
 check "resolution landed in the branch worktree" "l1 RESOLVED l3 " "$got"
 
+# Step 3 itself: with the branch worktree now holding REF's content for the
+# conflicted paths, the assertion the recipe calls "the point" must be empty.
+git -C "$proj/wt" add -- f.txt helper.txt >/dev/null 2>&1
+git -C "$proj/wt" commit -qm "take REF" >/dev/null 2>&1
+step3=$(git -C "$proj/wt" diff --stat ref-target HEAD)
+check "step 3 prints nothing when the trees match" "" "$step3"
+
+# And it must NOT be empty when they diverge — otherwise the assertion is not
+# an assertion.
+printf 'drift\n' >> "$proj/wt/f.txt"
+git -C "$proj/wt" add -- f.txt >/dev/null 2>&1
+git -C "$proj/wt" commit -qm drift >/dev/null 2>&1
+drift=$(git -C "$proj/wt" diff --stat ref-target HEAD | wc -l)
+if [ "$drift" -gt 0 ]; then pass "step 3 reports divergence"; else fail "step 3 stayed empty on a divergent tree"; fi
+
 # Step 4, from the project root: needs -C and --force, and two statements.
 cd "$proj" || exit 1
-git -C wt worktree remove --force "$TMP/ref" 2>/dev/null && pass "worktree remove --force"
-git -C wt branch -D ref-target >/dev/null 2>&1 && pass "pin deleted"
+try "worktree remove --force" git -C wt worktree remove --force "$TMP/ref"
+try "pin deleted" git -C wt branch -D ref-target
 if [ -d "$TMP/ref" ]; then fail "ref worktree still present"; else pass "ref worktree gone"; fi
 
 # --------------------------------------------------------------------------
@@ -107,20 +137,84 @@ git merge -q --no-ff sibling -m "Merge branch 'sibling' into feature" # not upst
 git checkout -q main; echo more >> a.txt; git commit -qam later-churn  # post-merge churn
 git checkout -q feature
 
+# This block is the recipe from advanced-git.md, verbatim apart from the
+# placeholders. If the document changes, change it here and see what breaks.
 report=$(
   merges=$(git rev-list --merges main..feature)
   for m in $merges; do
-    git merge-base --is-ancestor "$m^2" main || { echo "SKIP"; continue; }
-    BASE=$(git merge-base "$m^1" "$m^2")
-    git diff -z --name-only "$BASE" "$m^2" | while IFS= read -r -d '' f; do
+    [ "$(git rev-list --parents -n1 "$m" | wc -w)" -gt 3 ] && echo "OCTOPUS"
+    if git merge-base --is-ancestor "$m^2" main; then up=$m^2; base_side=$m^1
+    elif git merge-base --is-ancestor "$m^1" main; then up=$m^1; base_side=$m^2
+    else echo "SKIP"; continue; fi
+    BASE=$(git merge-base "$base_side" "$up")
+    git diff -z --name-only "$BASE" "$up" | while IFS= read -r -d '' f; do
       git diff --quiet main feature -- "$f" || echo "DIFFERS: $f"
     done
-  done | sort | tr '\n' ' '
+  done | sort -u | tr '\n' ' '
 )
-check "both drops found, sibling merge skipped" "DIFFERS: a.txt DIFFERS: b.txt SKIP " "$report"
+case "$report" in
+  *"DIFFERS: a.txt"*) pass "drop from the first merge found" ;;
+  *) fail "first merge's drop missed: $report" ;;
+esac
+case "$report" in
+  *"DIFFERS: b.txt"*) pass "drop from the second merge found" ;;
+  *) fail "second merge's drop missed: $report" ;;
+esac
+case "$report" in
+  *SKIP*) pass "sibling merge skipped, not reported as drops" ;;
+  *) fail "sibling merge was not skipped: $report" ;;
+esac
 
-empty_range=$(git rev-list --merges feature..feature | wc -l)
-check "range is empty once the branch has landed (the all-clear trap)" "0" "$empty_range"
+# Parents-swapped case, in its own fixture: the merge was made FROM the upstream
+# side, so ^1 is upstream and ^2 is the branch. The recipe must still find the
+# drop rather than skipping the merge.
+swaprepo="$TMP/p2c"; mkdir -p "$swaprepo"
+swapped=$(
+  cd "$swaprepo" || exit 1; git init -q .
+  echo base > a.txt; git add -A; git commit -qm base; git branch -q topic
+  echo up > a.txt; git commit -qam upstream-change; upstream=$(git rev-parse HEAD)
+  git checkout -q topic; echo branchver > a.txt; git commit -qam topic-change
+  # Merge made FROM the upstream side (^1 = upstream, ^2 = the branch), resolved
+  # in favour of the branch — so upstream's change to a.txt is dropped.
+  git checkout -q main
+  git merge --no-commit --no-ff topic >/dev/null 2>&1
+  git checkout topic -- a.txt
+  git commit -qm "Merge branch 'topic' into main"
+  git branch -f topic HEAD
+  git reset -q --hard "$upstream"     # main back to plain upstream
+  git checkout -q topic
+
+  for m in $(git rev-list --merges main..topic); do
+    if git merge-base --is-ancestor "$m^2" main; then up=$m^2; base_side=$m^1
+    elif git merge-base --is-ancestor "$m^1" main; then up=$m^1; base_side=$m^2
+    else echo "SKIP"; continue; fi
+    BASE=$(git merge-base "$base_side" "$up")
+    git diff -z --name-only "$BASE" "$up" | while IFS= read -r -d '' f; do
+      git diff --quiet main topic -- "$f" || echo "DIFFERS: $f"
+    done
+  done | sort -u | tr '\n' ' '
+)
+check "parents-swapped merge is examined, not skipped" "DIFFERS: a.txt " "$swapped"
+
+# The all-clear trap, in its own fixture so it cannot disturb the one above:
+# once the base contains the branch, the range is empty and the loop would
+# print nothing at all, which reads as "no drops found".
+landedrepo="$TMP/p2b"; mkdir -p "$landedrepo"
+(
+  cd "$landedrepo" || exit 1; git init -q .
+  echo a > a.txt; git add -A; git commit -qm base; git branch -q topic
+  echo up > a.txt; git commit -qam upstream
+  git checkout -q topic; echo t > t.txt; git add t.txt; git commit -qm topic-work
+  git merge -q -s ours main -m "Merge branch 'main' into topic"
+  git checkout -q main; git merge -q --no-ff topic -m "Merge topic"   # branch has landed
+)
+landed=$(
+  cd "$landedrepo" || exit 1
+  merges=$(git rev-list --merges main..topic)
+  [ -n "$merges" ] || echo "no merges in range — did the branch already land?"
+)
+check "warns instead of printing an empty all-clear" \
+      "no merges in range — did the branch already land?" "$landed"
 
 # Reconstruction uses the merge's own sides, so post-merge churn is not reported.
 m=$(git rev-list --merges main..feature | tail -1)
@@ -143,8 +237,11 @@ git checkout -q -b umbrella
 git rm -q doomed.txt gone.txt; echo k2 > keep.txt; echo x2 > "sp ace.txt"
 git commit -qam "umbrella: delete two, change two"
 git checkout -q split1
-git rm -q doomed.txt; echo k2 > keep.txt; echo x2 > "sp ace.txt"
-git commit -qam "split1: carries all but the gone.txt deletion"
+# Carries the doomed.txt deletion and keep.txt, but NOT gone.txt's deletion and
+# NOT the spaced path — so both must be reported, which is what makes the -z
+# handling and the ABSENT sentinel observable.
+git rm -q doomed.txt; echo k2 > keep.txt
+git commit -qam "split1: carries the deletion and keep.txt only"
 git checkout -q umbrella
 
 run_split() { # run_split <branches…>
@@ -163,12 +260,16 @@ run_split() { # run_split <branches…>
   done | sort | tr '\n' ' '
 }
 
-check "reports only the uncarried deletion; spaces intact" \
-      "NOT CARRIED: gone.txt " "$(run_split split1)"
+check "uncarried deletion and spaced path both reported" \
+      "NOT CARRIED: gone.txt NOT CARRIED: sp ace.txt " "$(run_split split1)"
 
 out=$(run_split split1 typo-branch 2>&1); rc=$?
 check "an unresolvable branch name aborts instead of masking a miss" "1" "$rc"
 check "and says which name" "no such branch: typo-branch" "$out"
 
-printf '\n---- failures: %s\n' "$failures"
+# The suite must notice when an assertion stops running at all — the failure
+# mode that `cmd && pass` used to produce silently.
+check "every assertion ran" "24" "$ran"
+
+printf '\n---- assertions: %s, failures: %s\n' "$ran" "$failures"
 [ "$failures" -eq 0 ]

--- a/tests/test_advanced_git_recipes.sh
+++ b/tests/test_advanced_git_recipes.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Executable form of the three recipes in references/advanced-git.md:
+#   - "A long rebase needs a reference merge to resolve against"
+#   - "A merge resolved in favour of the branch silently reverts upstream work"
+#   - "Verify a branch split by blob identity, not by reading the diffs"
+#
+# Three review rounds found the same defect class each time: a recipe that was
+# reasoned about at the edited line and never run end to end, from the cwd and
+# in the shell the document prescribes. Reading a diff cannot catch a missing
+# `git add`, a `-C` that only resolves from another directory, or a `rev-parse`
+# that echoes its argument instead of failing. Running it can.
+#
+# Keep this in step with the document: if a recipe changes there, change it here
+# and let the suite say whether it still works.
+
+set -uo pipefail
+
+failures=0
+pass() { printf '  OK   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); }
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then pass "$1"; else
+    fail "$1"; printf '       expected: %s\n       actual:   %s\n' "$2" "$3"
+  fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export GIT_CONFIG_GLOBAL="$TMP/gitconfig" GIT_CONFIG_SYSTEM=/dev/null
+git config --global user.email t@example.com
+git config --global user.name  Test
+git config --global commit.gpgsign false
+git config --global init.defaultBranch main
+# The recipes must survive a global that signs tags: a lightweight tag dies
+# under it, which is why the reference merge is pinned with a branch.
+git config --global tag.gpgsign true
+
+# --------------------------------------------------------------------------
+printf '\n== reference-merge recipe (bare layout, real conflict)\n'
+# --------------------------------------------------------------------------
+proj="$TMP/p1"; mkdir -p "$proj"; cd "$proj" || exit 1
+git init -q --bare .bare
+git clone -q .bare seed
+(
+  cd seed || exit 1
+  printf 'l1\nl2\nl3\n' > f.txt
+  git add -A && git commit -qm base && git push -q origin main
+  git checkout -q -b feature
+  printf 'l1\nBRANCH\nl3\n' > f.txt && git commit -qam branch && git push -q origin feature
+  git checkout -q main
+  printf 'l1\nMAIN\nl3\n' > f.txt && git commit -qam main-side && git push -q origin main
+)
+git -C .bare worktree add -q ../wt feature          # the branch worktree
+git -C .bare worktree add -q --detach "$TMP/ref" feature
+
+git -C "$TMP/ref" merge --no-commit --no-ff origin/main >/dev/null 2>&1
+printf 'l1\nRESOLVED\nl3\n' > "$TMP/ref"/f.txt
+printf 'leftover\n' > "$TMP/ref"/f.txt.orig        # what mergetool leaves behind
+
+out=$(git -C "$TMP/ref" commit -m REF 2>&1); rc=$?
+if [ "$rc" -ne 0 ]; then pass "commit before staging refuses (rc=$rc)"; else fail "commit before staging succeeded"; fi
+# Wording depends on whether the ref worktree is detached: an attached one says
+# "Committing is not possible because you have unmerged files", a detached one
+# reports "Not currently on any branch" first. Either way it refuses.
+case "$out" in
+  *"unmerged files"* | *"not currently on any branch"* | *"Not currently on any branch"*)
+    pass "and says why ($(printf '%s' "$out" | head -1))" ;;
+  *) fail "unexpected message: $out" ;;
+esac
+
+git -C "$TMP/ref" add -- f.txt
+dirty=$(git -C "$TMP/ref" status --porcelain | grep -c '^??')
+check "status --porcelain still shows the untracked leftover" "1" "$dirty"
+
+git -C "$TMP/ref" commit -qm REF && pass "commit after staging by name"
+git -C "$TMP/ref" branch ref-target && pass "branch pins REF under tag.gpgsign=true"
+
+# The untracked leftover must NOT be in REF — that is why we stage by name.
+in_ref=$(git -C "$TMP/ref" ls-tree --name-only ref-target | grep -c 'f.txt.orig' || true)
+check "leftover kept out of REF" "0" "$in_ref"
+
+# Step 2/3 from the branch worktree.
+( cd "$proj/wt" && git checkout ref-target -- f.txt ) && pass "checkout from a branch ref"
+got=$(tr '\n' ' ' < "$proj/wt/f.txt")
+check "resolution landed in the branch worktree" "l1 RESOLVED l3 " "$got"
+
+# Step 4, from the project root: needs -C and --force, and two statements.
+cd "$proj" || exit 1
+git -C wt worktree remove --force "$TMP/ref" 2>/dev/null && pass "worktree remove --force"
+git -C wt branch -D ref-target >/dev/null 2>&1 && pass "pin deleted"
+if [ -d "$TMP/ref" ]; then fail "ref worktree still present"; else pass "ref worktree gone"; fi
+
+# --------------------------------------------------------------------------
+printf '\n== dropped-upstream-work check (two merges, one sibling, later churn)\n'
+# --------------------------------------------------------------------------
+r="$TMP/p2"; mkdir -p "$r"; cd "$r" || exit 1; git init -q .
+echo base > a.txt; echo base > b.txt; git add -A; git commit -qm base
+git branch -q feature; git branch -q sibling
+echo up1 > a.txt; git commit -qam up1; u1=$(git rev-parse HEAD)
+git checkout -q sibling; echo s > s.txt; git add s.txt; git commit -qm sibling-work
+git checkout -q feature; echo w > w.txt; git add w.txt; git commit -qm branch-work
+git merge -q -s ours "$u1" -m "Merge branch 'main' into feature"      # drops a.txt
+git checkout -q main; echo up2 > b.txt; git commit -qam up2; u2=$(git rev-parse HEAD)
+git checkout -q feature
+git merge -q -s ours "$u2" -m "Merge branch 'main' into feature"      # drops b.txt
+git merge -q --no-ff sibling -m "Merge branch 'sibling' into feature" # not upstream
+git checkout -q main; echo more >> a.txt; git commit -qam later-churn  # post-merge churn
+git checkout -q feature
+
+report=$(
+  merges=$(git rev-list --merges main..feature)
+  for m in $merges; do
+    git merge-base --is-ancestor "$m^2" main || { echo "SKIP"; continue; }
+    BASE=$(git merge-base "$m^1" "$m^2")
+    git diff -z --name-only "$BASE" "$m^2" | while IFS= read -r -d '' f; do
+      git diff --quiet main feature -- "$f" || echo "DIFFERS: $f"
+    done
+  done | sort | tr '\n' ' '
+)
+check "both drops found, sibling merge skipped" "DIFFERS: a.txt DIFFERS: b.txt SKIP " "$report"
+
+empty_range=$(git rev-list --merges feature..feature | wc -l)
+check "range is empty once the branch has landed (the all-clear trap)" "0" "$empty_range"
+
+# Reconstruction uses the merge's own sides, so post-merge churn is not reported.
+m=$(git rev-list --merges main..feature | tail -1)
+BASE=$(git merge-base "$m^1" "$m^2")
+git show "$BASE:a.txt" > "$TMP/base"; git show "$m^1:a.txt" > "$TMP/ours"
+git show "$m^2:a.txt" > "$TMP/theirs"; git show "$m:a.txt" > "$TMP/result"
+git merge-file -p --diff3 "$TMP/ours" "$TMP/base" "$TMP/theirs" > "$TMP/merged" 2>/dev/null
+churn=$(diff -u "$TMP/result" "$TMP/merged" | grep -c '^+more' || true)
+check "post-merge churn not reported as dropped work" "0" "$churn"
+drop=$(diff -u "$TMP/result" "$TMP/merged" | grep -c '^+up1' || true)
+check "the genuine drop is reported" "1" "$drop"
+
+# --------------------------------------------------------------------------
+printf '\n== split verification (deletions, spaces, bad branch name)\n'
+# --------------------------------------------------------------------------
+s="$TMP/p3"; mkdir -p "$s"; cd "$s" || exit 1; git init -q .
+echo k > keep.txt; echo d > doomed.txt; echo g > gone.txt; echo x > "sp ace.txt"
+git add -A; git commit -qm base; git branch -q split1
+git checkout -q -b umbrella
+git rm -q doomed.txt gone.txt; echo k2 > keep.txt; echo x2 > "sp ace.txt"
+git commit -qam "umbrella: delete two, change two"
+git checkout -q split1
+git rm -q doomed.txt; echo k2 > keep.txt; echo x2 > "sp ace.txt"
+git commit -qam "split1: carries all but the gone.txt deletion"
+git checkout -q umbrella
+
+run_split() { # run_split <branches…>
+  local branches="$*"
+  for b in $branches; do
+    git rev-parse --verify -q "$b^{commit}" >/dev/null || { echo "no such branch: $b"; return 1; }
+  done
+  git diff -z --name-only main umbrella | while IFS= read -r -d '' f; do
+    u=$(git rev-parse --verify -q "umbrella:$f") || u=ABSENT
+    carried=""
+    for b in $branches; do
+      v=$(git rev-parse --verify -q "$b:$f") || v=ABSENT
+      [ "$v" = "$u" ] && carried=$b && break
+    done
+    [ -n "$carried" ] || echo "NOT CARRIED: $f"
+  done | sort | tr '\n' ' '
+}
+
+check "reports only the uncarried deletion; spaces intact" \
+      "NOT CARRIED: gone.txt " "$(run_split split1)"
+
+out=$(run_split split1 typo-branch 2>&1); rc=$?
+check "an unresolvable branch name aborts instead of masking a miss" "1" "$rc"
+check "and says which name" "no such branch: typo-branch" "$out"
+
+printf '\n---- failures: %s\n' "$failures"
+[ "$failures" -eq 0 ]

--- a/tests/test_advanced_git_recipes.sh
+++ b/tests/test_advanced_git_recipes.sh
@@ -67,9 +67,11 @@ printf 'l1\nRESOLVED\nl3\n' > "$TMP/ref"/f.txt
 printf 'extracted\n'       > "$TMP/ref"/helper.txt
 printf 'leftover\n'        > "$TMP/ref"/f.txt.orig   # what mergetool leaves behind
 
-# A lightweight tag is the alternative the recipe rejects; prove why.
-git -C "$TMP/ref" tag lightweight-probe HEAD >/dev/null 2>&1
-check "lightweight tag refused under tag.gpgsign=true" "128" "$?"
+# A lightweight tag is the alternative the recipe rejects; prove why. The exit
+# code varies by git version (1 and 128 both observed) — assert the refusal.
+git -C "$TMP/ref" tag lightweight-probe HEAD >/dev/null 2>&1; tagrc=$?
+if [ "$tagrc" -ne 0 ]; then pass "lightweight tag refused under tag.gpgsign=true (rc=$tagrc)"
+else fail "lightweight tag was accepted under tag.gpgsign=true"; fi
 
 out=$(git -C "$TMP/ref" commit -m REF 2>&1); rc=$?
 if [ "$rc" -ne 0 ]; then pass "commit before staging refuses (rc=$rc)"; else fail "commit before staging succeeded"; fi


### PR DESCRIPTION
## Summary

Fixes a blocker that reached `main` in #158, and turns the three recipes in `advanced-git.md` into an executable, mutation-tested suite so this class of defect stops recurring.

#158 merged before any review landed — both Copilot responses on it were `unable to review … quota limit`. Four independent review rounds have since run against this branch; each found real defects, including in the fixes for the previous round. The commit history is that sequence and is kept unsquashed on purpose.

## The blocker in `main`

`advanced-git.md` told the reader to derive the dropped-upstream-work candidate set from what upstream changed **after** the merge. The work a merge resolution can drop is what upstream changed **before** it. Reproduced on a purpose-built repo — upstream commit touching `f.txt` and `g.txt`, dropped by a `-s ours` merge, plus one unrelated later upstream commit:

```
shipped in #158:  DIFFERS: h.txt          <- unrelated; both dropped files missed
corrected:        DIFFERS: f.txt, g.txt
```

When upstream has not touched the dropped files again — the usual case — the shipped loop prints nothing and reads as an all-clear. Worse than not having the section.

## What else was wrong, by round

**Round 1 → the fixes in `67bbba9`, `843dcbe`, `7b50326`.** The candidate-set range; a stale PR-body section; a watcher armed for a producer that was switched off; five new evals.

**Round 2 → `b62a12f`.** The check has to run once *per merge* (`merge-base` of a later merge's parents is the earlier merge's upstream parent, so a single run misses the first merge's drop). The reconstruction used today's tips, so post-merge upstream work read as dropped work. The reference-merge recipe mixed two working directories and pinned REF with a lightweight tag, which dies under a global `tag.gpgsign=true`. The split loop's comment claimed deletions "compare equal"; `git rev-parse` echoes its argument on failure, so a deleted path was *always* reported `NOT CARRIED`. Four eval assertions could not be satisfied by a correct answer — the skill's own canonical `git diff <target>...HEAD` failed its own pattern.

**Round 3 → `a627326`.** Step 4 of the recipe could not run (`worktree remove` refuses the `.orig` files a resolution leaves, and the `&&` chain then skipped the pin deletion). `add -u` silently skips paths a resolution *creates*. A sibling-branch merge produced one false positive per file it touched. This is where the recipes became `tests/test_advanced_git_recipes.sh`.

**Round 4 → `8d77ea6`.** That suite was vacuous for the `add -u` fix it led with, and `cmd && pass` let broken steps vanish instead of failing. Three assertions were tautologies. The parents-swapped merge was skipped rather than examined. The octopus warning sat after the guard that skips, so it could never print. The `||` fallback added to `merge-gate-watcher.md` could never fire — the pipeline exits with `jq`'s status and `jq` on empty input exits 0.

## The suite

25 assertions over the three recipes: bare-repo layout, a real conflict, two merges dropping different files, a sibling merge, a parents-swapped merge, post-merge churn, deleted paths, paths with spaces, an unresolvable branch name. Mutation-tested — each of these flips it to FAIL, and the unmutated suite passes:

| mutation | caught by |
|---|---|
| `add -u` instead of staging by name | `REF holds exactly the resolution` |
| `add -A` instead of staging by name | `status --porcelain shows the leftover` |
| `worktree remove` without `--force` | `worktree remove --force (command failed)` |
| drop the swapped-parents branch | `parents-swapped merge is examined` |
| drop the branch-name guard | `unresolvable branch name aborts` |
| drop the `|| ABSENT` sentinel | `uncarried deletion and spaced path reported` |

## Test plan

- [x] `tests/test_advanced_git_recipes.sh` — 25 assertions, 0 failures, passes twice in a row, hermetic under `mktemp -d`
- [x] Mutation battery above — 6/6 caught, baseline green
- [x] `shellcheck` clean (info level, matching the pre-commit hook)
- [x] `Build/Scripts/validate-skill.sh` — 0 errors, 0 warnings
- [x] `skill-repo/scripts/validate-evals.sh` — 63 passed
- [x] `tests/test_validate_git_command.py`, `tests/test_pr_status_errored_review.sh` — 0 failures
- [x] Evals retested in both directions with answers written not to copy the skill: correct 3/3, no naive answer passes any entry
- [ ] Reviewer check: the `merge-gate-watcher.md` capture-then-parse form, which no test covers

## Not addressed

Section placement in `merge-gate-watcher.md`, and the fact that no CI job ever executes eval patterns against a response — the eval file still has the "checked by a reader" property this suite was written to end. Both belong to whoever next touches those files.
