### PR TITLE
docs(references): API-quota discipline, gh error-body capture trap, reset-rebuild verification

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -2,6 +2,26 @@
 
 ## Rewriting History
 
+### After ANY reset-based rebuild: the commit takes the INDEX, not the worktree
+
+`git reset --soft <base>` + `git commit` is the standard way to collapse a
+branch into one clean commit — and it commits whatever is **staged**, which
+is the old tree, not the files as they lie on disk. Edits made after the last
+`git add` (every editor/tool write) silently stay out, the commit "succeeds",
+and only CI notices that the pushed tree is the stale one (2026-08-13: a
+history rewrite meant to purge two files shipped without the accompanying
+test/docs edits; the red CI on removed-file assertions was the first signal).
+
+After the rebuild, before pushing:
+
+```bash
+git status --porcelain          # anything listed = NOT in the commit you just made
+git grep -l <purged-artifact> HEAD   # verify against the COMMIT, not the worktree
+```
+
+Run the second command bare — behind a pipe (`| head`) `$?` is the pipe
+tail's, and a "found it" exit code reads as clean.
+
 ### Interactive Rebase
 
 ```bash

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -17,6 +17,29 @@ Gate on the **exit code**, not on parsed output. `gh pr checks` and
 `gh run watch` already handle pending-state representation, the appearance of
 newly-triggered runs, and refresh.
 
+### `$(gh api … || echo "")` captures the ERROR BODY as data
+
+On an HTTP error (404, 403 rate limit, 5xx) `gh api` prints the JSON error
+body to **stdout** and does not apply `--jq` to it — so the classic fallback
+capture poisons the variable instead of emptying it:
+
+```bash
+# Wrong: on a 404, $rel holds '{"message":"Not Found",…}' — non-empty,
+# and every [[ -n "$rel" ]] downstream believes it is real data
+rel=$(gh api "repos/$R/releases/latest" --jq .tag_name 2>/dev/null || echo "")
+
+# Right: output reaches the variable only when the call SUCCEEDED
+if out=$(gh api "repos/$R/releases/latest" 2>/dev/null); then
+  rel=$(jq -r '.tag_name // empty' <<<"$out")
+else
+  rel=""
+fi
+```
+
+Verified with gh 2.97 (2026-08-13): a fleet survey using the wrong form
+classified never-released repos from their own error bodies. The same trap
+applies to `glab api` — gate on the exit code, never on non-empty stdout.
+
 ### `gh run watch` takes the RUN id — a check-run's `details_url` ends in the JOB id
 
 Reaching for `gh run watch` from a check-run means extracting an id from its

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -185,6 +185,37 @@ web UI: consistent authentication, structured `--json` output, and clearer
 errors. Drop to raw `gh api` only for endpoints the porcelain commands don't
 cover yet.
 
+### The quotas are session-shared pools — act, don't re-preflight
+
+Every `gh` call in a session draws from a shared pool — REST 5,000/h and
+GraphQL 5,000 points/h are SEPARATE pools, each shared across watchers,
+agents and scripts, plus short burst limits on top. A heavy session (fleet
+survey, repeated preflight batteries, parallel reviewers) usually kills the
+**GraphQL pool first** — and `gh pr merge`, `gh pr view --json`, and
+`pr-status.sh` are GraphQL-backed, so exactly the merge you verified
+everything for stops working (observed 2026-08-13, between "all gates green"
+and the merge).
+
+Two practices keep this from biting:
+
+- **When the full gate was verified on head X and nothing was pushed since,
+  the action is ONE call — not another preflight battery.** The REST merge
+  endpoint takes a `sha` pin whose 409 on mismatch IS the freshness check:
+
+  ```bash
+  gh api -X PUT "repos/$R/pulls/$PR/merge" \
+    -f merge_method=merge -f "sha=$(git rev-parse HEAD)"
+  ```
+
+  Take the SHA from local git, never by retyping a short SHA into a long one
+  — the pin rejects a fabricated tail exactly as it rejects a moved head.
+- **GraphQL dead ≠ blocked.** The REST twins keep answering: merge (above),
+  branch delete (`gh api -X DELETE repos/$R/git/refs/heads/<branch>`; a 422
+  means auto-delete beat you to it), reviews and comments lists. `gh api
+  rate_limit` is exempt and tells you both pools' reset times. Prefer one
+  `--watch` over repeated status reads, and stop any watcher whose answer
+  you already have.
+
 ## Describing the Change (PR Body, Commit Message, Issue)
 
 The rest of this file is about getting a change *merged*. This section is about


### PR DESCRIPTION
Retro findings from the 2026-08-13 fleet-release-driver session (skill-repo-skill [#218](https://github.com/netresearch/skill-repo-skill/issues/218)/[#219](https://github.com/netresearch/skill-repo-skill/pull/219)), each observed live before being written down:

- **pull-request-workflow — the quota is one shared pool; act, don't re-preflight.** A heavy session killed the GraphQL secondary quota between "all gates verified" and the merge, taking `gh pr merge` and pr-status.sh with it while REST still answered. New subsection: one SHA-pinned REST merge on a verified unchanged head (`-f sha=$(git rev-parse HEAD)` — the 409 IS the freshness check, and it caught a hand-retyped SHA live), REST twins for branch delete, `gh api rate_limit` is exempt, stop known-answer watchers.
- **ci-cd-integration — `$(gh api … || echo "")` captures the ERROR BODY as data.** gh 2.97 prints HTTP error JSON to stdout without applying `--jq`; a fleet survey using the fallback-capture form classified never-released repos from their own 404 bodies. New subsection with the exit-code-gated capture pattern; applies to `glab api` too.
- **advanced-git — a reset-based rebuild commits the INDEX, not the worktree.** Editor writes after the last `git add` silently stay out of the collapsed commit; red CI was the first signal. New subsection: `git status --porcelain` + `git grep <artifact> HEAD` (bare, no pipe) before pushing a rewritten branch.