### PR TITLE
chore(release): v1.24.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.24.0"
+  version: "1.24.1"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Patch release: pr-status.sh hook recommendations use the resolved absolute path and cover both gates (#182), API-quota discipline and gh error-body capture documented (#183), Copilot quota wall reported once without retries (#184).