### PR TITLE
feat(git-workflow): gate writes in the reference worktree, and three merge-gate fixes

### DIFF
--- a/scripts/reference-worktree-gate.py
+++ b/scripts/reference-worktree-gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: refuse a git write inside a reference `main/` worktree.
+
+In the bare-repo layout (`<project>/.bare` + one directory per branch), `main/`
+exists to be read, fetched from, and used as the base for new worktrees.
+`references/advanced-git.md` states that and so do most AGENTS.md files that
+adopt the layout. The rule still gets broken, because breaking it needs no
+intent: one Bash call omits its `cd`, inherits the working directory of an
+earlier call, and the commit lands on the shared branch locally — where a later
+push or a `jj git export` moves it under every sibling worktree.
+
+This denies the write. It does not deny naming the target explicitly:
+`git -C <path> commit` and `cd <path> && git commit` both pass, because both say
+where the write lands.
+
+Fails open. Any error, an unreadable payload, or a directory outside the layout
+allows the command — a gate that blocks on its own failure is worse than the
+friction it prevents.
+"""
+
+import json
+import os
+import re
+import sys
+
+# `<root>/<project>/main` (or `master`) — the reference checkout of the layout.
+# Set GIT_WORKTREE_ROOTS to a colon-separated list to match other roots.
+DEFAULT_ROOTS = ("~/projects", "~/p")
+
+# Subcommands that leave a commit, an index entry, or rewritten history behind.
+# `add` is included deliberately: the damage this gate exists to stop starts
+# with a stray `git add -A` staging a directory nobody meant to touch.
+GIT_WRITE = re.compile(
+    r"\bgit\s+(?:commit|add|merge|rebase|cherry-pick|revert|am|stash)\b"
+    r"|\bgit\s+reset\s+--hard\b"
+)
+# `git -C <path>` moves the operation out of the working directory, so the
+# working directory no longer decides where the write lands. That is the
+# explicit form this gate asks for, so it is never blocked.
+GIT_DASH_C = re.compile(r"\bgit\s+-C\s+\S+")
+
+
+def roots() -> list[str]:
+    raw = os.environ.get("GIT_WORKTREE_ROOTS")
+    parts = raw.split(":") if raw else DEFAULT_ROOTS
+    return [os.path.realpath(os.path.expanduser(p)) for p in parts if p]
+
+
+def effective_dir(cmd: str, cwd: str) -> str:
+    """The directory the command runs in: the last `cd` in the call wins."""
+    last = None
+    for m in re.finditer(r"(?:^|[|&;\n])\s*cd\s+([^\s|&;]+)", cmd or ""):
+        last = m.group(1).strip("'\"")
+    return last or (cwd or "")
+
+
+def is_reference_worktree(path: str) -> bool:
+    """True for `<root>/<project>/main` that sits beside a `.bare`.
+
+    Both halves matter. Without the name check every worktree matches; without
+    the `.bare` check an ordinary clone whose directory happens to be called
+    `main` would be gated.
+    """
+    d = os.path.realpath(os.path.expanduser(path or "")).rstrip("/")
+    if os.path.basename(d) not in ("main", "master"):
+        return False
+    parent = os.path.dirname(d)
+    if not any(os.path.dirname(parent) == r for r in roots()):
+        return False
+    return os.path.isdir(os.path.join(parent, ".bare"))
+
+
+def denies(cmd: str, cwd: str) -> bool:
+    c = (cmd or "").strip()
+    if "git worktree" in c or not GIT_WRITE.search(c):
+        return False
+    if GIT_DASH_C.search(c):
+        return False
+    return is_reference_worktree(effective_dir(c, cwd))
+
+
+REASON = (
+    "This is a git write inside a reference `main/` worktree. That directory is "
+    "for reading, for `git fetch`, and as the base for new worktrees; work "
+    "belongs in its own worktree beside it.\n\n"
+    "Usually the cause is an inherited working directory rather than intent — a "
+    "previous call left the shell somewhere else. Name the target:\n\n"
+    "  cd <project>/<branch> && git commit …\n"
+    "  git -C <project>/<branch> commit …\n\n"
+    "`git -C <path>` is never blocked. Reads, `git fetch` and `git worktree add` "
+    "are unaffected."
+)
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except Exception:  # noqa: BLE001 - hook entry point: fail open
+        return 0
+    if not isinstance(payload, dict) or payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    try:
+        if denies(cmd, payload.get("cwd", "")):
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": REASON,
+                        }
+                    }
+                )
+            )
+    except Exception:  # noqa: BLE001 - fail open
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_reference_worktree_gate.py
+++ b/scripts/test_reference_worktree_gate.py
@@ -107,6 +107,7 @@ def main() -> int:
             ),
             capture_output=True,
             text=True,
+            check=False,
             env={**os.environ, "GIT_WORKTREE_ROOTS": root},
         )
         e2e = '"deny"' in p.stdout

--- a/scripts/test_reference_worktree_gate.py
+++ b/scripts/test_reference_worktree_gate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Cases for reference-worktree-gate.py, run against a throwaway layout.
+
+The negative cases carry the rule: a gate that also blocks `git -C <path>` or a
+`cd` into a branch worktree would push the agent back toward the ambiguous form
+it exists to discourage.
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load(root: str):
+    os.environ["GIT_WORKTREE_ROOTS"] = root
+    spec = importlib.util.spec_from_file_location(
+        "gate", os.path.join(HERE, "reference-worktree-gate.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as root:
+        proj = os.path.join(root, "demo")
+        os.makedirs(os.path.join(proj, ".bare"))
+        os.makedirs(os.path.join(proj, "main"))
+        os.makedirs(os.path.join(proj, "feat-x"))
+        # A same-named directory WITHOUT a .bare sibling: an ordinary clone.
+        plain = os.path.join(root, "plain")
+        os.makedirs(os.path.join(plain, "main"))
+
+        gate = load(root)
+        ref = os.path.join(proj, "main")
+        branch = os.path.join(proj, "feat-x")
+
+        cases = [
+            (
+                "commit in the reference worktree",
+                True,
+                "git add -A && git commit -S --no-edit -q",
+                ref,
+            ),
+            (
+                "merge in the reference worktree",
+                True,
+                "git merge origin/main --no-edit",
+                ref,
+            ),
+            (
+                "hard reset in the reference worktree",
+                True,
+                "git reset --hard origin/main",
+                ref,
+            ),
+            (
+                "cd to a branch worktree first",
+                False,
+                f"cd {branch} && git commit -q -m x",
+                ref,
+            ),
+            ("git -C names the target", False, f"git -C {branch} commit -q -m x", ref),
+            ("read", False, "git log --oneline -3", ref),
+            ("fetch", False, "git fetch origin -q", ref),
+            ("worktree add", False, "git worktree add ../y -b y origin/main", ref),
+            (
+                "commit in a branch worktree",
+                False,
+                "git add -A && git commit -q -m x",
+                branch,
+            ),
+            (
+                "no .bare sibling",
+                False,
+                "git commit -q -m x",
+                os.path.join(plain, "main"),
+            ),
+            ("not a git write", False, "git status", ref),
+        ]
+
+        fails = 0
+        for name, want, cmd, cwd in cases:
+            got = gate.denies(cmd, cwd)
+            ok = got == want
+            fails += 0 if ok else 1
+            print(
+                f"  {'OK  ' if ok else 'FAIL'} {name:36} expected={want!s:5} got={got}"
+            )
+
+        # End-to-end through the hook protocol, so the payload shape is covered
+        # too — reading tool_input.command, not a top-level "command".
+        import json
+
+        p = subprocess.run(
+            [sys.executable, os.path.join(HERE, "reference-worktree-gate.py")],
+            input=json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git commit -m x"},
+                    "cwd": ref,
+                }
+            ),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GIT_WORKTREE_ROOTS": root},
+        )
+        e2e = '"deny"' in p.stdout
+        fails += 0 if e2e else 1
+        print(
+            f"  {'OK  ' if e2e else 'FAIL'} {'end-to-end payload':36} expected=True  got={e2e}"
+        )
+
+        print("  ---- failures:", fails)
+        return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -180,6 +180,53 @@ It fires only when the command actually runs `git commit` (`git -C <dir> commit`
 
 Verify it against both directions before relying on it: stage a file containing a real marker (must deny) and a `.rst` file with a `=======` underline (must allow).
 
+## Recipe 7: Block a git write inside the reference `main/` worktree
+
+`references/advanced-git.md` states that `main/` is reference only. The rule
+gets broken anyway because breaking it needs no intent: one Bash call omits its
+`cd`, inherits the working directory of an earlier call, and the commit lands on
+the shared branch locally — where a later push or a `jj git export` moves it
+under every sibling worktree. Prose cannot catch an inherited working directory;
+a gate reads it out of the payload.
+
+```bash
+cp <skill>/scripts/reference-worktree-gate.py ~/.claude/hooks/
+chmod +x ~/.claude/hooks/reference-worktree-gate.py
+```
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "python3 $HOME/.claude/hooks/reference-worktree-gate.py" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+It denies `commit`, `add`, `merge`, `rebase`, `cherry-pick`, `revert`, `am`,
+`stash` and `reset --hard` when the effective directory is a `main/` (or
+`master/`) that sits beside a `.bare`. It deliberately does **not** deny
+`git -C <path> …` or a call that starts with `cd <path> &&` — both name where the
+write lands, which is the shape it is steering toward — nor reads, `git fetch`,
+or `git worktree add`, which are what the directory is for. Roots default to
+`~/projects` and `~/p`; set `GIT_WORKTREE_ROOTS` to a colon-separated list for
+others.
+
+Already have a Bash gate? Extend it instead of adding a second hook — the
+directory test is three lines (`basename in {main,master}`, parent under a known
+root, `.bare` sibling exists) and reusing one hook keeps the denial messages in
+one place.
+
+Verify both directions before relying on it: `python3 scripts/test_reference_worktree_gate.py`
+builds a throwaway layout and checks that a commit in `main/` denies while
+`git -C <branch> commit` and a commit in a branch worktree pass.
+
 ## Anti-Patterns
 
 | Anti-pattern | Why wrong | Fix |

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -47,7 +47,26 @@ curl -s -H "$AUTH" "https://sonarcloud.io/api/qualitygates/project_status?projec
 curl -s -H "$AUTH" "https://sonarcloud.io/api/issues/search?componentKeys=$KEY&pullRequest=$PR&resolved=false&ps=1" | jq .total
 ```
 
-Merge-despite is defensible only when the sole failing condition is a touched-line re-attribution metric (`new_duplicated_lines_density`, patch coverage on refactor-moved lines), open PR issues are 0, and the PR body documents the rationale. Real findings: fix them.
+Merge-despite is defensible only when the sole failing condition is a touched-line **re-attribution** metric, open PR issues are 0, and the PR body documents the rationale. Real findings: fix them.
+
+**`new_duplicated_lines_density` is only sometimes that metric — check which case you are in before invoking the exemption.** It is re-attribution when the PR *moved or touched* existing lines and Sonar consequently charged the surrounding, already-duplicated block to the diff. It is a real finding when the PR *added* files: three new sibling classes written in one sitting are copy-paste, and the metric is measuring exactly that. `api/issues/search` cannot tell them apart — duplication is a measure, not an issue, so it returns 0 in both cases and the "open issues are 0" half of the exemption is satisfied either way.
+
+Ask which files carry the new duplicated lines, then read the blocks:
+
+```bash
+curl -s -H "$AUTH" "https://sonarcloud.io/api/measures/component_tree?component=$KEY&pullRequest=$PR&metricKeys=new_duplicated_lines&ps=200" \
+  | jq -r '.components[] | (.measures[0] | (.value // .periods[0].value // "0")) as $v
+           | select($v != "0") | select(.qualifier=="FIL") | "\($v)\t\(.path)"'
+curl -s -H "$AUTH" "https://sonarcloud.io/api/duplications/show?key=$KEY%3A<path>&pullRequest=$PR" \
+  | jq '.duplications[].blocks | map("\(.from)-\(.from + .size - 1)")'
+```
+
+Two shapes to get right or the first command prints nothing: a **`new_*`** metric
+carries its value under `periods[0].value`, not `.value`, and the response lists
+directories as well as files, so filter on `qualifier=="FIL"` to get paths you
+can pass to `duplications/show`.
+
+If the files listed are ones the PR *added*, dedupe them — the exemption does not apply. `typo3-testing-skill/references/sonarcloud.md` ("Gotchas: new-code duplication") carries the same rule from the analyzer side and the recovery patterns for it.
 
 ## Watcher skeleton
 
@@ -97,6 +116,37 @@ gh pr view $PR --repo $R --json reviews \
 Treat `unable to review` as **no review** and re-request; if the re-request returns the same notice the quota is still exhausted, and merging means merging unreviewed. Check the repo's recent merged PRs the same way before concluding that a bot review is the local norm — a quota outage can span every PR in a window, so "the last three merged PRs also show COMMENTED" is not evidence they were reviewed.
 
 **On a docs/prose PR the loop does not decay — it must be actively terminated.** The bot re-reads the whole changed file each round and keeps surfacing a *new cosmetic* nit (wording, an illustrative example value, a spelling), so pushing a fix just triggers another round almost indefinitely. To converge: once a finding is purely cosmetic and defensible, **reply on the thread and resolve it *without* a new commit** — no push means no re-review means no new nit. Reserve fresh pushes for substantive findings; batch several real fixes into one push rather than one-per-thread.
+
+## A polling watcher must emit on the transition, not on the state
+
+The skeleton above `exit`s when it is done, so it reports each outcome once. A
+watcher that instead *streams* events — a `Monitor`-style loop whose stdout lines
+become notifications — has no such protection: an emit condition written as a
+**state** (`pending == 0 && failures == 0`) is true on every subsequent poll and
+republishes the same line every cycle until something stops it. Three identical
+"checks complete" notifications for one PR is the usual first symptom, and the
+noise buries the event that actually changed.
+
+Latch the last emitted message and print only on change:
+
+```bash
+last=""
+while true; do
+  s=$(gh pr view "$PR" --repo "$R" --json state,statusCheckRollup) || { sleep 60; continue; }
+  [ "$(jq -r .state <<<"$s")" != "OPEN" ] && { echo "PR#$PR $(jq -r .state <<<"$s")"; break; }
+  fail=$(jq -r '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT")]|length' <<<"$s")
+  pend=$(jq -r '[.statusCheckRollup[]?|select(.status!="COMPLETED")]|length' <<<"$s")
+  if   [ "$fail" != 0 ]; then msg="PR#$PR RED"
+  elif [ "$pend" = 0 ];  then msg="PR#$PR checks complete, 0 failures"
+  else msg=""; fi
+  [ -n "$msg" ] && [ "$msg" != "$last" ] && { echo "$msg"; last="$msg"; }
+  sleep 60
+done
+```
+
+Watching several PRs in one loop needs one latch **per PR** (`declare -A seen`),
+not one shared variable — otherwise two PRs reaching the same state alternate and
+each re-emits.
 
 ## Check the producer is switched on before arming the watcher
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -989,6 +989,43 @@ git commit
 git push
 ```
 
+### A series of sibling branches: rebuild append-only sections, don't merge them
+
+When several of your own branches wait on one another, each needs `main` merged
+in again after the previous one lands. For an **append-only** section — a
+CHANGELOG's `[Unreleased]`, a toctree, an index — the second and later merges of
+that series behave differently from the first, and a resolver that works on the
+first silently corrupts the rest.
+
+The trap is any resolver whose premise is *"ours holds only my additions"* —
+fold-ours-into-theirs, `git checkout --ours` on a hunk, a script that appends one
+side to the other. That premise holds for the first merge only. Afterwards
+"ours" already contains everything the previous merge brought in, so each round
+appends `main`'s entries **again**. There are no conflict markers, the diff looks
+plausible, and the damage is visible only by counting: five branches merged in
+sequence produced ten `[Unreleased]` bullets standing three and four times over,
+and two of the PRs carried it to `main` before anyone noticed.
+
+Rebuild instead of merging. Take *theirs* (current `main`) verbatim, lift your
+own block out of *ours* by a distinctive first line, and insert it under the
+existing heading:
+
+```bash
+git show :3:CHANGELOG.md > /tmp/theirs.md   # current main
+git show :2:CHANGELOG.md > /tmp/ours.md     # your branch
+# extract your block from ours, insert into theirs under the matching heading
+```
+
+Then assert before committing — the three checks that catch every variant of
+this failure:
+
+- the heading count is unchanged (no second `### Added`),
+- your block appears exactly once, above the newest released section,
+- no top-level bullet's first line occurs twice in the section.
+
+The same three assertions find it after the fact, which is how the duplication
+above was eventually caught.
+
 ### Updating a PR branch without a local clone — `gh pr update-branch --rebase`
 
 To bring a **conflict-free** PR up to date with its base without checking it out, rebase its head branch remotely:


### PR DESCRIPTION
## Summary

Four findings from a `/retro` sweep of a session that took eight PRs through the merge queue. One new gate plus its recipe, and three corrections to guidance that was wrong or missing at the point it was needed.

## Came from

`/retro` session on 2026-08-10, project `t3x-nr-llm`.

### 1. Recipe 7 + `scripts/reference-worktree-gate.py` (C6 — written rule violated repeatedly)

- **Symptom:** four Bash calls in one session committed inside `~/projects/<project>/main`, producing a merge commit on the local `main`. Found three tool calls later, by accident.
- **Cause:** none of them said where they ran. Each inherited the working directory of an earlier call. `references/advanced-git.md` already states *"`main/` is reference only … Never commit, edit, or develop directly in it"*, and so did the operator's always-loaded instructions — prose cannot observe an inherited working directory, but a `PreToolUse` hook reads it out of the payload.
- **Required behavior:** deny the write; keep `git -C <path>` and `cd <path> &&` allowed, since both name where the write lands.
- **Verification:** `scripts/test_reference_worktree_gate.py` — 12 cases over a throwaway layout, including the exact command from the session and an end-to-end pass through the hook payload.

### 2. `new_duplicated_lines_density` is not always a re-attribution metric

- **Symptom:** the sole failing Sonar condition was `new_duplicated_lines_density` with 0 open issues — which this file described as grounds for merge-despite. It was measuring 191 lines of real copy-paste across three newly *added* sibling classes.
- **Cause:** the exemption was written for PRs that *move or touch* existing lines. It reads as unconditional, and `api/issues/search` cannot separate the cases — duplication is a measure, not an issue, so it returns 0 either way and the "issues are 0" half is satisfied in both.
- **Required behavior:** check which case you are in; ask `component_tree` which files carry the new duplicated lines. Added files → dedupe, no exemption.
- **Verification:** the query was run against a real response, which is how the two shapes now documented were found (`new_*` values live under `periods[0].value`, and the response lists directories as well as files).

### 3. A streaming watcher must emit on the transition

- **Symptom:** three identical "checks complete" notifications for one PR.
- **Cause:** the emit condition was a **state**, true on every subsequent poll. The `for`-loop skeleton in this file `exit`s and so never shows this; a `Monitor`-style streaming loop does.
- **Required behavior:** latch the last emitted message; one latch per PR when watching several.
- **Verification:** the snippet was run against a stubbed `gh` — three polls in the same state produce one line.

### 4. Serial merges duplicate append-only sections

- **Symptom:** ten `[Unreleased]` CHANGELOG bullets standing three and four times over; two PRs carried it to `main` before it was noticed.
- **Cause:** a resolver whose premise is *"ours holds only my additions"*. True for the first merge of a series, false for every later one — by then "ours" already contains what the previous merge brought in. No conflict markers, plausible diff.
- **Required behavior:** rebuild the section from *theirs* plus your own block instead of merging it, and assert heading count / single occurrence / no repeated first lines.
- **Verification:** those three assertions are what eventually caught it.

## Test plan

- [x] `scripts/test_reference_worktree_gate.py` — 12/12
- [x] every script in `tests/` — 8/8
- [x] `Build/Scripts/validate-skill.sh` — 0 errors, 0 warnings
- [x] pre-commit (markdownlint, ruff, ruff-format) clean; tests re-run after `ruff format` touched both new files
- [x] every snippet added here executed before committing (jq against a real SonarCloud response, latch against a stubbed `gh`, `bash -n` on the fragment)
