### PR TITLE
fix(pr-status): name a request-review that waiting cannot clear

### DIFF
--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -548,7 +548,22 @@ while :; do
     emit "$s"; exit 0
   fi
   case "$act" in
-    fix-ci|triage-ci|resolve-threads|request-review|rebase|resolve-conflicts|merge|blocked|none)
+    request-review)
+      # A request-review whose cause is an exhausted review bot is a standing
+      # condition, not an event: waiting cannot clear a quota ceiling, so every
+      # re-arm of --watch returns instantly with the same line. Saying so is
+      # what stops an operator re-arming it three times before switching to
+      # `gh pr checks --watch`, which watches something that does move.
+      if [ "$(jq -r '.copilot_error_count // 0' <<<"$s")" -ge 2 ]; then
+        echo "ACTIONABLE: request-review (UNSATISFIABLE — the review bot has failed" \
+             "$(jq -r '.copilot_error_count' <<<"$s")x on this head; re-arming this watch" \
+             "returns immediately. Review the diff yourself, or watch the checks instead:" \
+             "gh pr checks $(jq -r '.number' <<<"$s") --repo $(jq -r '.repo' <<<"$s") --watch)"
+      else
+        echo "ACTIONABLE: request-review"
+      fi
+      emit "$s"; exit 0 ;;
+    fix-ci|triage-ci|resolve-threads|rebase|resolve-conflicts|merge|blocked|none)
       echo "ACTIONABLE: $act"
       emit "$s"; exit 0 ;;
   esac


### PR DESCRIPTION
`--watch` exits on `request-review`, which is correct while a review can still arrive. Once the bot has failed twice on the head it cannot — a quota ceiling does not clear by waiting — so every re-arm returns instantly with the same line, and the second one teaches the operator nothing.

The script already distinguishes that state: `copilot_error_count >= 2` is what selects the *do not keep re-requesting* advice. It simply did not surface it at the moment the operator decides whether to re-arm. Now the ACTIONABLE line says the state is unsatisfiable and names the watch that does move:

```
ACTIONABLE: request-review (UNSATISFIABLE — the review bot has failed 2x on this head; re-arming this watch returns immediately. Review the diff yourself, or watch the checks instead: gh pr checks 39 --repo owner/name --watch)
```

Found the hard way: a session re-armed this watch three times before switching instrument by hand.

Verified with `bash -n` and by running the changed script against a live PR — the non-exhausted paths are untouched (the run took the `check failed` branch).

Came from /retro: yes.