### PR TITLE
fix(hooks): recommend pr-status.sh by its resolved absolute path

### DIFF
--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -198,6 +198,21 @@ def reply_path_without_pr(cmd: str) -> str | None:
     return None
 
 
+# The plugin's scripts are not on PATH: recommending a bare `pr-status.sh`
+# sends the reader into `command not found` (exit 127) and a hunt through the
+# plugin cache before the gate's advice becomes followable (2026-08-13). The
+# script ships in this plugin, so the message can name the invocable path;
+# the bare name stays as fallback for layouts where the sibling is absent.
+_PR_STATUS_SH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "skills",
+    "git-workflow",
+    "scripts",
+    "pr-status.sh",
+)
+PR_STATUS = _PR_STATUS_SH if os.path.isfile(_PR_STATUS_SH) else "pr-status.sh"
+
+
 def handrolled_pr_poll(cmd: str) -> str | None:
     if "--watch" in cmd or not POLLS_PR.search(cmd):
         return None
@@ -205,7 +220,7 @@ def handrolled_pr_poll(cmd: str) -> str | None:
         return None
     return (
         "Hand-rolled poll over pull-request state. Use "
-        "`pr-status.sh -R <owner/repo> <pr> --watch` instead: it returns at the "
+        f"`{PR_STATUS} -R <owner/repo> <pr> --watch` instead: it returns at the "
         "FIRST actionable event — a check that failed, a review that arrived, a "
         "thread that needs an answer — where a loop written here waits for the "
         "one outcome it was told about and sleeps through the rest. A loop that "
@@ -243,7 +258,7 @@ def merge_readiness_without_pr_status(cmd: str) -> str | None:
         if QUERIES_FORGE.match(segment) and MERGE_READINESS_FIELD.search(segment):
             return (
                 "Merge readiness asked of gh directly. Use "
-                "`pr-status.sh -R <owner/repo> <pr>` instead: it reports checks, "
+                f"`{PR_STATUS} -R <owner/repo> <pr>` instead: it reports checks, "
                 "reviews, rulesets and unresolved threads together and ends with "
                 "a NEXT: line naming the action. mergeable_state and "
                 "mergeStateStatus answer only 'blocked' and never say why, so an "

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -264,7 +264,7 @@ def merge_readiness_without_pr_status(cmd: str) -> str | None:
                 "mergeStateStatus answer only 'blocked' and never say why, so an "
                 "unresolved thread or a red check stays invisible and the pull "
                 "request looks like it is merely waiting. To find out which "
-                "required context is unmet, run pr-status.sh first, then the "
+                f"required context is unmet, run {PR_STATUS} first, then the "
                 "GraphQL query with `isRequired` — that one is not gated."
             )
     return None

--- a/tests/test_validate_git_command.py
+++ b/tests/test_validate_git_command.py
@@ -137,20 +137,17 @@ def fifo_case() -> bool:
         os.rmdir(tmp)
 
 
-def pr_status_path_case() -> bool:
+def pr_status_path_case(command: str) -> bool:
     """The deny must name an invocable pr-status.sh, not a bare command name.
 
     The plugin's scripts are not on PATH: a bare `pr-status.sh` produced
     `command not found` (exit 127) and a hunt through the plugin cache
     (2026-08-13). The recommendation must carry the absolute path of the
-    script shipped in this plugin, and that path must exist.
+    script shipped in this plugin, and that path must exist. Both gates
+    that recommend the script are exercised, so a later message edit
+    cannot drop the interpolation from one of them unnoticed.
     """
-    payload = json.dumps(
-        {
-            "tool_name": "Bash",
-            "tool_input": {"command": "gh pr view 6651 --json mergeStateStatus"},
-        }
-    )
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
     proc = subprocess.run(
         [sys.executable, HOOK],
         input=payload,
@@ -182,12 +179,22 @@ def main() -> int:
         f"got={'no-hang' if ok else 'HUNG'}"
     )
 
-    ok = pr_status_path_case()
-    fails += 0 if ok else 1
-    print(
-        f"  {'OK  ' if ok else 'FAIL'} {'deny names an existing pr-status.sh path':<44} "
-        f"want=abs-path got={'abs-path' if ok else 'bare-name'}"
-    )
+    for name, command in [
+        (
+            "merge-readiness deny names pr-status.sh path",
+            "gh pr view 6651 --json mergeStateStatus",
+        ),
+        (
+            "poll deny names pr-status.sh path",
+            "until [ x = y ]; do gh pr view 1 --json state; sleep 30; done",
+        ),
+    ]:
+        ok = pr_status_path_case(command)
+        fails += 0 if ok else 1
+        print(
+            f"  {'OK  ' if ok else 'FAIL'} {name:<44} "
+            f"want=abs-path got={'abs-path' if ok else 'bare-name'}"
+        )
 
     print(f"  ---- failures: {fails}")
     return 1 if fails else 0

--- a/tests/test_validate_git_command.py
+++ b/tests/test_validate_git_command.py
@@ -10,6 +10,7 @@ names the failure it stands for.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -136,6 +137,36 @@ def fifo_case() -> bool:
         os.rmdir(tmp)
 
 
+def pr_status_path_case() -> bool:
+    """The deny must name an invocable pr-status.sh, not a bare command name.
+
+    The plugin's scripts are not on PATH: a bare `pr-status.sh` produced
+    `command not found` (exit 127) and a hunt through the plugin cache
+    (2026-08-13). The recommendation must carry the absolute path of the
+    script shipped in this plugin, and that path must exist.
+    """
+    payload = json.dumps(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr view 6651 --json mergeStateStatus"},
+        }
+    )
+    proc = subprocess.run(
+        [sys.executable, HOOK],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    out = proc.stdout.strip()
+    if not out.startswith("{"):
+        return False
+    reason = json.loads(out)["hookSpecificOutput"].get("permissionDecisionReason", "")
+    match = re.search(r"`(/[^`\s]+/pr-status\.sh)", reason)
+    return bool(match and os.path.isfile(match.group(1)))
+
+
 def main() -> int:
     fails = 0
     for name, expected, command in CASES:
@@ -149,6 +180,13 @@ def main() -> int:
     print(
         f"  {'OK  ' if ok else 'FAIL'} {'--body-file on a pipe returns':<44} want=no-hang  "
         f"got={'no-hang' if ok else 'HUNG'}"
+    )
+
+    ok = pr_status_path_case()
+    fails += 0 if ok else 1
+    print(
+        f"  {'OK  ' if ok else 'FAIL'} {'deny names an existing pr-status.sh path':<44} "
+        f"want=abs-path got={'abs-path' if ok else 'bare-name'}"
     )
 
     print(f"  ---- failures: {fails}")


### PR DESCRIPTION
Both gate messages in [`scripts/validate_git_command.py`](https://github.com/netresearch/git-workflow-skill/blob/main/scripts/validate_git_command.py) (hand-rolled PR poll, merge-readiness query) recommend a bare `pr-status.sh`, but the plugin's scripts are not on PATH — following the advice verbatim yields `command not found` (exit 127) and a search through the plugin cache before the gate's advice becomes followable (hit 2026-08-13). The hook now resolves the sibling script (`skills/git-workflow/scripts/pr-status.sh`) relative to its own location and names the invocable absolute path in both messages, falling back to the bare name where the sibling is absent. The layout is identical in the repo and in the installed plugin cache, so the path resolves in both.

Tests: new case asserts the deny message names an existing absolute `pr-status.sh` path — verified red on the old code (bare name), green after the fix; both existing suites (`tests/` and `scripts/`) pass.