### PR TITLE
docs(merge-gate-watcher): ask git whether a PR merged, and reach REST when GraphQL is dead

### DIFF
--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -294,6 +294,8 @@ git merge-base --is-ancestor "$HEAD_SHA" origin/main && echo MERGED
 
 `$HEAD_SHA` is the PR head you pushed, which you already know. This keeps working while both budgets are exhausted, which is exactly when a watcher is most likely to be running. Reserve `pr-status.sh` for the merge *gate* — checks, threads, reviews, the `NEXT` line — and use git for the merge *fact*.
 
+**Ancestry answers only where the merge preserves the commit.** `--merge` and `--rebase` do; **squash does not** — it writes one new commit with a new hash, so the original head is never an ancestor and the check reads "not merged" forever. In a squash-merge repo, accept one cheap REST call instead: `gh api repos/$R/pulls/$PR --jq .merged`. Know which strategy the repo allows before relying on ancestry — `pr-status.sh` prints it as `merge: methods=[…]`.
+
 **`git log --grep="#<pr>"` is not that test.** It is the tempting one-liner and it produces false positives: `--grep` searches the whole commit *message*, and a dependency bump carries its upstream changelog in the body — including that upstream's issue numbers, from a different repository. Observed 2026-08-13: a watcher on PR #765 reported `MERGED` on its first tick, seven months after the commit it matched. That commit was `chore(deps): bump actions/attest-build-provenance` from January, whose embedded changelog links `actions/attest-build-provenance` issue #765. The PR being watched was in fact `CONFLICTING` and needed a rebuild.
 
 Ancestry is a fact about the graph; `--grep` is a text search over prose that nobody wrote for you to parse.

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -294,7 +294,9 @@ git merge-base --is-ancestor "$HEAD_SHA" origin/main && echo MERGED
 
 `$HEAD_SHA` is the PR head you pushed, which you already know. This keeps working while both budgets are exhausted, which is exactly when a watcher is most likely to be running. Reserve `pr-status.sh` for the merge *gate* — checks, threads, reviews, the `NEXT` line — and use git for the merge *fact*.
 
-**`git log --grep="#<pr>"` is not that test.** It is the tempting one-liner and it produces false positives: `--grep` searches the whole commit message, so any older commit whose body happens to mention the number matches. Observed 2026-08-13: a watcher on PR #765 reported `MERGED` from its first tick because a months-old dependency bump mentioned `#765` in its body; the PR was in fact `CONFLICTING` and needed a rebuild. Ancestry is a fact about the graph, `--grep` is a text search over prose. Use ancestry.
+**`git log --grep="#<pr>"` is not that test.** It is the tempting one-liner and it produces false positives: `--grep` searches the whole commit *message*, and a dependency bump carries its upstream changelog in the body — including that upstream's issue numbers, from a different repository. Observed 2026-08-13: a watcher on PR #765 reported `MERGED` on its first tick, seven months after the commit it matched. That commit was `chore(deps): bump actions/attest-build-provenance` from January, whose embedded changelog links `actions/attest-build-provenance` issue #765. The PR being watched was in fact `CONFLICTING` and needed a rebuild.
+
+Ancestry is a fact about the graph; `--grep` is a text search over prose that nobody wrote for you to parse.
 
 The same asymmetry as the empty-result rule, inverted: an empty result is first a broken query, and a *positive* result from a text search is first a coincidence.
 

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -283,6 +283,34 @@ Three rules follow, and they cost nothing:
 
 Recovery is waiting: `gh api rate_limit --jq '.resources.graphql.reset'` is an epoch timestamp — sleep to it in **one** background command rather than retrying into the limit.
 
+### "Has it merged yet?" costs nothing — ask git, not the API
+
+The three rules above make a watcher cheaper. This one makes the commonest watcher free. Once a PR is queued the only question left is whether its head landed on the base, and git answers that with no API budget at all:
+
+```bash
+git fetch origin main --quiet
+git merge-base --is-ancestor "$HEAD_SHA" origin/main && echo MERGED
+```
+
+`$HEAD_SHA` is the PR head you pushed, which you already know. This keeps working while both budgets are exhausted, which is exactly when a watcher is most likely to be running. Reserve `pr-status.sh` for the merge *gate* — checks, threads, reviews, the `NEXT` line — and use git for the merge *fact*.
+
+**`git log --grep="#<pr>"` is not that test.** It is the tempting one-liner and it produces false positives: `--grep` searches the whole commit message, so any older commit whose body happens to mention the number matches. Observed 2026-08-13: a watcher on PR #765 reported `MERGED` from its first tick because a months-old dependency bump mentioned `#765` in its body; the PR was in fact `CONFLICTING` and needed a rebuild. Ancestry is a fact about the graph, `--grep` is a text search over prose. Use ancestry.
+
+The same asymmetry as the empty-result rule, inverted: an empty result is first a broken query, and a *positive* result from a text search is first a coincidence.
+
+### When GraphQL is exhausted, REST still opens the PR
+
+`gh pr create` and `gh pr view` are GraphQL; the two budgets drain independently, so `graphql: 0/5000` with `core: 4700/5000` leaves the whole `gh pr *` surface dead while REST is untouched. The REST endpoint takes the same arguments:
+
+```bash
+gh api repos/$OWNER/$REPO/pulls -X POST \
+  -f title="…" -f head="<branch>" -f base=main -F body=@body.md --jq '.html_url'
+```
+
+`gh api repos/$OWNER/$REPO/issues/$PR/comments -X POST -F body=@file` posts a PR comment the same way. Both worked on 2026-08-13 while `gh pr create` returned `GraphQL: API rate limit already exceeded`.
+
+One flag trap while you are there: `gh api --paginate --slurp` is **rejected** together with `--jq` (`the --slurp option is not supported with --jq or --template`). Write the paginated JSON to a file first, then run `jq` over it.
+
 ### `gh api` writes its error to stdout — test a field, never emptiness
 
 On a 404 (or any error) `gh api` prints a JSON error object to **stdout** and exits non-zero. A watcher that decides on "did I get output?" reads the error as the answer:


### PR DESCRIPTION
Two additions to `merge-gate-watcher.md`, both from burning the GraphQL budget twice in one session while doing nothing unusual.

## "Has it merged yet?" needs no API at all

The existing "Watcher cost" section makes a watcher cheaper — one per subject, REST over GraphQL, 180 s. It does not say that the commonest watcher question is free: once a PR is queued, the only thing left to learn is whether its head landed on the base, and `git merge-base --is-ancestor` answers that from the local graph. It keeps working while both budgets are exhausted, which is exactly when a watcher is still running.

Added with the trap that bit me: **`git log --grep="#<pr>"` is not that test.** `--grep` searches the whole commit message, so an older commit whose body mentions the number matches. A watcher on PR #765 reported `MERGED` from its first tick because a months-old dependency bump mentioned that number; the PR was actually `CONFLICTING`. Same asymmetry as the section's own empty-result rule, inverted — an empty result is first a broken query, and a positive result from a text search is first a coincidence.

## REST still opens a PR when GraphQL is dead

`gh pr create` is GraphQL. With `graphql: 0/5000` and `core: 4700/5000` the whole `gh pr *` surface is unusable while REST is fine, and `gh api repos/$O/$R/pulls -X POST` takes the same arguments. Same for PR comments. Both used on 2026-08-13 to finish work that `gh pr create` refused.

Plus one flag trap found next to it: `gh api --paginate --slurp` is rejected together with `--jq`, so paginated check-runs need a file and then `jq`.

## Not added

The section already says to sleep to the reset in one background command rather than retrying into the limit. I violated that rule rather than found it missing, so it needs no more prose.
