### PR TITLE
fix(signing): assert the commit object, not local verification

### DIFF
--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -174,7 +174,18 @@ llm_reviews:
     prompt: |
       Check if the repository has signed commits.
 
-      Use `git log --show-signature -5` to check recent commits for GPG/SSH signatures.
+      Read the commit object — a signed commit carries a `gpgsig` header:
+
+      ```
+      git log -5 --format=%H | while read c; do
+        git cat-file commit "$c" | sed -n '/^$/q;p' | grep -q '^gpgsig' \
+          && echo "$c signed" || echo "$c UNSIGNED"
+      done
+      ```
+
+      Do NOT use `git log --show-signature` or `%G?` here: under `gpg.format=ssh`
+      with no `gpg.ssh.allowedSignersFile` they report `No signature` / `N` on
+      correctly signed commits, which fails a fully signed repository.
 
       Report:
       - How many of the last 5 commits are signed?

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -145,6 +145,19 @@ mechanical:
       decisions to an ADR and remove the raw files. See
       references/spec-cleanup.md and spec-cleanup-guard.sh.
 
+  # Signature *presence*, read from the commit object. Deliberately not `%G?`
+  # or `--show-signature`: under gpg.format=ssh with no
+  # gpg.ssh.allowedSignersFile both report a correctly signed commit as
+  # unsigned, which fails a fully signed repository. Whether a signature
+  # verifies is the host's answer (GW-11 / the commits API), not this one's.
+  # Kept in step with signing-preflight.sh by tests/test_signing_preflight.sh.
+  - id: GW-17
+    type: command
+    pattern: |-
+      test -z "$(git log -5 --format=%H | while read -r c; do git cat-file commit "$c" | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' || echo "$c"; done)"
+    severity: info
+    desc: "Recent commits should carry a GPG/SSH signature"
+
 llm_reviews:
   # === CONVENTIONAL COMMITS ===
   - id: GW-20

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -151,12 +151,20 @@ mechanical:
   # unsigned, which fails a fully signed repository. Whether a signature
   # verifies is the host's answer (GW-11 / the commits API), not this one's.
   # Kept in step with signing-preflight.sh by tests/test_signing_preflight.sh.
+  #
+  # HEAD only, single line, and no `$(`/`;`/`&&`: the checkpoint runner's
+  # allowlist (is_safe_eval_command in automated-assessment's
+  # run-checkpoints.sh) rejects command-chaining metacharacters outright, and a
+  # multi-line YAML scalar reaches it as an EMPTY pattern. A loop over the last
+  # five commits satisfies neither, so this mirrors the rule rather than
+  # reproducing it — the same arrangement as SR-37 in skill-repo. The full
+  # sweep lives in verify-git-workflow.sh (last 10) and signing-preflight.sh.
+  # `sed -n -e '/^$/q' -e p` is the semicolon-free spelling of the header cut.
   - id: GW-17
     type: command
-    pattern: |-
-      test -z "$(git log -5 --format=%H | while read -r c; do git cat-file commit "$c" | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' || echo "$c"; done)"
+    pattern: "git cat-file commit HEAD | sed -n -e '/^$/q' -e p | grep -qE '^gpgsig(-sha256)? '"
     severity: info
-    desc: "Recent commits should carry a GPG/SSH signature"
+    desc: "HEAD should carry a GPG/SSH signature"
 
 llm_reviews:
   # === CONVENTIONAL COMMITS ===

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -192,8 +192,8 @@ llm_reviews:
       Read the commit object — a signed commit carries a `gpgsig` header:
 
       ```
-      git log -5 --format=%H | while read c; do
-        git cat-file commit "$c" | sed -n '/^$/q;p' | grep -q '^gpgsig' \
+      git log -5 --format=%H | while read -r c; do
+        git cat-file commit "$c" | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' \
           && echo "$c signed" || echo "$c UNSIGNED"
       done
       ```

--- a/skills/git-workflow/checkpoints.yaml
+++ b/skills/git-workflow/checkpoints.yaml
@@ -172,7 +172,9 @@ llm_reviews:
   - id: GW-21
     domain: git-workflow
     prompt: |
-      Check if the repository has signed commits.
+      Check whether the repository's commits carry signatures. This checkpoint
+      asks about signature *presence*, not about whether the signatures verify —
+      that is the host's answer, not the local keyring's.
 
       Read the commit object — a signed commit carries a `gpgsig` header:
 
@@ -192,7 +194,7 @@ llm_reviews:
       - Are all commits from the same author signed?
       - Pass if all commits are signed, warn if some, fail if none
     severity: info
-    desc: "Commits should be GPG/SSH signed for authenticity"
+    desc: "Commits should carry a GPG/SSH signature"
 
   - id: GW-22
     domain: git-workflow

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -489,5 +489,49 @@
         "pattern": "(?i)(required approvals|COMMENT review|comment.only)"
       }
     ]
+  },
+  {
+    "name": "signing_readiness_probe_ssh",
+    "prompt": "Before a commit-heavy run I want to confirm git commit -S will actually sign. I use gpg.format=ssh and have not set gpg.ssh.allowedSignersFile. What probe should I use, and why does git log --show-signature say 'No signature'?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)cat-file commit[^\\n]{0,120}gpgsig"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)allowed.?signers"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(is signed|was signed|correctly signed|local verification|verification config)"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(throwaway|--allow-empty|reset --soft)"
+      }
+    ]
+  },
+  {
+    "name": "script_check_commit_is_signed",
+    "prompt": "In a script, is `git log -1 --format='%G?'` returning G a reliable check that HEAD is signed?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(?i)(unreliable|not reliable|not (a )?(reliable|sufficient|safe)|(don.t|do not) (reach for|rely on|use)[^\\n]{0,60}(%G\\?|show-signature))"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)allowed.?signers"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)cat-file commit[^\\n]{0,120}gpgsig"
+      },
+      {
+        "type": "content",
+        "pattern": "(?i)(blank line|first blank|sed -n)"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -514,11 +514,11 @@
   },
   {
     "name": "script_check_commit_is_signed",
-    "prompt": "In a script, is `git log -1 --format='%G?'` returning G a reliable check that HEAD is signed?",
+    "prompt": "In a script I need to decide whether HEAD is signed. Can I test `git log -1 --format='%G?'` = G and treat every other result as unsigned?",
     "assertions": [
       {
         "type": "content",
-        "pattern": "(?i)(unreliable|not reliable|not (a )?(reliable|sufficient|safe)|(don.t|do not) (reach for|rely on|use)[^\\n]{0,60}(%G\\?|show-signature))"
+        "pattern": "(?i)(unreliable|not reliable|not (a )?(reliable|sufficient|safe)|false negative|does ?n.?t (prove|mean)|no proof|(don.t|do not) (reach for|rely on|use)[^\\n]{0,60}(%G\\?|show-signature))"
       },
       {
         "type": "content",

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -160,10 +160,10 @@ BEFORE=$(git rev-parse HEAD)
 git add -- path/to/file path/to/other
 git commit -s -F msg.txt
 [ "$(git rev-parse HEAD)" != "$BEFORE" ] || { echo "commit aborted — re-stage and retry" >&2; exit 1; }
-git log -1 --format='%h %G?'          # now describes YOUR commit
+git log -1 --format='%h %s'           # now describes YOUR commit
 ```
 
-Checking `git commit`'s own exit code works, but only if nothing reads it first — and in practice the next thing in the block is a status line that answers from the *previous* commit and looks right. `git log -1 --format='%G?'` prints `G`, and the `git push` that follows succeeds while pushing nothing new, because the branch never moved. HEAD is the one value the aborted commit did not leave intact, which is why comparing it answers the question the others only appear to.
+Checking `git commit`'s own exit code works, but only if nothing reads it first — and in practice the next thing in the block is a status line that answers from the *previous* commit and looks right. `git log -1 --format='%G?'` prints the same value it printed before the aborted commit, and the `git push` that follows succeeds while pushing nothing new, because the branch never moved. HEAD is the one value the aborted commit did not leave intact, which is why comparing it answers the question the others only appear to.
 
 **Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
 
@@ -185,7 +185,10 @@ If you must actually exercise the signing path, do it on a throwaway branch and 
 
 ```bash
 git switch -c tmp/sign-probe
-git commit --allow-empty -S -m "chore: signing probe" && git log -1 --format='%G?'   # conventional msg so a commit-msg hook won't reject it; expect: G
+# conventional msg so a commit-msg hook won't reject it; header, not %G? — see "Verifying a Signed Commit" below
+git commit --allow-empty -S -m "chore: signing probe" \
+  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed || echo "NOT signed") \
+  || echo "NOT signed — commit failed"   # keep the chain: unchained, the check reads the parent commit
 git switch - && git branch -D tmp/sign-probe
 ```
 
@@ -219,8 +222,30 @@ Match on both, or on the object type plus a looser pattern:
 git tag -v v1.2.3 2>&1 | grep -qE 'Good ("git" )?signature' && echo signed
 ```
 
-The same applies to commits: `git log --format='%G?'` returning `G` is the
-backend-independent check, and is what to use in scripts.
+`git tag -v` needs `gpg.ssh.allowedSignersFile` as well. Without it, it prints
+`error: gpg.ssh.allowedSignersFile needs to be configured and exist for SSH
+signature verification`, exits 1, and the pattern above matches nothing (git
+2.54.0) — so a failed match means "not verifiable *here*", not "unsigned".
+
+### Verifying a Signed Commit
+
+For commits, do not reach for `git log --format='%G?'`: it is backend-independent
+but *not* verification-config-independent. Under `gpg.format=ssh` with no
+`gpg.ssh.allowedSignersFile`, `%G?` returns `N` and `--show-signature` prints
+`No signature` on a correctly signed commit (git 2.54.0) — `N` is
+indistinguishable from unsigned, and setting that config flips the identical
+commit to `G`. Read the commit header instead, which both backends write
+(`-----BEGIN SSH SIGNATURE-----` / `-----BEGIN PGP SIGNATURE-----`) and no local
+config gates:
+
+```bash
+git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed
+```
+
+Cut the header at the first blank line — over the whole object, `^gpgsig` also
+matches a message body line starting with `gpgsig` and reports an unsigned commit
+as signed. Whether the *host* accepts the key is a separate question, answered
+only by the commits API check above.
 
 ## Atomic Commits
 

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -165,7 +165,7 @@ git log -1 --format='%h %s'           # now describes YOUR commit
 
 Checking `git commit`'s own exit code works, but only if nothing reads it first — and in practice the next thing in the block is a status line that answers from the *previous* commit and looks right. `git log -1 --format='%G?'` prints the same value it printed before the aborted commit, and the `git push` that follows succeeds while pushing nothing new, because the branch never moved. HEAD is the one value the aborted commit did not leave intact, which is why comparing it answers the question the others only appear to.
 
-**Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause.
+**Never skip hooks** unless explicitly told to. `--no-verify` bypasses hook enforcement that exists for good reasons. If a hook fails, diagnose the root cause. The one exception is a throwaway *probe* commit that is deleted moments later and never enters history — `signing-preflight.sh` retries with `--no-verify` there, and only to tell a hook rejection apart from a signing failure.
 
 **Never bypass signing** unless explicitly told to. `--no-gpg-sign` and `-c commit.gpgsign=false` disable commit signing; the result will fail branch-protection or policy checks that require signed commits later.
 

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -181,13 +181,15 @@ git config gpg.format         # ssh (SSH signing) or empty (GPG)
 git config user.signingkey    # the key/path that will be used
 ```
 
-If you must actually exercise the signing path, do it on a throwaway branch and discard it:
+If you must actually exercise the signing path, run `scripts/signing-preflight.sh`
+— it does the whole dance below and cleans up after itself. By hand, do it on a
+throwaway branch and discard it:
 
 ```bash
 git switch -c tmp/sign-probe
 # conventional msg so a commit-msg hook won't reject it; header, not %G? — see "Detecting a Signed Commit" below
 git commit --allow-empty -S -m "chore: signing probe" \
-  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed || echo "NOT signed") \
+  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' && echo signed || echo "NOT signed") \
   || echo "NOT signed — commit failed"   # keep the chain: unchained, the check reads the parent commit
 git switch - && git branch -D tmp/sign-probe
 ```
@@ -244,8 +246,14 @@ write (`-----BEGIN SSH SIGNATURE-----` / `-----BEGIN PGP SIGNATURE-----`) and no
 local config gates:
 
 ```bash
-git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed
+scripts/signing-preflight.sh --check-commit HEAD      # exit 0 signed, 1 unsigned
+# by hand:
+git cat-file commit HEAD | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' && echo signed
 ```
+
+`gpgsig-sha256` is the header name in SHA-256 repositories; the alternation
+covers both. Match the header name and the space, so nothing else in the header
+block can pass.
 
 Cut the header at the first blank line — over the whole object, `^gpgsig` also
 matches a message body line starting with `gpgsig` and reports an unsigned commit

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -185,7 +185,7 @@ If you must actually exercise the signing path, do it on a throwaway branch and 
 
 ```bash
 git switch -c tmp/sign-probe
-# conventional msg so a commit-msg hook won't reject it; header, not %G? — see "Verifying a Signed Commit" below
+# conventional msg so a commit-msg hook won't reject it; header, not %G? — see "Detecting a Signed Commit" below
 git commit --allow-empty -S -m "chore: signing probe" \
   && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed || echo "NOT signed") \
   || echo "NOT signed — commit failed"   # keep the chain: unchained, the check reads the parent commit
@@ -227,16 +227,21 @@ git tag -v v1.2.3 2>&1 | grep -qE 'Good ("git" )?signature' && echo signed
 signature verification`, exits 1, and the pattern above matches nothing (git
 2.54.0) — so a failed match means "not verifiable *here*", not "unsigned".
 
-### Verifying a Signed Commit
+### Detecting a Signed Commit
 
-For commits, do not reach for `git log --format='%G?'`: it is backend-independent
-but *not* verification-config-independent. Under `gpg.format=ssh` with no
-`gpg.ssh.allowedSignersFile`, `%G?` returns `N` and `--show-signature` prints
-`No signature` on a correctly signed commit (git 2.54.0) — `N` is
-indistinguishable from unsigned, and setting that config flips the identical
-commit to `G`. Read the commit header instead, which both backends write
-(`-----BEGIN SSH SIGNATURE-----` / `-----BEGIN PGP SIGNATURE-----`) and no local
-config gates:
+Signedness and verification are different questions, and only the first has a
+stable local answer: whether a commit *carries* a signature is a property of the
+object, whether *this machine* trusts that signature depends on local config.
+The check below answers the first one only.
+
+For that question, do not reach for `git log --format='%G?'`: it is
+backend-independent but *not* verification-config-independent. Under
+`gpg.format=ssh` with no `gpg.ssh.allowedSignersFile`, `%G?` returns `N` and
+`--show-signature` prints `No signature` on a correctly signed commit (git
+2.54.0) — `N` is indistinguishable from unsigned, and setting that config flips
+the identical commit to `G`. Read the commit header instead, which both backends
+write (`-----BEGIN SSH SIGNATURE-----` / `-----BEGIN PGP SIGNATURE-----`) and no
+local config gates:
 
 ```bash
 git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo signed

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1741,16 +1741,19 @@ merge.
 
 ### Signing Readiness (Preflight — Before Committing)
 
-A signing failure surfaces only at the *merge gate* (BLOCKED on DCO / "verified signatures") — i.e. **after** all the work is staged, forcing a full re-sign cycle. Catch it up front: before a commit-heavy run (e.g. `/pr-finish`), confirm a signing key is actually available and that `git commit -S` will sign, rather than assuming it.
+Two failures hide behind "signing is broken", and they surface at opposite ends of the run. A **local** signing failure surfaces immediately: `git commit -S` aborts and the branch does not move. A **host** verification failure — the key signs fine but GitHub does not recognise it — surfaces only at the *merge gate* (BLOCKED on DCO / "verified signatures"), i.e. **after** all the work is committed and pushed, forcing a full re-sign cycle. Preflight both before a commit-heavy run (e.g. `/pr-finish`): confirm a signing key is actually available and that `git commit -S` will sign, rather than assuming it.
 
 ```bash
 # SSH-signing setups: is a key the agent can sign with actually loaded?
 ssh-add -l        # "no identities" → signing (and any SSH git auth) will fail until re-added
-# Definitive probe: a throwaway signed commit carries a signature, then drop it
-# (do this on a throwaway branch, not on `main` — see commit-conventions.md, "Verify signing capability without committing on `main`")
-git commit -S --allow-empty -m probe \
-  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo "SIGNING READY" || echo "SIGNING NOT READY"; git reset --soft HEAD~1) \
+# Definitive probe: a throwaway signed commit carries a signature, then drop it —
+# on a throwaway branch, not on `main` (see commit-conventions.md, "Verify signing capability without committing on `main`")
+git switch -c tmp/sign-probe
+# conventional msg — a commit-msg hook rejecting `probe` aborts the commit and reads as a signing failure
+git commit -S --allow-empty -m "chore: signing probe" \
+  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo "SIGNING READY" || echo "SIGNING NOT READY") \
   || echo "SIGNING NOT READY — commit failed"
+git switch - && git branch -D tmp/sign-probe
 ```
 
 **Assert on the commit object, not on local verification.** `git log --show-signature` / `%G?` answer the narrower question "can *this machine* verify the signature", and report failure on setups that sign perfectly well. With `gpg.format=ssh` and no `gpg.ssh.allowedSignersFile`, `git log --show-signature -1` prints `error: gpg.ssh.allowedSignersFile needs to be configured and exist for SSH signature verification` and then `No signature`, and `%G?` returns `N` — on a commit that carries a valid signature and that the host reports as `verified: true` once the key is registered as a signing key. The command still **exits 0** while printing that error, so a driver reading `$?` sees success too.
@@ -1761,7 +1764,7 @@ The `gpgsig` header depends on no verification config and is written by both bac
 
 **Do not assert on `Good` either.** Unanchored, it matches the `Author:` line, so an unsigned commit by an author named e.g. "Goodwin" reports `SIGNING READY`. And a local `Good` only proves your own allowed-signers file accepts your key, never that GitHub does — that is the `unknown_key` API check under *Signing and DCO Failures* below. **Keep the commit chained to the check with `&&`.** `git commit -S` cannot silently produce an unsigned commit: with a key it cannot load it aborts (`fatal: failed to write commit object`, exit 128, HEAD unmoved). But an unchained check then reads the *parent* commit, which in signed history carries its own `gpgsig` header — so it prints `SIGNING READY` for a probe that never happened.
 
-If the probe fails (no askpass, a locked/dropped key, or an unloadable `user.signingkey`), resolve it **before** doing the work — the mid-run remedy is the same `rebase --exec` re-sign as a reactive failure, but you avoid discovering it at the gate. See *Signing and DCO Failures* below for that remedy.
+If the probe fails (no askpass, a locked/dropped key, or an unloadable `user.signingkey`), resolve it **before** doing the work — the mid-run remedy is the same `rebase --exec` re-sign as a reactive failure, but you avoid discovering it at the gate. `commit failed` is not by itself a signing verdict: a `commit-msg` hook rejecting the probe message aborts the commit exactly the same way, so read the commit output before chasing keys. See *Signing and DCO Failures* below for that remedy.
 
 ### Signing and DCO Failures
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1744,6 +1744,14 @@ merge.
 Two failures hide behind "signing is broken", and they surface at opposite ends of the run. A **local** signing failure surfaces immediately: `git commit -S` aborts and the branch does not move. A **host** verification failure — the key signs fine but GitHub does not recognise it — surfaces only at the *merge gate* (BLOCKED on DCO / "verified signatures"), i.e. **after** all the work is committed and pushed, forcing a full re-sign cycle. Preflight both before a commit-heavy run (e.g. `/pr-finish`): confirm a signing key is actually available and that `git commit -S` will sign, rather than assuming it.
 
 ```bash
+scripts/signing-preflight.sh     # exit 0 READY · 1 NOT READY · 2 could not probe
+```
+
+`signing-preflight.sh` is the mechanical form of everything below: it probes on a throwaway branch through a temporary index (so a staged change is never swept into the probe commit), asserts on the commit object, retries once with `--no-verify` to tell a hook rejection apart from a signing failure, and removes the branch either way. `--check-commit <rev>` answers the same question for an existing commit, `--config-only` reports the config without committing. Its regression suite is `tests/test_signing_preflight.sh`; checkpoint GW-17 applies the same rule to a repository being assessed.
+
+By hand, where the script is not available:
+
+```bash
 # SSH-signing setups: is a key the agent can sign with actually loaded?
 ssh-add -l        # "no identities" → signing (and any SSH git auth) will fail until re-added
 # Definitive probe: a throwaway signed commit carries a signature, then drop it —
@@ -1751,7 +1759,7 @@ ssh-add -l        # "no identities" → signing (and any SSH git auth) will fail
 git switch -c tmp/sign-probe
 # conventional msg — a commit-msg hook rejecting `probe` aborts the commit and reads as a signing failure
 git commit -S --allow-empty -m "chore: signing probe" \
-  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo "SIGNING READY" || echo "SIGNING NOT READY") \
+  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? ' && echo "SIGNING READY" || echo "SIGNING NOT READY") \
   || echo "SIGNING NOT READY — commit failed"
 git switch - && git branch -D tmp/sign-probe
 ```

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1746,13 +1746,22 @@ A signing failure surfaces only at the *merge gate* (BLOCKED on DCO / "verified 
 ```bash
 # SSH-signing setups: is a key the agent can sign with actually loaded?
 ssh-add -l        # "no identities" → signing (and any SSH git auth) will fail until re-added
-# Definitive probe: a throwaway signed commit verifies, then drop it
+# Definitive probe: a throwaway signed commit carries a signature, then drop it
+# (do this on a throwaway branch, not on `main` — see commit-conventions.md, "Verify signing capability without committing on `main`")
 git commit -S --allow-empty -m probe \
-  && (git log --show-signature -1 | grep -q Good && echo "SIGNING READY" || echo "SIGNING NOT READY"; git reset --soft HEAD~1) \
+  && (git cat-file commit HEAD | sed -n '/^$/q;p' | grep -q '^gpgsig' && echo "SIGNING READY" || echo "SIGNING NOT READY"; git reset --soft HEAD~1) \
   || echo "SIGNING NOT READY — commit failed"
 ```
 
-If the probe fails (no askpass, a locked/dropped key, or a key not registered as a *signing* key), resolve it **before** doing the work — the mid-run remedy is the same `rebase --exec` re-sign as a reactive failure, but you avoid discovering it at the gate. See *Signing and DCO Failures* below for that remedy.
+**Assert on the commit object, not on local verification.** `git log --show-signature` / `%G?` answer the narrower question "can *this machine* verify the signature", and report failure on setups that sign perfectly well. With `gpg.format=ssh` and no `gpg.ssh.allowedSignersFile`, `git log --show-signature -1` prints `error: gpg.ssh.allowedSignersFile needs to be configured and exist for SSH signature verification` and then `No signature`, and `%G?` returns `N` — on a commit that carries a valid signature and that the host reports as `verified: true` once the key is registered as a signing key. The command still **exits 0** while printing that error, so a driver reading `$?` sees success too.
+
+`N` is indistinguishable from genuinely unsigned, which makes it more dangerous than the `E` case in *Signature verification: the GitHub API is the source of truth, not your keyring* above — `E` at least reads as "could not check here". Setting `gpg.ssh.allowedSignersFile` flips that same unchanged commit to `Good "git" signature` / `%G? = G` (measured on git 2.54.0), which is the fix if you also want local verification to work.
+
+The `gpgsig` header depends on no verification config and is written by both backends (`-----BEGIN SSH SIGNATURE-----` under `gpg.format=ssh`, `-----BEGIN PGP SIGNATURE-----` under GPG), so it answers exactly what the preflight asks: did `git commit -S` produce a signature. Cut the header at the first blank line (`sed -n '/^$/q;p'`) — matching `^gpgsig` against the whole object also matches a message *body* line starting with `gpgsig`, and reports an unsigned commit as signed.
+
+**Do not assert on `Good` either.** Unanchored, it matches the `Author:` line, so an unsigned commit by an author named e.g. "Goodwin" reports `SIGNING READY`. And a local `Good` only proves your own allowed-signers file accepts your key, never that GitHub does — that is the `unknown_key` API check under *Signing and DCO Failures* below. **Keep the commit chained to the check with `&&`.** `git commit -S` cannot silently produce an unsigned commit: with a key it cannot load it aborts (`fatal: failed to write commit object`, exit 128, HEAD unmoved). But an unchained check then reads the *parent* commit, which in signed history carries its own `gpgsig` header — so it prints `SIGNING READY` for a probe that never happened.
+
+If the probe fails (no askpass, a locked/dropped key, or an unloadable `user.signingkey`), resolve it **before** doing the work — the mid-run remedy is the same `rebase --exec` re-sign as a reactive failure, but you avoid discovering it at the gate. See *Signing and DCO Failures* below for that remedy.
 
 ### Signing and DCO Failures
 

--- a/skills/git-workflow/scripts/signing-preflight.sh
+++ b/skills/git-workflow/scripts/signing-preflight.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# signing-preflight.sh — does `git commit -S` actually produce a signature here?
+#
+# Answers the one question a commit-heavy run needs answered up front, and
+# answers it from the commit object rather than from local verification:
+#
+#   git log --show-signature / %G?  →  "can THIS MACHINE verify the signature"
+#   gpgsig header in the object     →  "did git WRITE a signature"
+#
+# Those differ. With gpg.format=ssh and no gpg.ssh.allowedSignersFile, git
+# 2.54.0 reports `%G? = N` and `No signature` for a perfectly signed commit —
+# indistinguishable from unsigned, and it exits 0 while printing the error, so
+# a driver reading $? sees success. Whether the *host* accepts the key is a
+# third question again, answered only by the GitHub commits API.
+#
+# The probe never touches the working tree, the index or the current branch:
+# it commits on a throwaway branch through a temporary index and removes both.
+#
+# Usage: signing-preflight.sh [--config-only] [--check-commit <rev>]
+#                             [--repo <dir>] [--quiet]
+#
+#   (default)         probe: prove that `git commit -S` signs, here, now
+#   --config-only     report the signing config without creating a commit
+#   --check-commit    report whether an existing commit carries a signature
+#
+# Exit codes:
+#   0  READY / signed
+#   1  NOT READY / unsigned — no signature, or signing aborted the commit
+#   2  INCONCLUSIVE — could not probe (hooks rejected it even with --no-verify,
+#                     or --config-only found the config incomplete)
+#   3  USAGE        — not a git repository / bad arguments
+
+set -uo pipefail
+
+CONFIG_ONLY=0
+QUIET=0
+REPO_DIR="."
+CHECK_REV=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config-only)  CONFIG_ONLY=1 ;;
+        --check-commit) shift; CHECK_REV="${1:-}" ;;
+        --quiet)        QUIET=1 ;;
+        --repo)         shift; REPO_DIR="${1:-}" ;;
+        -h|--help)      sed -n '2,30p' "$0"; exit 0 ;;
+        *)              echo "unknown argument: $1" >&2; exit 3 ;;
+    esac
+    shift
+done
+
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+
+cd "$REPO_DIR" 2>/dev/null || { echo "no such directory: $REPO_DIR" >&2; exit 3; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repository: $REPO_DIR" >&2; exit 3; }
+
+# --- the check itself -------------------------------------------------------
+# Both backends write the signature as a commit *header*: `gpgsig` (SHA-1
+# repositories) or `gpgsig-sha256` (SHA-256), carrying `-----BEGIN SSH
+# SIGNATURE-----` or `-----BEGIN PGP SIGNATURE-----`. No local config gates it.
+#
+# Cut the object at the first blank line before matching: over the whole
+# object, `^gpgsig` also matches a message *body* line that starts with
+# `gpgsig`, which reports an unsigned commit as signed.
+commit_carries_signature() {
+    git cat-file commit "$1" 2>/dev/null | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? '
+}
+
+if [ -n "$CHECK_REV" ]; then
+    git rev-parse --verify --quiet "${CHECK_REV}^{commit}" >/dev/null \
+        || { echo "no such commit: $CHECK_REV" >&2; exit 3; }
+    if commit_carries_signature "$CHECK_REV"; then
+        say "signed: $CHECK_REV carries a signature header"
+        exit 0
+    fi
+    say "unsigned: $CHECK_REV carries no signature header"
+    exit 1
+fi
+
+# --- configuration ----------------------------------------------------------
+gpgsign=$(git config --get commit.gpgsign || echo "")
+gpgformat=$(git config --get gpg.format || echo "openpgp")
+signingkey=$(git config --get user.signingkey || echo "")
+
+say "config: commit.gpgsign=${gpgsign:-<unset>} gpg.format=$gpgformat user.signingkey=${signingkey:-<unset>}"
+
+if [ "$gpgformat" = "ssh" ] && command -v ssh-add >/dev/null 2>&1; then
+    if ! ssh-add -l >/dev/null 2>&1; then
+        # Not fatal: user.signingkey may name a private key file, which signs
+        # without an agent. Worth reporting, since a dropped agent key is the
+        # most common cause of a mid-run signing failure.
+        say "note: ssh-agent holds no identities — signing works only if user.signingkey names a private key file"
+    fi
+fi
+
+if [ "$CONFIG_ONLY" -eq 1 ]; then
+    if [ -z "$signingkey" ] && [ "$gpgformat" = "ssh" ]; then
+        say "INCONCLUSIVE — gpg.format=ssh without user.signingkey; config cannot tell whether signing works"
+        exit 2
+    fi
+    say "config present — run without --config-only to prove signing actually works"
+    exit 0
+fi
+
+# --- probe ------------------------------------------------------------------
+PROBE_BRANCH="tmp/sign-probe-$$"
+ORIG_REF=$(git symbolic-ref -q --short HEAD || git rev-parse --verify HEAD 2>/dev/null || echo "")
+TMP_INDEX=$(mktemp)
+STDERR_LOG=$(mktemp)
+
+# shellcheck disable=SC2329  # invoked by the EXIT trap below
+cleanup() {
+    # Restore first, then drop the branch: a branch cannot be deleted while
+    # it is checked out.
+    if [ -n "$ORIG_REF" ]; then
+        git checkout -q "$ORIG_REF" -- 2>/dev/null || git checkout -q "$ORIG_REF" 2>/dev/null || true
+    fi
+    git branch -q -D "$PROBE_BRANCH" 2>/dev/null || true
+    rm -f "$TMP_INDEX" "$STDERR_LOG"
+}
+trap cleanup EXIT
+
+# A temporary index seeded from HEAD keeps the real index untouched — without
+# it, `commit --allow-empty` sweeps whatever the user had staged into the
+# throwaway commit and unstages it when the branch is deleted.
+export GIT_INDEX_FILE="$TMP_INDEX"
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    git read-tree HEAD || { echo "could not seed temporary index" >&2; exit 3; }
+fi
+
+git checkout -q -b "$PROBE_BRANCH" 2>/dev/null || { echo "could not create probe branch" >&2; exit 3; }
+
+# Conventional message: a commit-msg hook rejecting `probe` aborts the commit
+# and is indistinguishable from a signing failure at the exit code.
+probe_commit() { git commit -S --allow-empty "$@" -m "chore: signing probe" >/dev/null 2>"$STDERR_LOG"; }
+
+HOOK_BLOCKED=0
+if ! probe_commit; then
+    # Retry with hooks off. If it now commits, the first failure was a hook,
+    # not signing — a distinction the plain probe cannot make. --no-verify is
+    # confined to this throwaway commit, which is deleted moments later.
+    if probe_commit --no-verify; then
+        HOOK_BLOCKED=1
+        say "note: a hook rejected the probe commit; retried with --no-verify to isolate signing"
+    else
+        say "NOT READY — git commit -S aborted:"
+        say "$(sed 's/^/  /' "$STDERR_LOG")"
+        exit 1
+    fi
+fi
+
+if commit_carries_signature HEAD; then
+    say "SIGNING READY — the probe commit carries a signature header"
+    [ "$HOOK_BLOCKED" -eq 1 ] && say "  (hooks reject a plain probe here; real commits must satisfy them)"
+    exit 0
+fi
+
+say "NOT READY — the probe commit was created without a signature"
+say "  commit.gpgsign is ${gpgsign:-unset}; pass -S explicitly or set commit.gpgsign=true"
+exit 1

--- a/skills/git-workflow/scripts/signing-preflight.sh
+++ b/skills/git-workflow/scripts/signing-preflight.sh
@@ -25,9 +25,9 @@
 #
 # Exit codes:
 #   0  READY / signed
-#   1  NOT READY / unsigned — no signature, or signing aborted the commit
-#   2  INCONCLUSIVE — could not probe (hooks rejected it even with --no-verify,
-#                     or --config-only found the config incomplete)
+#   1  NOT READY / unsigned — no signature, or the commit aborted with hooks
+#                     already ruled out by the --no-verify retry
+#   2  INCONCLUSIVE — --config-only cannot answer from the config alone
 #   3  USAGE        — not a git repository / bad arguments
 
 set -uo pipefail
@@ -143,7 +143,9 @@ if ! probe_commit; then
         HOOK_BLOCKED=1
         say "note: a hook rejected the probe commit; retried with --no-verify to isolate signing"
     else
-        say "NOT READY — git commit -S aborted:"
+        # --no-verify skips pre-commit and commit-msg, so hooks are ruled out
+        # by the retry: what remains is signing, or the repository itself.
+        say "NOT READY — git commit -S aborted with hooks disabled:"
         say "$(sed 's/^/  /' "$STDERR_LOG")"
         exit 1
     fi

--- a/skills/git-workflow/scripts/verify-git-workflow.sh
+++ b/skills/git-workflow/scripts/verify-git-workflow.sh
@@ -15,8 +15,11 @@ echo ""
 # Change to repo directory
 cd "$REPO_DIR"
 
-# Check if it's a git repository
-if [[ ! -d ".git" ]]; then
+# Check if it's a git repository. Asking git, not testing for a `.git`
+# directory: in a worktree `.git` is a *file* pointing at the real gitdir, so
+# the directory test refused to run in every worktree — including the layout
+# this skill's own references recommend.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "❌ Not a git repository"
     exit 1
 fi
@@ -38,7 +41,7 @@ if [[ -n "$INVALID_BRANCHES" ]]; then
     echo "⚠️  Non-standard branch names found:"
     echo "  $INVALID_BRANCHES"
     echo "   Expected: main, develop, feature/*, fix/*, release/*, hotfix/*"
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 else
     echo "✅ All branch names follow conventions"
 fi
@@ -54,11 +57,11 @@ VALID_COMMITS=0
 
 while IFS= read -r commit; do
     if echo "$commit" | grep -qE "$CONV_PATTERN"; then
-        ((VALID_COMMITS++))
+        VALID_COMMITS=$((VALID_COMMITS + 1))
     else
         # Allow merge commits
         if ! echo "$commit" | grep -qE "^[a-f0-9]+ Merge"; then
-            ((INVALID_COMMITS++))
+            INVALID_COMMITS=$((INVALID_COMMITS + 1))
         fi
     fi
 done <<< "$RECENT_COMMITS"
@@ -70,10 +73,10 @@ if [[ $TOTAL_COMMITS -gt 0 ]]; then
         echo "✅ $PERCENT% of commits follow Conventional Commits format"
     elif [[ $PERCENT -ge 50 ]]; then
         echo "⚠️  $PERCENT% of commits follow Conventional Commits format"
-        ((WARNINGS++))
+        WARNINGS=$((WARNINGS + 1))
     else
         echo "⚠️  Only $PERCENT% of commits follow Conventional Commits format"
-        ((WARNINGS++))
+        WARNINGS=$((WARNINGS + 1))
     fi
 fi
 
@@ -98,7 +101,7 @@ if [[ -f ".gitignore" ]]; then
     fi
 else
     echo "⚠️  No .gitignore file found"
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 # Check for hooks
@@ -177,7 +180,7 @@ fi
 
 if [[ "$CI_FOUND" == "false" ]]; then
     echo "⚠️  No CI/CD configuration found"
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 # Check for semantic release
@@ -247,9 +250,37 @@ fi
 if [[ -n "$CONFLICT_FILES" ]]; then
     echo "❌ Conflict markers found in files:"
     while IFS= read -r conflict_file; do echo "   $conflict_file"; done <<< "$CONFLICT_FILES"
-    ((ERRORS++))
+    ERRORS=$((ERRORS + 1))
 else
     echo "✅ No conflict markers found"
+fi
+
+echo ""
+echo "=== Commit Signing ==="
+
+# Read the signature from the commit object, not from `git log --show-signature`
+# or `%G?`: those answer "can this machine verify it", and report a correctly
+# signed commit as unsigned whenever gpg.format=ssh is set without
+# gpg.ssh.allowedSignersFile. Same rule as checkpoint GW-17 and
+# signing-preflight.sh. Cut at the first blank line so a `gpgsig` line in the
+# message body cannot pass as a signature.
+UNSIGNED=""
+while read -r sha; do
+    [[ -z "$sha" ]] && continue
+    if ! git cat-file commit "$sha" 2>/dev/null | sed -n '/^$/q;p' | grep -qE '^gpgsig(-sha256)? '; then
+        UNSIGNED="$UNSIGNED $sha"
+    fi
+done < <(git log -10 --format=%H 2>/dev/null)
+
+if [[ -z "$UNSIGNED" ]]; then
+    echo "✅ Last 10 commits all carry a signature"
+else
+    UNSIGNED_COUNT=$(wc -w <<< "$UNSIGNED")
+    echo "⚠️  $UNSIGNED_COUNT of the last 10 commits carry no signature:"
+    for sha in $UNSIGNED; do echo "   ${sha:0:8}"; done
+    echo "   Signature presence only — whether a signature verifies is the host's"
+    echo "   answer, not this check's. Probe your own setup with signing-preflight.sh."
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 # Summary

--- a/tests/test_signing_preflight.sh
+++ b/tests/test_signing_preflight.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Regression tests for signing-preflight.sh — the mechanical counterpart to the
+# signing prose in references/. Every case here is a bug that shipped, or a
+# measured claim the docs make and would otherwise never be re-measured:
+#
+#   %G? / --show-signature report N / "No signature" on a correctly signed SSH
+#   commit when gpg.ssh.allowedSignersFile is unset. That is the premise of the
+#   header check — if a future git changes it, case 1 fails and the measured
+#   claims in commit-conventions.md / pull-request-workflow.md need revisiting.
+#
+#   grep -q Good over --show-signature matches the Author: line, so an unsigned
+#   commit by an author named "Goodwin" reported SIGNING READY.
+#
+#   ^gpgsig over the whole object matches a message *body* line, so an unsigned
+#   commit whose body starts with "gpgsig" reported as signed.
+#
+# Uses a throwaway ssh key it generates itself, an isolated git config and
+# temporary repositories: no network, no agent, no user config.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/signing-preflight.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Isolate from the developer's own git config and ssh-agent: this suite must
+# measure the repository it builds, not the machine it runs on.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+unset SSH_AUTH_SOCK
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+KEY="$WORK/id_probe"
+ssh-keygen -q -t ed25519 -N "" -C "signing-preflight test" -f "$KEY" \
+    || { echo "ssh-keygen unavailable — cannot run signing tests"; exit 1; }
+
+# new_repo <name> [--sha256] [--unsigned]
+# Signing points at the *private* key file so it works without an ssh-agent.
+# gpg.ssh.allowedSignersFile stays unset on purpose: that is the setup the
+# whole design exists for.
+new_repo() {
+    local dir="$WORK/$1"; shift
+    local fmt="sha1" signed=1
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --sha256)   fmt="sha256" ;;
+            --unsigned) signed=0 ;;
+        esac
+        shift
+    done
+    mkdir -p "$dir"
+    git -C "$dir" init -q -b main --object-format="$fmt"
+    git -C "$dir" config user.name "Probe User"
+    git -C "$dir" config user.email probe@example.com
+    if [ "$signed" -eq 1 ]; then
+        git -C "$dir" config gpg.format ssh
+        git -C "$dir" config user.signingkey "$KEY"
+    fi
+    echo "$dir"
+}
+
+echo "signing-preflight.sh"
+
+# --- 1. the premise: signed, but local verification says otherwise ----------
+repo=$(new_repo premise)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+out=$("$SCRIPT" --repo "$repo" 2>&1); rc=$?
+check "probe reports READY on an ssh-signing repo" 0 "$rc"
+check "probe says SIGNING READY" 1 "$(grep -c 'SIGNING READY' <<<"$out")"
+gstatus=$(git -C "$repo" log -1 --format='%G?' 2>/dev/null)
+if [ "$gstatus" = "G" ]; then
+    echo "  FAIL premise: %G? returned G without gpg.ssh.allowedSignersFile —"
+    echo "       git's behaviour changed; re-measure the claims in"
+    echo "       references/commit-conventions.md and pull-request-workflow.md"
+    fail=1
+else
+    echo "  ok   premise holds: %G? = '$gstatus' on a correctly signed commit"
+fi
+check "--check-commit agrees the seed commit is signed" 0 \
+    "$("$SCRIPT" --repo "$repo" --check-commit HEAD --quiet; echo $?)"
+
+# --- 2. unsigned commit by an author named Goodwin --------------------------
+repo=$(new_repo goodwin --unsigned)
+git -C "$repo" config user.name "Alice Goodwin"
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -m "chore: seed"
+check "an unsigned Goodwin commit is not reported signed" 1 \
+    "$("$SCRIPT" --repo "$repo" --check-commit HEAD --quiet; echo $?)"
+
+# --- 3. 'gpgsig' in the message body ----------------------------------------
+repo=$(new_repo body --unsigned)
+echo seed > "$repo/a"; git -C "$repo" add a
+printf 'chore: seed\n\ngpgsig this is not actually a signature\n' > "$WORK/msg.txt"
+git -C "$repo" commit -q -F "$WORK/msg.txt"
+check "a 'gpgsig' body line is not a signature" 1 \
+    "$("$SCRIPT" --repo "$repo" --check-commit HEAD --quiet; echo $?)"
+
+# --- 4. SHA-256 repository writes gpgsig-sha256 -----------------------------
+repo=$(new_repo sha256 --sha256)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+check "gpgsig-sha256 counts as a signature" 0 \
+    "$("$SCRIPT" --repo "$repo" --check-commit HEAD --quiet; echo $?)"
+
+# --- 5. a hook that rejects every message must not read as a signing failure -
+repo=$(new_repo hooked)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+printf '#!/bin/sh\necho "commit-msg: rejected" >&2\nexit 1\n' > "$repo/.git/hooks/commit-msg"
+chmod +x "$repo/.git/hooks/commit-msg"
+out=$("$SCRIPT" --repo "$repo" 2>&1); rc=$?
+check "a rejecting hook still yields a signing verdict" 0 "$rc"
+check "the hook interference is reported" 1 "$(grep -c 'hook rejected the probe' <<<"$out")"
+
+# --- 6. an unusable signing key is NOT READY, with git's own error ----------
+repo=$(new_repo brokenkey)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+git -C "$repo" config user.signingkey "$WORK/does-not-exist"
+out=$("$SCRIPT" --repo "$repo" 2>&1); rc=$?
+check "an unloadable signing key reports NOT READY" 1 "$rc"
+check "git's own error is surfaced" 1 "$(grep -c 'NOT READY' <<<"$out")"
+
+# --- 7. the probe leaves nothing behind -------------------------------------
+repo=$(new_repo sideeffects)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+before_head=$(git -C "$repo" rev-parse HEAD)
+before_branch=$(git -C "$repo" symbolic-ref --short HEAD)
+echo staged > "$repo/b"; git -C "$repo" add b          # user work sitting in the index
+echo dirty > "$repo/c"                                  # and in the worktree
+"$SCRIPT" --repo "$repo" --quiet >/dev/null 2>&1
+check "HEAD is unchanged"                "$before_head"   "$(git -C "$repo" rev-parse HEAD)"
+check "branch is restored"               "$before_branch" "$(git -C "$repo" symbolic-ref --short HEAD)"
+check "no probe branch is left behind"   ""               "$(git -C "$repo" branch --list 'tmp/sign-probe*' --format='%(refname:short)')"
+check "the staged file is still staged"  "b"              "$(git -C "$repo" diff --cached --name-only)"
+check "the untracked file survives"      "dirty"          "$(cat "$repo/c")"
+
+# --- 8. --config-only creates no commit -------------------------------------
+repo=$(new_repo configonly)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+before_head=$(git -C "$repo" rev-parse HEAD)
+"$SCRIPT" --repo "$repo" --config-only --quiet >/dev/null 2>&1
+check "--config-only leaves HEAD alone" "$before_head" "$(git -C "$repo" rev-parse HEAD)"
+
+# --- 9. checkpoint GW-17 uses the same rule as the script -------------------
+# The checkpoint runs inline in an assessed repository and cannot call this
+# script; the two must agree or the checkpoint becomes a second, drifting
+# implementation.
+repo=$(new_repo checkpoint)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKPOINTS="$REPO_ROOT/skills/git-workflow/checkpoints.yaml"
+
+# Extracted with awk rather than a YAML parser: CI installs no PyYAML, and a
+# test that needs a dependency the runner lacks is a test that does not run.
+gw17=$(awk '/^  - id: GW-17$/{f=1} f && /^      test -z/{print; exit}' "$CHECKPOINTS")
+
+# The load-bearing part is the header pattern. If the two implementations ever
+# disagree, the checkpoint silently becomes a second, drifting answer.
+RULE='\^gpgsig(-sha256)? '
+check "the script uses the shared header rule" 1 \
+    "$(grep -c -- "$RULE" "$REPO_ROOT/skills/git-workflow/scripts/signing-preflight.sh")"
+check "the checkpoint uses the shared header rule" 1 \
+    "$(grep -c -- "$RULE" "$CHECKPOINTS")"
+
+if [ -z "$gw17" ]; then
+    echo "  FAIL could not extract the GW-17 command from checkpoints.yaml —"
+    echo "       the entry moved or was reformatted; re-anchor this test"
+    fail=1
+else
+    ( cd "$repo" && bash -c "$gw17" ) >/dev/null 2>&1
+    check "GW-17 passes on a signed repo" 0 "$?"
+    git -C "$repo" -c commit.gpgsign=false commit -q --allow-empty --no-gpg-sign -m "chore: unsigned"
+    ( cd "$repo" && bash -c "$gw17" ) >/dev/null 2>&1
+    check "GW-17 fails once an unsigned commit lands" 1 "$?"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All signing-preflight tests passed"
+else
+    echo "Some signing-preflight tests FAILED"
+fi
+exit "$fail"

--- a/tests/test_signing_preflight.sh
+++ b/tests/test_signing_preflight.sh
@@ -174,7 +174,15 @@ CHECKPOINTS="$REPO_ROOT/skills/git-workflow/checkpoints.yaml"
 
 # Extracted with awk rather than a YAML parser: CI installs no PyYAML, and a
 # test that needs a dependency the runner lacks is a test that does not run.
-gw17=$(awk '/^  - id: GW-17$/{f=1} f && /^      test -z/{print; exit}' "$CHECKPOINTS")
+gw17=$(awk '/^  - id: GW-17$/{f=1} f && /^    pattern: /{sub(/^    pattern: "/, ""); sub(/"$/, ""); print; exit}' "$CHECKPOINTS")
+
+# The checkpoint runner's allowlist (is_safe_eval_command) rejects `$(`, `;`,
+# `&&`, `||` and backticks outright, and a multi-line YAML scalar reaches it as
+# an empty pattern. A checkpoint that trips either never runs — the exact
+# failure this whole branch is about, one layer up.
+check "GW-17's pattern is a single line" 1 "$(wc -l <<<"$gw17")"
+check "GW-17's pattern has no chaining metacharacters" 0 \
+    "$(grep -cE '[;`]|&&|\|\||\$\(' <<<"$gw17")"
 
 # The load-bearing part is the header pattern. Every place that answers "is this
 # commit signed" must use the same rule, or one of them silently becomes a

--- a/tests/test_signing_preflight.sh
+++ b/tests/test_signing_preflight.sh
@@ -121,6 +121,15 @@ out=$("$SCRIPT" --repo "$repo" 2>&1); rc=$?
 check "a rejecting hook still yields a signing verdict" 0 "$rc"
 check "the hook interference is reported" 1 "$(grep -c 'hook rejected the probe' <<<"$out")"
 
+# --- 5b. the same for a pre-commit hook ------------------------------------
+repo=$(new_repo prehooked)
+echo seed > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -S -m "chore: seed"
+printf '#!/bin/sh\nexit 1\n' > "$repo/.git/hooks/pre-commit"
+chmod +x "$repo/.git/hooks/pre-commit"
+check "a rejecting pre-commit hook still yields a signing verdict" 0 \
+    "$("$SCRIPT" --repo "$repo" --quiet; echo $?)"
+
 # --- 6. an unusable signing key is NOT READY, with git's own error ----------
 repo=$(new_repo brokenkey)
 echo seed > "$repo/a"; git -C "$repo" add a
@@ -167,13 +176,21 @@ CHECKPOINTS="$REPO_ROOT/skills/git-workflow/checkpoints.yaml"
 # test that needs a dependency the runner lacks is a test that does not run.
 gw17=$(awk '/^  - id: GW-17$/{f=1} f && /^      test -z/{print; exit}' "$CHECKPOINTS")
 
-# The load-bearing part is the header pattern. If the two implementations ever
-# disagree, the checkpoint silently becomes a second, drifting answer.
+# The load-bearing part is the header pattern. Every place that answers "is this
+# commit signed" must use the same rule, or one of them silently becomes a
+# second, drifting answer — and the weak form `^gpgsig` (no alternation, no
+# trailing space) must appear nowhere at all.
 RULE='\^gpgsig(-sha256)? '
 check "the script uses the shared header rule" 1 \
     "$(grep -c -- "$RULE" "$REPO_ROOT/skills/git-workflow/scripts/signing-preflight.sh")"
-check "the checkpoint uses the shared header rule" 1 \
+check "the checkpoints use the shared header rule" 2 \
     "$(grep -c -- "$RULE" "$CHECKPOINTS")"
+check "the verifier uses the shared header rule" 1 \
+    "$(grep -c -- "$RULE" "$REPO_ROOT/skills/git-workflow/scripts/verify-git-workflow.sh")"
+# Scoped to the shipped surface: this file names the weak form in its own
+# assertion text and would otherwise match itself.
+check "the weak form appears nowhere under skills/" 0 \
+    "$(grep -rl -- "\^gpgsig'" "$REPO_ROOT/skills" 2>/dev/null | wc -l)"
 
 if [ -z "$gw17" ]; then
     echo "  FAIL could not extract the GW-17 command from checkpoints.yaml —"

--- a/tests/test_verify_git_workflow_sections.sh
+++ b/tests/test_verify_git_workflow_sections.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression test: verify-git-workflow.sh must run every section.
+#
+# Two defects made most of the script unreachable, both silent:
+#
+#   1. `set -e` + `((WARNINGS++))`. Post-increment returns the OLD value, so the
+#      first increment of a zero counter exits 1 and set -e aborts the script.
+#      Any repository that tripped an early warning got exactly one section and
+#      an exit code that read like an ordinary failed verification.
+#   2. `[[ ! -d ".git" ]]` as the repository test. In a worktree `.git` is a
+#      file, so the script refused to run in the very layout the skill's own
+#      references recommend.
+#
+# Both are invisible from the exit code alone, which is why this test asserts on
+# the sections that appear.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/verify-git-workflow.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+echo "verify-git-workflow.sh"
+
+# A repo that trips the first warning (non-standard branch name) and several
+# later ones: no .gitignore, no CI config, unconventional commits.
+repo="$WORK/repo"
+mkdir -p "$repo"
+git -C "$repo" init -q -b wip-nonstandard
+git -C "$repo" config user.name "Probe User"
+git -C "$repo" config user.email probe@example.com
+echo x > "$repo/a"; git -C "$repo" add a
+git -C "$repo" commit -q -m "did some stuff"
+
+out=$(bash "$SCRIPT" "$repo" 2>&1)
+
+for section in "Branch Naming Convention" "Commit Message Format" ".gitignore Check" \
+               "Git Hooks" "Code Ownership" "PR Templates" "CI/CD Configuration" \
+               "Release Configuration" "Current State" "Conflict Markers" \
+               "Commit Signing" "Summary"; do
+    check "section runs after an early warning: $section" 1 \
+        "$(grep -c "^=== $section ===$" <<<"$out")"
+done
+
+# The unsigned commit above must reach the signing section as a warning, not as
+# silence — a section that runs but reports nothing is the same blind spot.
+check "unsigned commits are reported" 1 \
+    "$(grep -c 'carry no signature' <<<"$out")"
+
+# A worktree is a git repository. `.git` is a file there.
+git -C "$repo" worktree add -q "$WORK/wt" -b side 2>/dev/null
+check "a worktree is recognised as a repository" 0 \
+    "$(grep -c 'Not a git repository' <<<"$(bash "$SCRIPT" "$WORK/wt" 2>&1)")"
+
+# A directory that is genuinely not a repository still fails.
+mkdir -p "$WORK/plain"
+out_plain=$(bash "$SCRIPT" "$WORK/plain" 2>&1)
+check "a non-repository is still rejected" 1 "$(grep -c 'Not a git repository' <<<"$out_plain")"
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All verify-git-workflow section tests passed"
+else
+    echo "Some verify-git-workflow section tests FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
## Problem

The signing-readiness preflight in `references/pull-request-workflow.md` asserted signing worked with:

```bash
git log --show-signature -1 | grep -q Good && echo "SIGNING READY"
```

`--show-signature` and `%G?` answer "can *this machine* verify the signature", not "did `git commit -S` sign". Under `gpg.format=ssh` with no `gpg.ssh.allowedSignersFile` they report failure on a setup that signs correctly, so the preflight reports `SIGNING NOT READY` and sends the reader to fix a working configuration.

## Measured (git 2.54.0)

Same commit throughout, `gpg.format=ssh`, `user.signingkey` set:

```
$ git commit -S --allow-empty -m probe
$ git log --show-signature -1
error: gpg.ssh.allowedSignersFile needs to be configured and exist for SSH signature verification
No signature
$ git log --show-signature -1 >/dev/null 2>&1; echo $?
0
$ git log -1 --format='%G?'
N
$ git cat-file commit HEAD | sed -n '/^$/q;p' | grep -c '^gpgsig'
1
```

`N` is indistinguishable from genuinely unsigned, and the command **exits 0** while printing the error, so a driver reading `$?` also sees success. Setting `gpg.ssh.allowedSignersFile` flips the identical commit:

```
$ git log --show-signature -1
Good "git" signature for ... with ED25519 key SHA256:...
$ git log -1 --format='%G?'
G
```

`git tag -v` needs the same config, and without it exits 1 with the same error, so a failed `Good` match there means "not verifiable here", not "unsigned".

## Two defects in the replaced pattern

`grep -q Good` is unanchored and `--show-signature` output includes the author line, so an **unsigned** commit matches:

```
$ git -c user.name="Alice Goodwin" -c commit.gpgsign=false commit --allow-empty -m unsigned
$ git log --show-signature -1 | grep -q Good && echo "SIGNING READY"
SIGNING READY
$ git cat-file commit HEAD | sed -n '/^$/q;p' | grep -c '^gpgsig'
0
```

And the header check must cut at the first blank line: matched over the whole object, `^gpgsig` also matches a message *body* line starting with `gpgsig`.

The `&&` chaining is kept deliberately. `git commit -S` aborts rather than producing an unsigned commit, but an unchained check then reads the *parent*, which in signed history carries its own `gpgsig` header and reports ready for a probe that never ran.

## Change

- `references/pull-request-workflow.md` — the preflight assertion, plus why the commit object is the right thing to assert on
- `references/commit-conventions.md` — the same probe, the `%G?`-in-scripts claim, the `git tag -v` caveat, and a "Verifying a Signed Commit" section
- `checkpoints.yaml` — GW-21 judged signedness from `--show-signature -5`, which fails a fully signed repository
- two evals

Whether the *host* accepts the key stays a separate question, answered by the existing `unknown_key` commits-API check.