### PR TITLE
fix(pr-status): say the Copilot quota wall once, clearly, without retries

### DIFF
--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -38,7 +38,7 @@
 #   base head headOid
 #   checks checks_settled threads unresolved_threads
 #   reviewDecision reviews_on_head has_review_on_head
-#   has_copilot_review_on_head copilot_review_errored copilot_error_count
+#   has_copilot_review_on_head copilot_review_errored copilot_error_count copilot_quota_hit
 #   requested_reviewers
 #   merge_methods auto_merge_allowed queue_active queue_entry
 #   rulesets rules_fetched required_contexts undispatched unsigned
@@ -308,6 +308,10 @@ evaluate() {
         # $copilot_errored for why the check-run is not consulted.
         copilot_review_errored: $copilot_review_errored,
         copilot_error_count: ($copilot_errored|length),
+        # True when an errored Copilot review body names the quota limit.
+        # Quota is MONTHLY: once this is true, no re-request on any PR will
+        # succeed until the monthly reset — distinct from a transient outage.
+        copilot_quota_hit: (([$copilot_errored[] | select((.body // "") | test("quota"; "i"))] | length) > 0),
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
@@ -422,7 +426,20 @@ evaluate() {
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           (if $copilot_exhausted then
+           (if $s.copilot_quota_hit then
+             # Quota, not outage: the error body names the quota limit. Said
+             # once, with the fact that makes retrying pointless — the quota
+             # is monthly and will NOT recover this month, on this or any
+             # other PR. No cmd on purpose: there is nothing to run.
+             {action:"request-review",
+              why:($unreviewed
+                   + "Copilot is OUT OF REVIEW QUOTA — the error body says the requesting"
+                   + " user reached the quota limit. The quota is MONTHLY: it will not"
+                   + " recover this month, on this or any other PR, and re-requesting"
+                   + " cannot change that. Review the diff yourself, note in the PR that"
+                   + " the bot review was unavailable, and decide on that. Treat this"
+                   + " notice as covering every PR until the monthly reset\($stale_approval)")}
+            elif $copilot_exhausted then
              {action:"request-review",
               why:($unreviewed
                    + "Copilot failed \($s.copilot_error_count)x on \($s.headOid[0:8]), so the COMMENTED rows"
@@ -631,7 +648,13 @@ while :; do
       # re-arm of --watch returns instantly with the same line. Saying so is
       # what stops an operator re-arming it three times before switching to
       # `gh pr checks --watch`, which watches something that does move.
-      if [ "$(jq -r '.copilot_error_count // 0' <<<"$s")" -ge 2 ]; then
+      if [ "$(jq -r '.copilot_quota_hit // false' <<<"$s")" = "true" ]; then
+        echo "ACTIONABLE: request-review (UNSATISFIABLE — Copilot is OUT OF REVIEW QUOTA" \
+             "for the month; this will NOT change until the monthly reset, on this or any" \
+             "other PR. Do not re-arm this watch and do not re-request — review the diff" \
+             "yourself and decide. To watch something that moves:" \
+             "gh pr checks $(jq -r '.number' <<<"$s") --repo $(jq -r '.repo' <<<"$s") --watch)"
+      elif [ "$(jq -r '.copilot_error_count // 0' <<<"$s")" -ge 2 ]; then
         echo "ACTIONABLE: request-review (UNSATISFIABLE — the review bot has failed" \
              "$(jq -r '.copilot_error_count' <<<"$s")x on this head; re-arming this watch" \
              "returns immediately. Review the diff yourself, or watch the checks instead:" \

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -223,6 +223,30 @@ case "$(run_flag 'next.cmd')" in
         fail=1 ;;
 esac
 
+# Quota is not an outage: the error body names the quota limit, the quota is
+# monthly, and no re-request on any PR will succeed until the reset. The retry
+# command must be withheld even on the FIRST failure, and the advice must say
+# the state will not change this month — this is the message an operator sees
+# exactly once instead of rediscovering the wall per PR.
+echo "case 7c: quota error — no retry cmd even on the FIRST failure, monthly advice"
+make_stub "$ERR_QUOTA"
+check "copilot_quota_hit"   "true"           "$(run_flag copilot_quota_hit)"
+check "copilot_error_count" "1"              "$(run_flag copilot_error_count)"
+check "next.action"         "request-review" "$(run_next)"
+check "next.cmd absent"     "null"           "$(run_flag 'next.cmd')"
+if status | jq -e '.next.why | test("MONTHLY")' >/dev/null; then
+    echo "  ok   why states the quota is monthly and will not recover"
+else
+    echo "  FAIL why lacks the monthly-quota advice"
+    fail=1
+fi
+
+# The quota detector must be able to stay quiet: a generic outage row must not
+# trip it, or every outage would be misreported as a month-long dead end.
+echo "case 7d: generic outage only — quota flag stays false"
+make_stub "$ERR_GENERIC"
+check "copilot_quota_hit" "false" "$(run_flag copilot_quota_hit)"
+
 # Regression for a dead end that shipped once: an earlier version escalated to a
 # distinct "review-yourself" action guarded on has_review_on_head. A review by
 # the PR author is excluded from that gate by design, and the operator driving


### PR DESCRIPTION
## Summary

The Copilot review quota is **monthly**: once the error body reads "reached their quota limit", no re-request on any PR succeeds until the monthly reset. `pr-status.sh` treated every failed review as a maybe-outage — advising one re-request per PR and letting `--watch` be re-armed — so the operator rediscovered the same wall on every pull request of the month (today: four PRs, each with its own re-request round and narration).

Changes:

- New `--json` field `copilot_quota_hit`, derived from the errored review body (`test("quota"; "i")`; the live error text is "Copilot was unable to review this pull request because the user who requested the review has reached their quota limit").
- Decision ladder: on a quota error the advice is issued **once** and states plainly that the condition will not change this month, on this or any other PR; the retry command is withheld even on the first failure. Generic outage behaviour (one re-request, then self-review) is unchanged.
- `--watch`: the quota condition returns immediately with the same will-not-change-this-month notice instead of the generic failed-2x line.
- Tests: case 7c (quota on first failure → no cmd, MONTHLY advice present) and case 7d (a generic outage row must NOT trip the quota flag — the detector can stay quiet).

Verified against the live quota-failed PR [netresearch/typo3-docs-skill#76](https://github.com/netresearch/typo3-docs-skill/pull/76) in both one-shot and `--watch` mode; full `test_pr_status_errored_review.sh` and `test_pr_status_json_contract.sh` suites pass; `bash -n` and shellcheck clean.

## Test plan

- `bash tests/test_pr_status_errored_review.sh` — all pass (incl. new 7c/7d)
- `bash tests/test_pr_status_json_contract.sh` — all pass (new key documented)
- Live run against a quota-failed PR: NEXT carries the monthly notice, no cmd; `--watch` returns once with the unsatisfiable notice
