### PR TITLE
fix(pr-status): a cancelled run is not a failed one, and CI readiness needs its own field

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -44,6 +44,37 @@ Because the exit code cannot distinguish "watched and passed" from "never
 found the run", assert the run exists before watching it, or re-read the
 check's state afterwards rather than trusting the watcher's return.
 
+### The step output of a failed job comes from the RUN's log archive
+
+`gh api repos/$R/actions/jobs/$JOB/logs` and `gh run view --job $JOB --log`
+routinely hand back only the runner's own preamble — image provisioning,
+hardening-agent chatter, `Cleaning up orphan processes` — with the failing
+step's output absent entirely. One of them can also return an empty body and
+exit 0. Filtering that noise then produces nothing and reads as "the log says
+nothing about why it failed", which sends you diagnosing the wrong layer.
+
+Download the **run's** archive instead. It contains one text file per job, with
+the real step output:
+
+```bash
+gh api "repos/$R/actions/runs/$RUN/logs" > /tmp/logs.zip
+unzip -q -o /tmp/logs.zip -d /tmp/logs
+grep -rn '##\[error\]' /tmp/logs | grep -viE 'armour|agentservice|pam_unix'
+```
+
+On 2026-08-12 this was the difference between three unexplained merge-queue
+ejections and one line — `[ERROR] Undefined constant …PHPUnitSetList::PHPUNIT_110`
+— that named the cause outright. The job-level calls had been tried first and
+showed nothing but setup.
+
+Note the archive is per *run*, so for a queue ejection you need the
+`gh-readonly-queue/*` run, not the pull request's own:
+
+```bash
+gh run list --repo "$R" --limit 20 --json headBranch,databaseId,conclusion \
+  --jq '.[] | select(.headBranch | startswith("gh-readonly-queue"))'
+```
+
 Hand-rolled `gh pr checks | jq` poll loops re-derive those semantics from
 undocumented field shapes (a running check's `conclusion` may be `""`, `null`,
 or absent) and are a recurring source of bugs. The sharpest one: a poll run
@@ -55,6 +86,15 @@ both before runs start and after they finish — it cannot tell the two apart.
 If you must hand-roll (e.g. watching something with no native watcher), gate on
 a **named required check reaching a terminal `pass`/`fail` state**, never on a
 zero-pending count, and confirm the run belongs to the current head SHA first.
+
+`pr-status.sh --json` answers this in one field: **`checks_settled`** is true
+only when nothing is pending *and* every required context has reported at
+least once. Gate on that rather than re-deriving it — and note the `NEXT:` line
+does not carry it, because the review branches of the ladder outrank every CI
+branch. On a repo with the `copilot_code_review` ruleset, `NEXT:` says
+`request-review` from the second a commit lands and keeps saying it; the CI
+state now rides along in that answer's `why`, but a script should read the
+field.
 
 ## Before you add or edit a workflow file: read the repo's Actions policy
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1615,6 +1615,18 @@ gh run list --repo "$R" --limit 40 --json databaseId,status,headBranch \
 Bot reviews (Copilot, Gemini) land 2–5 minutes after each push — wait that
 window out before concluding "no threads".
 
+**A cancelled run leaves rows behind, and they are not failures.** When a push
+supersedes a run, its jobs conclude `CANCELLED` and those check-runs stay on the
+*earlier* commit forever. Where a workflow's `name:` is an unevaluated
+expression they are doubly confusing, showing up as rows literally called
+`e2e / matrix.typo3 != '' && …`. `pr-status.sh` splits them: a cancelled context
+that later reported under the same name is counted as **stale** and dropped from
+the numbers, while one that never reported again still shuts the gate and is
+listed under `cancelled — re-run, do not debug`. Before this split, two stale
+e2e rows read as `2 fail` with `NEXT: fix-ci` on a pull request GitHub itself
+called `CLEAN`, which cost an hour of log archaeology on a run that had been
+cancelled on purpose.
+
 **Review on an earlier head + `CLEAN`: decide via the timeline, not the
 review list.** After a follow-up push (docs-only changes often do not
 re-trigger Copilot), the only review on record may sit on a previous commit

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -203,7 +203,9 @@ evaluate() {
         reviewDecision: ($p.reviewDecision // ""),
         base: $p.baseRefName, head: $p.headRefName, headOid: $head,
         checks: {
-          total: ($checks|length),
+          # Stale rows are excluded so pass+fail+pending+skip still adds up to
+          # total; the stale count is reported on its own line.
+          total: (($checks|length) - ($stale|length)),
           pass:  ($checks|map(select(.state=="PASS"))|length),
           fail:  ($failing|length),
           pending:($pending|length),
@@ -211,7 +213,10 @@ evaluate() {
           running:($running|length),
           skip:  ($checks|map(select(.state=="SKIP"))|length),
           stale: ($stale|length),
-          cancelled: ($cancelled|map(.name)),
+          # Flattened: where the name: of a workflow is an unevaluated expression the
+          # check-run name arrives with newlines in it and would break the
+          # single-line summary into fragments.
+          cancelled: ($cancelled|map(.name|gsub("\\s+";" ")|.[0:90])),
           failing: ($failing|map(.name)),
           failing_required: ($failing_required|map(.name)),
           pending_required: ($pending_required|map(.name)),
@@ -233,8 +238,13 @@ evaluate() {
         # its own, and the checks counts alone do not give it: right after a
         # push "0 pending" is true because one context has registered and the
         # other ninety have not.
-        checks_settled: (($pending|length) == 0 and ($undispatched|length) == 0
-                         and ($checks|length) > 0),
+        # null, not false, when the rules could not be fetched: $required is
+        # empty then, so $undispatched is empty for the wrong reason and a
+        # caller gating on this would act on a set it never verified.
+        checks_settled: (if $ok == 1
+                         then (($pending|length) == 0 and ($undispatched|length) == 0
+                               and ($checks|length) > 0)
+                         else null end),
         rulesets: $ruletypes,
         # Every distinct state per author, not just the last one. `add` over
         # map({login: state}) overwrites, so a reviewer who approves and then

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -119,10 +119,17 @@ evaluate() {
           # started — and that is a different situation with a different
           # answer: a merge queue drops an entry whose required check never
           # starts, so "wait" is the wrong advice.
+          # CANCELLED is kept apart from FAIL for the same reason: a run
+          # superseded by the next push is cancelled, not failed, and its rows
+          # stay on the commit forever. Counting them as failures reports a
+          # CLEAN pull request as red and answers fix-ci for a run nobody can
+          # fix. Which of the two it is depends on whether the context reported
+          # again, so it is decided below and not here.
           then {name, state: (if .status == "QUEUED" then "QUEUED"
                               elif .status != "COMPLETED" then "PENDING"
                               elif .conclusion == "SUCCESS" then "PASS"
                               elif .conclusion == "SKIPPED" or .conclusion == "NEUTRAL" then "SKIP"
+                              elif .conclusion == "CANCELLED" then "CANCEL"
                               else "FAIL" end), url: .detailsUrl, started: .startedAt}
           else {name: .context, state: (if .state == "SUCCESS" then "PASS"
                                         elif .state == "PENDING" then "PENDING"
@@ -164,7 +171,14 @@ evaluate() {
     | ([$reviews_raw[] | select(is_errored_copilot_review | not)]) as $head_reviews
     | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))]) as $copilot_on_head
     | ([$p.reviewThreads.nodes[]? | select(.isResolved == false)]) as $unresolved
-    | ($checks | map(select(.state=="FAIL"))) as $failing
+    # A cancelled context that reported again under the same name is STALE:
+    # the later row is the answer and the cancelled one is a leftover. One that
+    # never reported again is genuinely unmet and still shuts the gate — but it
+    # needs a re-run, not a fix, so it is named separately either way.
+    | ([$checks[] | select(.state=="PASS" or .state=="SKIP" or .state=="FAIL") | .name]) as $reported
+    | ($checks | map(select(.state=="CANCEL" and (.name as $n | $reported | index($n)))))     as $stale
+    | ($checks | map(select(.state=="CANCEL" and (.name as $n | $reported | index($n)) == null))) as $cancelled
+    | (($checks | map(select(.state=="FAIL"))) + $cancelled) as $failing
     | ($checks | map(select(.state=="QUEUED"))) as $queued
     | ($checks | map(select(.state=="PENDING"))) as $running
     # "pending" downstream keeps meaning "not finished", queued or running.
@@ -196,6 +210,8 @@ evaluate() {
           queued: ($queued|length),
           running:($running|length),
           skip:  ($checks|map(select(.state=="SKIP"))|length),
+          stale: ($stale|length),
+          cancelled: ($cancelled|map(.name)),
           failing: ($failing|map(.name)),
           failing_required: ($failing_required|map(.name)),
           pending_required: ($pending_required|map(.name)),
@@ -209,6 +225,16 @@ evaluate() {
                    | select((.signature.isValid // false) | not)
                    | .oid[0:8]],
         undispatched: $undispatched,
+        # Whether the check set has finished registering AND finished running.
+        # The review branches of the NEXT ladder sit above every CI branch, so
+        # on a repo with the copilot_code_review ruleset NEXT answers
+        # request-review from the second a commit is pushed and never mentions
+        # CI at all. A caller that automates enqueueing needs the CI answer on
+        # its own, and the checks counts alone do not give it: right after a
+        # push "0 pending" is true because one context has registered and the
+        # other ninety have not.
+        checks_settled: (($pending|length) == 0 and ($undispatched|length) == 0
+                         and ($checks|length) > 0),
         rulesets: $ruletypes,
         # Every distinct state per author, not just the last one. `add` over
         # map({login: state}) overwrites, so a reviewer who approves and then
@@ -377,7 +403,14 @@ evaluate() {
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)) then
-           {action:"request-review", why:"copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — the rule itself does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate",
+           # This branch outranks every CI branch below, so it is the one place
+           # the CI state has to be carried along: without it NEXT reads
+           # request-review while the checks are still registering, and a
+           # caller that acts on it enqueues a pull request whose CI has not
+           # started. Says it, rather than reordering the ladder — the review
+           # really is the blocking gate here.
+           {action:"request-review", why:("copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — the rule itself does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate"
+                 + (if $s.checks_settled then "" else " (CI is NOT settled yet: \($s.checks.pending) pending, \($s.undispatched|length) required context(s) not reported — do not enqueue on this reading)" end)),
             cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
          elif ($s.has_review_on_head|not) then
            # The generic gate is also reached by repos WITHOUT the
@@ -484,6 +517,8 @@ render() {
     "  head        : \(.headOid[0:8]) on \(.head) -> \(.base)",
     "  checks      : \(.checks.pass) pass, \(.checks.fail) fail, \(.checks.pending) pending\(if .checks.pending > 0 then " (\(.checks.running) running, \(.checks.queued) queued)" else "" end), \(.checks.skip) skip (of \(.checks.total))",
     (if (.checks.failing|length) > 0 then "  failing     : \(.checks.failing|join(", "))" else empty end),
+    (if (.checks.cancelled|length) > 0 then "  cancelled   : \(.checks.cancelled|join(", ")) — re-run, do not debug" else empty end),
+    (if .checks.stale > 0 then "  stale       : \(.checks.stale) cancelled row(s) from a superseded run, ignored" else empty end),
     (if (.checks.failing_required|length) > 0 then "  ^ REQUIRED  : \(.checks.failing_required|join(", "))" else empty end),
     "  rulesets    : \(if (.rulesets|length)>0 then (.rulesets|join(", ")) else "none" end)",
     "  reviews     : \(if .has_review_on_head then (.reviews_on_head|to_entries|map("\(.key)=\(.value)")|join(", ")) else "NONE on current head" end)  decision=\(if .reviewDecision=="" then "-" else .reviewDecision end)",


### PR DESCRIPTION
Two readings that sent an operator after the wrong thing during a 19-PR merge series on 2026-08-12.

**CANCELLED counted as FAIL.** Every conclusion that is not SUCCESS, SKIPPED or NEUTRAL fell into `else "FAIL"`. When a push supersedes a run, its jobs conclude CANCELLED and those check-runs stay on the earlier commit forever, so a pull request GitHub itself called CLEAN read as `2 fail` with `NEXT: fix-ci`. The rows were doubly opaque because the workflow's `name:` is an unevaluated expression, so they showed up as `e2e / matrix.typo3 != '' && …`. An hour went into a run that had been cancelled on purpose.

CANCELLED is now its own state and split by whether the context reported again:

- reported again under the same name -> `stale`, dropped from the counts;
- never reported again -> still shuts the gate, but listed as `cancelled — re-run, do not debug` rather than folded into `failing`.

Merge semantics are unchanged: a genuinely unmet context still counts.

**No field said whether CI had started.** The review branches of the NEXT ladder sit above every CI branch, so on a repo with the copilot_code_review ruleset NEXT answers `request-review` from the second a commit is pushed and never mentions CI. The checks counts do not fill the gap either: right after a push `0 pending` is true because one context has registered and the other ninety have not. `ci-cd-integration.md` already warned about that trap in prose, but there was nothing machine-readable to gate on, so an automated caller enqueued a pull request whose CI had not started and the merge queue refused it.

`checks_settled` is now in the JSON — true only when nothing is pending and every required context has reported at least once — and the request-review answer carries the CI state in its `why`. The ladder order is unchanged: the review really is the blocking gate there.

Also documents how to read a failed job's output at all. `gh api .../actions/jobs/<id>/logs` and `gh run view --job <id> --log` return the runner's preamble and nothing else (one of them an empty body, exit 0); the run's log archive has the step output. That was the difference between three unexplained merge-queue ejections and the one line naming the cause.

Verified against the pull requests that misreported: #728 goes from `2 fail` to `1 fail` plus an explicit stale/cancelled breakdown, and `checks_settled` is false there (four required contexts never reported on that head) while true on a sibling that settled normally.
