### PR TITLE
fix(git-workflow): let the reference worktree refresh itself

### DIFF
--- a/scripts/reference-worktree-gate.py
+++ b/scripts/reference-worktree-gate.py
@@ -38,6 +38,12 @@ GIT_WRITE = re.compile(
 # working directory no longer decides where the write lands. That is the
 # explicit form this gate asks for, so it is never blocked.
 GIT_DASH_C = re.compile(r"\bgit\s+-C\s+\S+")
+# Bringing the reference checkout up to date is what the directory is FOR — it
+# has to be current to serve as the base for new worktrees. A fast-forward
+# cannot create a commit or discard work, so `merge --ff-only` / `pull --ff-only`
+# are the sanctioned refresh and stay allowed. `reset --hard` is not: it reaches
+# the same state by discarding, which is the case worth stopping.
+FAST_FORWARD_ONLY = re.compile(r"\bgit\s+(?:merge|pull)\b[^|&;]*--ff-only\b")
 
 
 def roots() -> list[str]:
@@ -74,7 +80,7 @@ def denies(cmd: str, cwd: str) -> bool:
     c = (cmd or "").strip()
     if "git worktree" in c or not GIT_WRITE.search(c):
         return False
-    if GIT_DASH_C.search(c):
+    if GIT_DASH_C.search(c) or FAST_FORWARD_ONLY.search(c):
         return False
     return is_reference_worktree(effective_dir(c, cwd))
 
@@ -87,8 +93,9 @@ REASON = (
     "previous call left the shell somewhere else. Name the target:\n\n"
     "  cd <project>/<branch> && git commit …\n"
     "  git -C <project>/<branch> commit …\n\n"
-    "`git -C <path>` is never blocked. Reads, `git fetch` and `git worktree add` "
-    "are unaffected."
+    "`git -C <path>` is never blocked, and neither is the reference checkout's own "
+    "refresh — `git merge --ff-only origin/main` / `git pull --ff-only`. Reads, "
+    "`git fetch` and `git worktree add` are unaffected."
 )
 
 

--- a/scripts/test_reference_worktree_gate.py
+++ b/scripts/test_reference_worktree_gate.py
@@ -81,6 +81,21 @@ def main() -> int:
                 os.path.join(plain, "main"),
             ),
             ("not a git write", False, "git status", ref),
+            # Refreshing the reference checkout is the directory's purpose: it
+            # must be current to serve as the base for new worktrees. Caught by
+            # the gate itself minutes after it was installed.
+            (
+                "ff-only merge refreshes the reference",
+                False,
+                "git merge --ff-only origin/main",
+                ref,
+            ),
+            ("ff-only pull refreshes the reference", False, "git pull --ff-only", ref),
+            # A plain merge still lands a merge commit there.
+            ("plain merge is still refused", True, "git merge origin/main", ref),
+            # `reset --hard` reaches the same state by discarding, which is the
+            # case worth stopping.
+            ("hard reset is still refused", True, "git reset --hard origin/main", ref),
         ]
 
         fails = 0

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -214,7 +214,14 @@ It denies `commit`, `add`, `merge`, `rebase`, `cherry-pick`, `revert`, `am`,
 `master/`) that sits beside a `.bare`. It deliberately does **not** deny
 `git -C <path> …` or a call that starts with `cd <path> &&` — both name where the
 write lands, which is the shape it is steering toward — nor reads, `git fetch`,
-or `git worktree add`, which are what the directory is for. Roots default to
+or `git worktree add`, which are what the directory is for.
+
+Nor `git merge --ff-only` / `git pull --ff-only`: the reference checkout has to
+be *current* to serve as a base, so refreshing it is the directory's purpose and
+a fast-forward can neither create a commit nor discard work. `reset --hard`
+reaches the same state by discarding and stays refused. (That exemption is not
+theory — the gate blocked its own author's `reset --hard` in `main/` minutes
+after installation, which is how the over-block was found.) Roots default to
 `~/projects` and `~/p`; set `GIT_WORKTREE_ROOTS` to a colon-separated list for
 others.
 


### PR DESCRIPTION
## Summary

The gate added in #166 over-blocked: it denied `git merge --ff-only origin/main` inside a `main/` worktree, which is the one write that directory exists for.

## Came from

The gate blocked its own author's `git reset --hard origin/main` in `main/` **minutes after installation** — while verifying that an unrelated PR had landed. The block was correct in kind, and the question it forced ("is this actually wrong?") is what separated the two cases:

- A reference checkout has to be **current** to serve as the base for new worktrees. Refreshing it is the directory's purpose, and `merge --ff-only` / `pull --ff-only` can neither create a commit nor discard work → **exempt**.
- `reset --hard` reaches the same state *by discarding*, which is exactly the case worth stopping → **still refused**.
- A plain `merge` lands a merge commit there → **still refused**.

## Change

- `FAST_FORWARD_ONLY` exemption in `scripts/reference-worktree-gate.py`, beside the existing `git -C` one.
- The denial message names the allowed refresh, so the reader is pointed at the right command rather than only away from the wrong one.
- Recipe 7 states the exemption and why `reset --hard` is not part of it.
- Four cases in `scripts/test_reference_worktree_gate.py` pin both directions.

## Test plan

- [x] `scripts/test_reference_worktree_gate.py` — 16/16, including the two now-allowed refresh forms and the two still-refused ones
- [x] every script in `tests/` passes
- [x] `validate-skill.sh` — 0 errors
- [x] `ruff check .` and `ruff format --check .` at the versions CI pins
