### PR TITLE
feat(pr-status): make the --json contract discoverable and enforced

### DIFF
--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -24,6 +24,35 @@
 # soon as something can be worked on: a failing check, a new annotation, or all
 # required checks concluded. Waiting for `pending == 0` means learning nothing
 # until the slowest matrix job ends, long after the first failure was visible.
+#
+# --json contract
+#
+# One object, and its field names are THIS SCRIPT'S — not the GraphQL names
+# `gh pr view` uses. `mergeState`, not `mergeStateStatus`. `base`, not
+# `baseRefName`. Guessing costs more than reading: jq answers a missing key
+# with `null` and says nothing, so a loop waiting for
+# `.mergeStateStatus == "CLEAN"` never fires and reads as "still running"
+# forever. Top-level keys:
+#
+#   state mergeable mergeState draft number title repo author
+#   base head headOid
+#   checks checks_settled threads unresolved_threads
+#   reviewDecision reviews_on_head has_review_on_head
+#   has_copilot_review_on_head copilot_review_errored copilot_error_count
+#   requested_reviewers
+#   merge_methods auto_merge_allowed queue_active queue_entry
+#   rulesets rules_fetched required_contexts undispatched unsigned
+#   next
+#
+# `checks` is {total,pass,fail,pending,skip,...} and `next` is
+# {action,why,cmd} — the same two things the prose rendering leads with.
+#
+# Before writing a jq filter against any of these, consider whether --watch
+# already answers the question; it usually does, and a hand-rolled poll loop is
+# how the wrong field name gets guessed in the first place.
+#
+# tests/test_pr_status_json_contract.sh fails when this list and the emitted
+# object drift apart, in either direction.
 set -uo pipefail
 
 REPO=""; PR=""; JSON=0; WATCH=0; INTERVAL=20; MAXWAIT=3600
@@ -39,7 +68,10 @@ while [ $# -gt 0 ]; do
     --watch)    WATCH=1; shift ;;
     --interval) need "$@"; INTERVAL="$2"; shift 2 ;;
     --max-wait) need "$@"; MAXWAIT="$2"; shift 2 ;;
-    -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    # Prints the whole leading comment block rather than a fixed line range:
+    # a hard-coded range silently truncates --help the moment the header
+    # grows, which is how a documented contract stops being visible.
+    -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  PR="$1"; shift ;;
   esac

--- a/tests/test_pr_status_json_contract.sh
+++ b/tests/test_pr_status_json_contract.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Regression test: the --json key list in pr-status.sh's header must match what
+# --json actually emits.
+#
+# Why this is a test and not a comment: a caller who guesses a field name gets
+# `null` from jq and no warning, so a watcher polling `.mergeStateStatus`
+# (the GraphQL name, not this script's) never fires and reads as "still
+# running" forever. The header exists to stop that guess — which only works
+# while it is true, and a documented contract that nobody checks rots at the
+# first new field.
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+
+# --- stub `gh`: one rules payload, one GraphQL payload -----------------------
+
+printf '%s\n' '[{"type":"copilot_code_review","parameters":{}}]' > "$STUB_DIR/rules.json"
+
+cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+chmod +x "$STUB_DIR/gh"
+
+python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json
+head = "deadbeefcafe"
+json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "reviewDecision": None,
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": []},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS", "contexts": {"nodes": [
+                {"__typename": "CheckRun", "name": "CI", "conclusion": "SUCCESS",
+                 "status": "COMPLETED", "detailsUrl": "u",
+                 "startedAt": "2026-01-01T00:00:00Z"}]}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(sys.argv[1], "w"))
+PY
+
+# --- the two lists -----------------------------------------------------------
+
+emitted="$(PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json | jq -r 'keys[]' | sort)"
+
+# The documented block: the indented run of key names between the "--json
+# contract" heading and the first line that is not part of it. Matching on
+# indentation rather than on a marker keeps the header readable as prose.
+documented="$(
+  awk '
+    /^# --json contract$/ { inblock = 1; next }
+    !inblock { next }
+    /^#   [a-z]/ { sub(/^#   /, ""); print; next }
+    /^# `checks` is/ { exit }
+  ' "$SCRIPT" | tr " " "\n" | sed "/^$/d" | sort
+)"
+
+# --- compare both directions -------------------------------------------------
+
+if [ -z "$emitted" ]; then
+    echo "  FAIL the stubbed run emitted no JSON keys at all"
+    exit 1
+fi
+if [ -z "$documented" ]; then
+    echo "  FAIL no key list found under the '--json contract' header"
+    exit 1
+fi
+
+undocumented="$(comm -23 <(printf '%s\n' "$emitted") <(printf '%s\n' "$documented"))"
+stale="$(comm -13 <(printf '%s\n' "$emitted") <(printf '%s\n' "$documented"))"
+
+if [ -n "$undocumented" ]; then
+    echo "  FAIL --json emits keys the header does not list:"
+    printf '         %s\n' "$undocumented"
+    echo "       Add them to the '--json contract' block in pr-status.sh."
+    fail=1
+else
+    echo "  ok   every emitted key is documented"
+fi
+
+if [ -n "$stale" ]; then
+    echo "  FAIL the header lists keys --json does not emit:"
+    printf '         %s\n' "$stale"
+    echo "       Remove them from the '--json contract' block in pr-status.sh."
+    fail=1
+else
+    echo "  ok   every documented key is emitted"
+fi
+
+# --help must show the block; a fixed line range used to truncate it.
+if bash "$SCRIPT" --help | grep -q '^--json contract$'; then
+    echo "  ok   --help shows the contract"
+else
+    echo "  FAIL --help does not show the '--json contract' block"
+    fail=1
+fi
+
+exit $fail


### PR DESCRIPTION
`pr-status.sh --json` did not describe itself, so a caller writing a jq filter against it had to guess — and a wrong guess is silent. jq answers a missing key with `null` and says nothing, so a loop waiting for `.mergeStateStatus == "CLEAN"` (the GraphQL name `gh pr view` uses, not this script's `mergeState`) never fires and reads as "still running" forever.

That is not hypothetical: it happened to me on 2026-08-13 while watching two PRs of this repo. The loop ran to its iteration limit reporting `null` every tick, on PRs that had been `CLEAN` for ten minutes.

## What this adds

**A `--json contract` block in the header**, which is what `-h/--help` prints — the place I should have looked. It lists every top-level key, names the two traps (the field names are this script's, not GraphQL's; a wrong key is silent), and points at `--watch` first, because in my case the whole loop was a hand-rolled substitute for a flag that already exists.

**`--help` no longer truncates.** It printed a hard-coded line range, so the header could grow past it and the new block would have been invisible — the exact failure the block exists to prevent. It now prints the leading comment block, however long it gets.

**`tests/test_pr_status_json_contract.sh`** compares the documented list against what a stubbed run actually emits, in both directions, and asserts `--help` still shows it. A contract nobody checks rots at the first new field; `checks_settled` was added recently and would have been the first to go missing.

## Verification

Controlled failure in all three directions, not just a green run:

| injected fault | result |
|---|---|
| header lists `bogusField` | `FAIL … header lists keys --json does not emit: bogusField` |
| header drops `checks_settled` | `FAIL … --json emits keys the header does not list: checks_settled` |
| `--help` back to a fixed line range | `FAIL --help does not show the '--json contract' block` |

Restored: all three ok. Full suite: 8/8 shell tests pass, including `test_pr_status_errored_review.sh`, which drives the same script.

No behaviour change to `--json`, `--watch` or the prose rendering.
