### PR TITLE
docs(git-workflow): name a path pr-status.sh can be invoked by

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -12,10 +12,18 @@ BLOCKED` never says *why*, and the reason lives in five different places:
 checks, rulesets, review threads, whether a review exists on the *current*
 head, and the repository's allowed merge methods.
 
+The script is not on `PATH`, and you run it from the repository under
+inspection, so a relative `./scripts/…` misses. Bind the skill directory once,
+then call it by that path:
+
 ```bash
-./scripts/pr-status.sh -R owner/repo 123        # human summary + NEXT action
-./scripts/pr-status.sh -R owner/repo 123 --json # for scripts and merge drivers
-./scripts/pr-status.sh -R owner/repo 123 --watch
+GW=$(ls -d ~/.claude/skills/git-workflow \
+        ~/.claude/plugins/cache/*/git-workflow/*/skills/git-workflow \
+        2>/dev/null | tail -1)
+
+bash "$GW/scripts/pr-status.sh" -R owner/repo 123        # human summary + NEXT action
+bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --json # for scripts and merge drivers
+bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --watch
 ```
 
 Two API calls, and the output ends in a computed `NEXT:` — rebase, fix-ci,

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -17,9 +17,11 @@ inspection, so a relative `./scripts/…` misses. Bind the skill directory once,
 then call it by that path:
 
 ```bash
+# sort -V, not plain sort: 1.10.0 must beat 1.9.0. A directly installed
+# skill sorts after the cache paths and so wins when both exist.
 GW=$(ls -d ~/.claude/skills/git-workflow \
         ~/.claude/plugins/cache/*/git-workflow/*/skills/git-workflow \
-        2>/dev/null | tail -1)
+        2>/dev/null | sort -V | tail -1)
 
 bash "$GW/scripts/pr-status.sh" -R owner/repo 123        # human summary + NEXT action
 bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --json # for scripts and merge drivers


### PR DESCRIPTION
`references/pull-request-workflow.md` shows `./scripts/pr-status.sh`. That path resolves only when the working directory is this skill's own directory — which it never is, because the script is run against a repository, from that repository. The scripts are not on `PATH` either, so the bare name fails too.

Observed today: a hook message advises `pr-status.sh -R <owner/repo> <pr>`, I ran exactly that, got `command not found`, then had to `find` the real path and ended up hardcoding `~/.claude/plugins/cache/netresearch-claude-code-marketplace/git-workflow/1.23.0/…` for the rest of the session — which breaks on the next release.

This binds the skill directory once and calls the script by it:

```bash
GW=$(ls -d ~/.claude/skills/git-workflow \
        ~/.claude/plugins/cache/*/git-workflow/*/skills/git-workflow \
        2>/dev/null | sort -V | tail -1)

bash "$GW/scripts/pr-status.sh" -R owner/repo 123
```

Verified against a cache holding 1.21.0, 1.22.0 and 1.23.0: the glob selects 1.23.0 and `--help` answers. `sort -V` rather than plain ordering because `tail -1` alone takes the lexicographically last path, which picks 1.9.0 over 1.10.0 — checked against a synthetic cache holding both. A directly installed skill sorts after the cache paths, so it wins when both exist.

## What this deliberately leaves alone

`SKILL.md:78` carries the same `./scripts/…` form for all three scripts. I did not fix it there: it is at 497 words against the validator's 500-word ceiling, so any addition trips `validate-skill` — my first attempt did, at 542 and then 520. Correcting it needs a trade against existing content, and which sentence pays is your call, not mine.

## An alternative that would be better than this

Neither `CLAUDE_SKILL_DIR` nor `CLAUDE_PLUGIN_ROOT` is exported into the shell the Bash tool runs — I checked both, unset. If the harness can be made to export one, or the skill can ship a `PATH` shim, that beats a glob in the docs and would fit inside SKILL.md's budget as a single short path.
