### PR TITLE
docs(no-editorializing): name the pipe that breaks the line-wrapping rule

### DIFF
--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -93,7 +93,9 @@ EOF
 ```
 
 **Hard-wrap the commit *body* (~72 cols); don't hard-wrap prose whose wrapping
-you don't control.** The 72-column convention is for commit message bodies. For
+you don't control.** The 72-column convention is for commit message bodies —
+which is exactly why a commit body must not be piped into a PR description
+unchanged; see *The rule breaks at the pipe* in `no-editorializing.md`. For
 **PR/MR & issue descriptions, release notes, review comments, and chat**, write
 one line per paragraph (and per list item) and let the renderer soft-wrap — a
 hard break mid-paragraph there does nothing for the output. For **committed

--- a/skills/git-workflow/references/no-editorializing.md
+++ b/skills/git-workflow/references/no-editorializing.md
@@ -58,3 +58,45 @@ pipelines, and hard-wrapping prose is right in one and wrong in the other.
 Do not wrap a release body or PR/comment the way you wrap a `.md` file. Fix one
 already published with hard-wraps via `gh release edit <tag> --notes-file <file>`
 (release bodies stay editable) or by editing the PR/comment.
+
+### The rule breaks at the pipe, not at the keyboard
+
+Knowing the rule is not enough, because the way it gets violated does not feel
+like writing prose at all:
+
+```bash
+git log -1 --format=%b > /tmp/body.md
+gh pr create --body-file /tmp/body.md      # <-- wrapped, every time
+```
+
+A commit body is *correctly* hard-wrapped at ~72 columns — `commit-conventions.md`
+says so. Piping it into a PR body moves that text across the boundary this
+section is about, and nothing in the command looks wrong. Observed on six of six
+pull requests created that way in one session, while every body and comment the
+same author typed by hand in the same session was clean: the rule was held for
+writing and lost for plumbing.
+
+The same applies to any other correctly-wrapped source: a CHANGELOG entry, an
+ADR paragraph, a quoted issue body.
+
+**Join the paragraphs before posting**, and strip the trailers while you are
+there — a commit body carries `Signed-off-by`, which is noise in a PR
+description:
+
+```bash
+git log -1 --format=%b \
+  | sed '/^Signed-off-by:/d' \
+  | awk 'BEGIN{RS="";ORS="\n\n"} {gsub(/\n/," "); gsub(/  +/," "); print}' > /tmp/body.md
+```
+
+That `awk` joins each blank-line-separated paragraph onto one line. It is
+deliberately naive — it will also join a fenced code block or a list, so read
+the result before posting rather than trusting it on a body that has either.
+
+**The fingerprint.** `Signed-off-by:` visible in a rendered PR description means
+that description came from a commit message, which means it is hard-wrapped.
+Grep for it when auditing:
+
+```bash
+gh pr view "$PR" --repo "$R" --json body --jq .body | grep -c '^Signed-off-by:'
+```


### PR DESCRIPTION
The line-wrapping rule in `no-editorializing.md` was already here and already correct — it lists PR/MR descriptions, review comments, issue bodies and release notes as comment surfaces where a hard wrap renders as a `<br>`. This is not a gap in what the reference says.

It was still broken on **six of six** pull requests created in one session, by someone who had this reference loaded. Every body and comment the same person typed by hand in that session measured clean. So the difference was not knowledge — it was that the violating step does not look like writing prose at all:

```bash
git log -1 --format=%b > /tmp/body.md
gh pr create --body-file /tmp/body.md
```

A commit body is *correctly* hard-wrapped at ~72 columns, and `commit-conventions.md` says so two files over. Piping it into a description carries that wrapping across the boundary the section is about, and nothing in the command reads as wrong.

## What this adds

- The trap itself, named, with the command that causes it.
- A join-and-strip recipe that also removes `Signed-off-by`, which is noise in a description rather than a trailer anyone reads there.
- The caveat that the recipe is deliberately naive: it will flatten a fenced block or a list, so the output needs reading before it is posted. Verified by running it against a real commit body and against a list.
- A detector worth grepping for in an audit: a `Signed-off-by:` visible in a rendered PR description means that description came from a commit message, which means it is wrapped. That is how the six were found.
- A forward reference from `commit-conventions.md` at the 72-column rule, which is where the wrong idea starts.

## Why documentation and not a check

A mechanical gate would have to live in whatever creates the pull request, and `gh pr create --body-file` is not this skill's to wrap. The realistic guard is the fingerprint: one grep over `gh pr view --json body` finds every body that came from a commit message, and that is cheap enough to run in a sweep.
