### PR TITLE
docs(pull-request-workflow): pr-status.sh is GitHub-only, name the GitLab path

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -28,6 +28,23 @@ Measured on a 40-PR rollout that did not have it: **183 of 370 shell calls
 were PR-status probing**, the rulesets endpoint was queried exactly once, and
 `copilot_code_review` blocked four merges by surprise.
 
+**GitHub only.** The script speaks GitHub GraphQL, so it cannot answer for a
+GitLab merge request — `-R git.netresearch.de/group/project` is accepted at the
+command line and then fails with a bare `pr-status: GraphQL query failed`, and
+`--watch` produces nothing at all until it is killed. Nothing in the name says
+so, which is how a GitLab MR ended up behind a watcher that could never fire.
+For GitLab the equivalent is one `glab api` call:
+
+```bash
+glab api "projects/$(printf %s 'group/project' | jq -sRr @uri)/merge_requests/123" \
+  | jq '{state, detailed_merge_status, pipeline: .head_pipeline.status}'
+glab api "projects/.../merge_requests/123/discussions" \
+  | jq '[.[] | select(.notes[0].resolvable==true and .notes[0].resolved==false)] | length'
+```
+
+`detailed_merge_status` is GitLab's counterpart to `mergeStateStatus` and,
+unlike it, does name the reason.
+
 ## Then Merge: `scripts/pr-merge.sh`
 
 ```bash

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -36,9 +36,10 @@ so, which is how a GitLab MR ended up behind a watcher that could never fire.
 For GitLab the equivalent is one `glab api` call:
 
 ```bash
-glab api "projects/$(printf %s 'group/project' | jq -sRr @uri)/merge_requests/123" \
+P=$(printf %s 'group/project' | jq -sRr @uri)   # the path must be URI-encoded
+glab api "projects/$P/merge_requests/123" \
   | jq '{state, detailed_merge_status, pipeline: .head_pipeline.status}'
-glab api "projects/.../merge_requests/123/discussions" \
+glab api "projects/$P/merge_requests/123/discussions" \
   | jq '[.[] | select(.notes[0].resolvable==true and .notes[0].resolved==false)] | length'
 ```
 


### PR DESCRIPTION
Nothing in the script's name or in the section that introduces it says it cannot answer for a GitLab merge request. It speaks GitHub GraphQL, so `-R git.netresearch.de/group/project` is accepted at the command line and then fails with a bare `pr-status: GraphQL query failed` — and `--watch` produces no output at all and simply sits there. A GitLab MR ended up behind such a watcher for 560 s before the mismatch was noticed, which is exactly the "waiting on something that can never fire" failure the surrounding guidance exists to prevent.

Added a short scope statement where the script is introduced, plus the two `glab api` calls that answer the same question for GitLab: `detailed_merge_status` on the merge request — which, unlike `mergeStateStatus`, does name the reason — and the `/discussions` endpoint for unresolved threads.

Documentation only, no script change. `markdownlint-cli2` clean.