### PR TITLE
fix(pr-status): carry the Copilot quota wall across PRs

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -138,6 +138,20 @@ yourself**: an outage may clear, but a quota ceiling does not clear by asking
 again, and the alternatives — merging unreviewed or waiting indefinitely on
 third-party infrastructure — are both worse than a self-review that says so.
 
+A body naming the **quota** is not an outage, so it costs no second strike:
+`pr-status.sh` withholds the retry command on the first failure and remembers
+the wall in
+`${XDG_CACHE_HOME:-~/.cache}/pr-status/copilot-quota-exhausted-YYYY-MM`. The
+quota is account-wide and monthly while the evidence is per PR — a pull request
+nobody ever requested a review on carries none at all — so without that file
+the next PR in the next repo is handed a `requested_reviewers` POST the same
+exhausted quota rejects (`netresearch/maint` #52 and #53, hours after the wall
+was proven elsewhere). Later runs read the marker, report
+`copilot_quota_exhausted: true` and answer with the self-review guidance and no
+command. The month is in the **filename**, so the marker stops applying at the
+reset rather than being aged out; delete the file to undo a verdict recorded in
+error.
+
 ## Check the Default Branch Before Operating
 
 Not every repo uses `main` — older repos often use `master`, and some use

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -25,6 +25,17 @@
 # required checks concluded. Waiting for `pending == 0` means learning nothing
 # until the slowest matrix job ends, long after the first failure was visible.
 #
+# Copilot review quota
+#
+# The quota is per ACCOUNT and per MONTH, but the only evidence a single pull
+# request carries is an errored review body on its own head — a PR nobody ever
+# requested a review on carries none at all, and used to be answered with a
+# re-request command the exhausted quota rejects. So the wall proven on one PR
+# is written to ${XDG_CACHE_HOME:-~/.cache}/pr-status/, one file per calendar
+# month, and every later invocation reads it before offering that command.
+# The month lives in the FILENAME, so a marker from an earlier month is ignored
+# rather than carried over the reset; delete the file to undo the effect.
+#
 # --json contract
 #
 # One object, and its field names are THIS SCRIPT'S — not the GraphQL names
@@ -39,6 +50,7 @@
 #   checks checks_settled threads unresolved_threads
 #   reviewDecision reviews_on_head has_review_on_head
 #   has_copilot_review_on_head copilot_review_errored copilot_error_count copilot_quota_hit
+#   copilot_quota_exhausted
 #   requested_reviewers
 #   merge_methods auto_merge_allowed queue_active queue_entry
 #   rulesets rules_fetched required_contexts undispatched unsigned
@@ -90,6 +102,30 @@ if [ -z "$PR" ]; then
 fi
 OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
 
+# --------------------------------------------------------- quota marker -----
+# The Copilot review quota is account-wide and monthly; the evidence for it is
+# not. It arrives as an error body on ONE pull request, and every other PR of
+# that account looks untouched — so the ladder below kept offering a
+# re-request command that the same exhausted quota would reject (observed on
+# netresearch/maint#52 and #53, hours after the wall was proven on another
+# repo). One file per calendar month carries the fact across invocations.
+QUOTA_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/pr-status"
+# The month is in the NAME, not in the mtime: any later write would refresh an
+# mtime and make a marker outlive the reset it describes.
+QUOTA_MARKER="$QUOTA_DIR/copilot-quota-exhausted-$(date -u +%Y-%m)"
+
+quota_marker_seen() { if [ -f "$QUOTA_MARKER" ]; then echo true; else echo false; fi; }
+
+# Best-effort by design: the marker only saves a wasted re-request, so a
+# read-only or full cache directory must never turn a status query into a
+# failure. Content is for the human who wonders where the verdict came from.
+remember_quota_hit() {
+  [ -f "$QUOTA_MARKER" ] && return 0
+  mkdir -p "$QUOTA_DIR" 2>/dev/null || return 0
+  printf 'copilot review quota exhausted; proven on %s#%s at %s\n' \
+    "$REPO" "$PR" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$QUOTA_MARKER" 2>/dev/null || return 0
+}
+
 # ---------------------------------------------------------------- data ------
 collect() {
   # shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
@@ -132,8 +168,9 @@ collect() {
 # would discard the status flag.
 
 evaluate() {
-  local gql="$1" rules="$2" ok="$3"
-  jq -n --argjson g "$gql" --argjson r "$rules" --argjson ok "$ok" '
+  local gql="$1" rules="$2" ok="$3" marker="$4"
+  jq -n --argjson g "$gql" --argjson r "$rules" --argjson ok "$ok" \
+        --argjson marker "$marker" --arg marker_path "$QUOTA_MARKER" '
     # Defined once and used by BOTH the error list and the $head_reviews filter.
     # Two hand-kept copies would have to stay byte-identical: loosening one to
     # match a third error body and not the other puts the row back into
@@ -196,6 +233,11 @@ evaluate() {
     # API call.
     | ([$reviews_raw[] | select(is_errored_copilot_review)]) as $copilot_errored
     | (($copilot_errored | length) > 0) as $copilot_review_errored
+    # Bound rather than written twice: copilot_quota_hit reports the evidence
+    # found HERE, copilot_quota_exhausted folds in the marker, and a second
+    # copy of the test would let the two drift into disagreeing about the same
+    # review body.
+    | (([$copilot_errored[] | select((.body // "") | test("quota"; "i"))] | length) > 0) as $quota_hit
     # Drop the errored rows from $head_reviews itself, not just from the Copilot
     # view: has_review_on_head feeds the generic "no review on the current head"
     # gate, so filtering only the Copilot list would leave every repo WITHOUT
@@ -308,10 +350,14 @@ evaluate() {
         # $copilot_errored for why the check-run is not consulted.
         copilot_review_errored: $copilot_review_errored,
         copilot_error_count: ($copilot_errored|length),
-        # True when an errored Copilot review body names the quota limit.
-        # Quota is MONTHLY: once this is true, no re-request on any PR will
-        # succeed until the monthly reset — distinct from a transient outage.
-        copilot_quota_hit: (([$copilot_errored[] | select((.body // "") | test("quota"; "i"))] | length) > 0),
+        # True when an errored Copilot review body ON THIS PR names the quota
+        # limit — the evidence, not the verdict.
+        copilot_quota_hit: $quota_hit,
+        # The verdict, and what the NEXT ladder reads: the quota is MONTHLY and
+        # account-wide, so it is equally exhausted on a PR that carries no
+        # evidence of its own. True when this PR proves it, or when an earlier
+        # invocation this calendar month wrote the marker.
+        copilot_quota_exhausted: ($quota_hit or $marker),
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
@@ -367,6 +413,21 @@ evaluate() {
     # assert this when a review does exist on the head.
     | "no review on the current head (\($s.headOid[0:8])) — do not merge unreviewed" as $no_review
     | (if ($s.has_review_on_head | not) then "\($no_review). " else "" end) as $unreviewed
+    # One quota sentence for every branch that would otherwise hand back a
+    # re-request command. Where the evidence came from is stated rather than
+    # assumed: on a PR that carries no Copilot row at all, saying the error
+    # body names the limit would describe a review that is not there — and the
+    # operator could not tell a fresh reading from a remembered one, nor find
+    # the file to undo it.
+    | (if $s.copilot_quota_hit
+       then "the error body on this pull request says the requesting user reached the quota limit"
+       else "an earlier run recorded the wall this month in \($marker_path) — delete that file if it was recorded in error"
+       end) as $quota_evidence
+    | ("Copilot is OUT OF REVIEW QUOTA — \($quota_evidence). The quota is MONTHLY and"
+       + " account-wide: it will not recover this month, on this or any other PR, and"
+       + " re-requesting cannot change that. Review the diff yourself, note in the PR that"
+       + " the bot review was unavailable, and decide on that. Treat this notice as covering"
+       + " every PR until the monthly reset") as $quota_why
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -458,19 +519,14 @@ evaluate() {
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
-           (if $s.copilot_quota_hit then
-             # Quota, not outage: the error body names the quota limit. Said
-             # once, with the fact that makes retrying pointless — the quota
-             # is monthly and will NOT recover this month, on this or any
-             # other PR. No cmd on purpose: there is nothing to run.
+           (if $s.copilot_quota_exhausted then
+             # Quota, not outage: the quota limit is named — by this PR or by
+             # the marker an earlier run left. Said once, with the fact that
+             # makes retrying pointless: the quota is monthly and will NOT
+             # recover this month, on this or any other PR. No cmd on purpose,
+             # there is nothing to run.
              {action:"request-review",
-              why:($unreviewed
-                   + "Copilot is OUT OF REVIEW QUOTA — the error body says the requesting"
-                   + " user reached the quota limit. The quota is MONTHLY: it will not"
-                   + " recover this month, on this or any other PR, and re-requesting"
-                   + " cannot change that. Review the diff yourself, note in the PR that"
-                   + " the bot review was unavailable, and decide on that. Treat this"
-                   + " notice as covering every PR until the monthly reset\($stale_approval)")}
+              why:($unreviewed + $quota_why + $stale_approval)}
             elif $copilot_exhausted then
              {action:"request-review",
               why:($unreviewed
@@ -500,9 +556,20 @@ evaluate() {
            # caller that acts on it enqueues a pull request whose CI has not
            # started. Says it, rather than reordering the ladder — the review
            # really is the blocking gate here.
-           {action:"request-review", why:("copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — the rule itself does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate"
-                 + (if $s.checks_settled then "" else " (CI is NOT settled yet: \($s.checks.pending) pending, \($s.undispatched|length) required context(s) not reported — do not enqueue on this reading)" end)),
-            cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+           #
+           # This is the branch a PR reaches when Copilot was never asked here
+           # at all, so it carries no error row and $copilot_review_errored is
+           # false. Until the marker existed, that was every PR in every OTHER
+           # repo once the account hit the wall, and each of them was handed a
+           # POST command the quota had already made impossible.
+           (if $s.copilot_quota_exhausted then
+              {action:"request-review",
+               why:($unreviewed + $quota_why + $stale_approval)}
+            else
+              {action:"request-review", why:("copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — the rule itself does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate"
+                    + (if $s.checks_settled then "" else " (CI is NOT settled yet: \($s.checks.pending) pending, \($s.undispatched|length) required context(s) not reported — do not enqueue on this reading)" end)),
+               cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
+            end)
          elif ($s.has_review_on_head|not) then
            # The generic gate is also reached by repos WITHOUT the
            # copilot_code_review ruleset, and its cmd re-requests Copilot. Once
@@ -515,7 +582,13 @@ evaluate() {
            # prints mergeState=CLEAN and decision=APPROVED directly above this
            # line, so dropping "do not merge unreviewed" reads as license to
            # merge on a review that sits on an older commit.
-           (if $copilot_exhausted then
+           (if $s.copilot_quota_exhausted then
+               # Reached without any Copilot row of its own whenever the marker
+               # is what proves the wall — the generic gate serves the repos
+               # without the ruleset, and its cmd re-requests the same bot.
+               {action:"request-review",
+                why:($unreviewed + $quota_why + $stale_approval)}
+             elif $copilot_exhausted then
                {action:"request-review",
                 why:("\($no_review). "
                      + "Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"
@@ -645,10 +718,18 @@ snapshot() {
 
   base=$(jq -r '.data.repository.pullRequest.baseRefName // "main"' <<<"$g")
 
-  local enc r ok
+  local enc r ok out
   enc=$(printf '%s' "$base" | jq -sRr @uri)
   if r=$(gh api "repos/$REPO/rules/branches/$enc" 2>/dev/null); then ok=1; else ok=0; r='[]'; fi
-  evaluate "$g" "$r" "$ok"
+  out=$(evaluate "$g" "$r" "$ok" "$(quota_marker_seen)")
+  # Written from the EVIDENCE field, never from the verdict: with
+  # copilot_quota_exhausted the marker would re-assert itself, and the PR named
+  # inside it would be whichever one read the file rather than the one that
+  # proved the wall — the single thing the content is there to answer.
+  if [ "$(jq -r '.copilot_quota_hit // false' <<<"$out")" = "true" ]; then
+    remember_quota_hit
+  fi
+  printf '%s\n' "$out"
 }
 
 emit() {
@@ -681,14 +762,14 @@ while :; do
       # checks settle this returns on the review state (#186). The quota
       # dead-end is exempt — waiting cannot clear it, return immediately.
       if [ "$(jq -r '.checks_settled' <<<"$s")" != "true" ] \
-         && [ "$(jq -r '.copilot_quota_hit // false' <<<"$s")" != "true" ]; then
+         && [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" != "true" ]; then
         :
       # A request-review whose cause is an exhausted review bot is a standing
       # condition, not an event: waiting cannot clear a quota ceiling, so every
       # re-arm of --watch returns instantly with the same line. Saying so is
       # what stops an operator re-arming it three times before switching to
       # `gh pr checks --watch`, which watches something that does move.
-      elif [ "$(jq -r '.copilot_quota_hit // false' <<<"$s")" = "true" ]; then
+      elif [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" = "true" ]; then
         echo "ACTIONABLE: request-review (UNSATISFIABLE — Copilot is OUT OF REVIEW QUOTA" \
              "for the month; this will NOT change until the monthly reset, on this or any" \
              "other PR. Do not re-arm this watch and do not re-request — review the diff" \
@@ -704,7 +785,7 @@ while :; do
       fi
       # Unsettled-CI hold: emit nothing, fall through to the wait line.
       if [ "$(jq -r '.checks_settled' <<<"$s")" = "true" ] \
-         || [ "$(jq -r '.copilot_quota_hit // false' <<<"$s")" = "true" ]; then
+         || [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" = "true" ]; then
         emit "$s"; exit 0
       fi ;;
     fix-ci|triage-ci|resolve-threads|rebase|resolve-conflicts|merge|blocked|none|fix-signatures)

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -32,7 +32,14 @@ check() { # check <name> <expected> <actual>
 # from the review bodies passed in. Bodies never pass through shell quoting.
 #   make_stub <body>...                 — repo HAS the copilot_code_review ruleset
 #   RULES_JSON='[]' make_stub <body>... — repo has NO ruleset
+#   KEEP_MARKER=1 make_stub …           — keep the quota marker a previous case
+#                                         (or a previous run in the same case)
+#                                         left behind
+# Setting up a scenario clears the quota marker by default. It is the one piece
+# of state that survives an invocation, so without this the first case feeding a
+# quota body would silently change the verdict of every case after it.
 make_stub() {
+    [ "${KEEP_MARKER:-0}" = "1" ] || clear_marker
     # Assigned in a branch, not via ${VAR:-default}: a literal } inside the
     # default value closes the parameter expansion early and mangles the JSON.
     local rules
@@ -102,6 +109,7 @@ PY
 # cannot occur in production and would test the author filter instead of the
 # commit-staleness filter the warning is actually about.
 make_stub_reviews() {
+    [ "${KEEP_MARKER:-0}" = "1" ] || clear_marker
     local rules
     if [ -n "${RULES_JSON:-}" ]; then
         rules="$RULES_JSON"
@@ -161,6 +169,30 @@ json.dump({"data": {"repository": {
                                              "signature": {"isValid": True}}}]},
     }}}}, open(out, "w"))
 PY
+}
+
+# pr-status.sh remembers a proven quota wall under $XDG_CACHE_HOME/pr-status and
+# reads it back on every later run, so the cache has to live in the throwaway
+# stub dir: otherwise the suite answers differently on a machine whose operator
+# hit the wall this month, and writes into their real cache while doing it.
+export XDG_CACHE_HOME="$STUB_DIR/cache"
+marker_path() {
+    printf '%s/pr-status/copilot-quota-exhausted-%s\n' "$XDG_CACHE_HOME" "$(date -u +%Y-%m)"
+}
+clear_marker() { rm -rf "$XDG_CACHE_HOME/pr-status"; }
+plant_marker() {
+    mkdir -p "$XDG_CACHE_HOME/pr-status"
+    printf 'planted by the test suite\n' > "$(marker_path)"
+}
+# Derived from the script's own month (UTC), not from the local date: on the
+# first of a month the two can name different months for a few hours, and the
+# case would then plant a marker for the CURRENT month and assert it is ignored.
+prev_month() {
+    python3 -c "
+import datetime
+cur = datetime.datetime.strptime('$(date -u +%Y-%m)', '%Y-%m').date()
+print((cur - datetime.timedelta(days=1)).strftime('%Y-%m'))
+"
 }
 
 status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json; }
@@ -256,6 +288,103 @@ fi
 echo "case 7d: generic outage only — quota flag stays false"
 make_stub "$ERR_GENERIC"
 check "copilot_quota_hit" "false" "$(run_flag copilot_quota_hit)"
+
+# --- Quota marker: the wall is account-wide, the evidence is per PR ---------
+# A PR nobody ever requested a Copilot review on carries no error row at all, so
+# every case above is blind to a quota that is already exhausted — and the
+# ladder handed those PRs a re-request command GitHub rejects (netresearch/maint
+# #52 and #53). The marker is what carries the fact from the PR that proved it.
+echo "case Q1: a quota error is written to the month-keyed marker"
+make_stub "$ERR_QUOTA"
+status >/dev/null
+if [ -f "$(marker_path)" ]; then
+    echo "  ok   marker written for the current month"
+else
+    echo "  FAIL no marker at $(marker_path)"
+    fail=1
+fi
+
+# The marker must be as quiet as the flag: an outage is not a month-long wall,
+# and a marker written for one would suppress every re-request until the reset.
+echo "case Q2: a generic outage writes no marker"
+make_stub "$ERR_GENERIC"
+status >/dev/null
+if [ -f "$(marker_path)" ]; then
+    echo "  FAIL an outage row left a quota marker behind"
+    fail=1
+else
+    echo "  ok   no marker for a generic outage"
+fi
+
+# The regression this change exists for: ruleset active, no Copilot row on the
+# head at all, quota already proven elsewhere. Before the marker this answered
+# request-review WITH the POST command.
+echo "case Q3: marker + no Copilot row (ruleset) — quota advice, no retry cmd"
+make_stub
+plant_marker
+check "copilot_quota_hit"       "false"          "$(run_flag copilot_quota_hit)"
+check "copilot_quota_exhausted" "true"           "$(run_flag copilot_quota_exhausted)"
+check "next.action"             "request-review" "$(run_next)"
+check "next.cmd absent"         "null"           "$(run_flag 'next.cmd')"
+if status | jq -e '.next.why | test("OUT OF REVIEW QUOTA")' >/dev/null; then
+    echo "  ok   why carries the quota guidance"
+else
+    echo "  FAIL why does not name the exhausted quota"
+    fail=1
+fi
+# Remembered is not measured: the why must say which of the two it is, and name
+# the file, or the operator has no way to undo a wrongly recorded wall.
+if status | jq -e --arg m "$(marker_path)" '.next.why | index($m) != null' >/dev/null; then
+    echo "  ok   why names the marker file it read"
+else
+    echo "  FAIL why does not name the marker file"
+    fail=1
+fi
+
+# The generic gate serves the repos without the ruleset and re-requests the same
+# bot, so the suppression has to reach it too — the trap a previous fix fell
+# into by putting the check inside the $needs_copilot guard.
+echo "case Q4: marker + NO ruleset — retry command dropped here too"
+RULES_JSON='[]' make_stub
+plant_marker
+check "next.action"     "request-review" "$(run_next)"
+check "next.cmd absent" "null"           "$(run_flag 'next.cmd')"
+
+# The quota resets monthly, so a marker must expire with its month — and by its
+# NAME, since any write refreshes an mtime.
+echo "case Q5: a marker from the previous month is ignored"
+make_stub
+mkdir -p "$XDG_CACHE_HOME/pr-status"
+printf 'stale\n' > "$XDG_CACHE_HOME/pr-status/copilot-quota-exhausted-$(prev_month)"
+check "copilot_quota_exhausted" "false" "$(run_flag copilot_quota_exhausted)"
+case "$(run_flag 'next.cmd')" in
+    *"repos/o/r/pulls/1/requested_reviewers"*)
+        echo "  ok   last month's marker does not suppress the re-request" ;;
+    *)  echo "  FAIL a stale marker suppressed the re-request command"
+        fail=1 ;;
+esac
+
+# Remembering is an optimisation; refusing to answer is not. A cache directory
+# that cannot be written must cost one wasted re-request, never a status query.
+# Skipped as root, where the mode bits do not bite and the case would pass
+# without ever exercising the failure.
+echo "case Q6: an unwritable cache directory does not break the run"
+if [ "$(id -u)" = "0" ]; then
+    echo "  skip running as root — the read-only cache dir would be writable"
+else
+    make_stub "$ERR_QUOTA"
+    mkdir -p "$STUB_DIR/ro-cache"
+    chmod 500 "$STUB_DIR/ro-cache"
+    if out=$(XDG_CACHE_HOME="$STUB_DIR/ro-cache" PATH="$STUB_DIR:$PATH" \
+             bash "$SCRIPT" -R o/r 1 --json) \
+       && [ "$(jq -r '.next.action' <<<"$out")" = "request-review" ]; then
+        echo "  ok   status still answered with an unwritable cache dir"
+    else
+        echo "  FAIL an unwritable cache dir broke the run"
+        fail=1
+    fi
+    chmod 700 "$STUB_DIR/ro-cache"
+fi
 
 # Regression for a dead end that shipped once: an earlier version escalated to a
 # distinct "review-yourself" action guarded on has_review_on_head. A review by
@@ -514,6 +643,22 @@ case "$out" in
     *"ACTIONABLE: fix-signatures"*) echo "  ok   watch returns immediately on the signature gate" ;;
     *TIMEOUT*) echo "  FAIL watch held to timeout on its own headline scenario"; fail=1 ;;
     *) echo "  FAIL unexpected watch output"; fail=1 ;;
+esac
+
+# Same exemption as W3, reached through the marker instead of an error body:
+# waiting cannot clear a wall proven on another PR either, so a watch armed on
+# a PR with no Copilot row of its own must not hold to timeout.
+echo "case W5: watch + pending check + MARKER — exemption fires without an error row"
+PENDING_CHECK=1 make_stub
+plant_marker
+out=$(watch || true)
+case "$out" in
+    *"ACTIONABLE: request-review (UNSATISFIABLE"*)
+        case "$out" in
+            *TIMEOUT*) echo "  FAIL exemption fired only at timeout"; fail=1 ;;
+            *) echo "  ok   remembered quota returns immediately despite unsettled CI" ;;
+        esac ;;
+    *) echo "  FAIL marker exemption did not fire (no UNSATISFIABLE ACTIONABLE line)"; fail=1 ;;
 esac
 
 


### PR DESCRIPTION
## The failure

`pr-status.sh` detects Copilot's review-quota wall from an errored review body on the PR being inspected — and only from there. The quota itself is per account and per calendar month, which the script's own comment already says ("once this is true, no re-request on any PR will succeed until the monthly reset"), but the evidence is per PR: a pull request nobody ever requested a Copilot review on carries no error row at all. On those PRs the NEXT ladder kept answering `request-review` together with a ready-to-run `gh api … requested_reviewers -X POST` command. Observed on 2026-08-14/15 in `netresearch/maint` #52 and #53: the operator ran the command the tool handed over, hours after the same account's quota had already been proven exhausted on another repo, and the request predictably never produced a review.

## The fix

The wall is remembered where the next invocation can find it. When a PR proves it (`copilot_quota_hit`), the run writes one marker file per calendar month to `${XDG_CACHE_HOME:-$HOME/.cache}/pr-status/copilot-quota-exhausted-YYYY-MM`, containing the PR that proved it and a timestamp so the verdict can be traced back. Every invocation reads the current month's marker before deciding.

The month is in the **filename**, never in the mtime — any later write would refresh an mtime and let a marker outlive the reset it describes — so a marker from an earlier month is ignored by name comparison alone and needs no cleanup. Writing is best effort throughout: an unwritable or full cache directory costs one wasted re-request, never a failed status query.

`copilot_quota_hit` keeps exactly its previous meaning, the evidence found on THIS pull request, so the existing per-PR detection still stands on its own. The new `copilot_quota_exhausted` is the verdict — evidence or marker — and it is what the NEXT ladder and the `--watch` exemption now read. Three branches change: the errored-review branch (unchanged behaviour when the evidence is local, marker-aware otherwise), the `copilot_code_review` ruleset branch, and the generic review gate — the last two being precisely the ones that used to hand back the POST command on a PR with no Copilot row of its own. No other NEXT outcome moves. The quota prose is hoisted into one binding used by all three, and it names which of the two sources the verdict came from plus the marker path, so an operator can tell a fresh reading from a remembered one and delete the file if it was recorded in error.

## Verification

`shellcheck` clean on both changed shell files; `pre-commit run --all-files` passes apart from a pre-existing `SC2148` on `.envrc`, untouched here. All eight `tests/*.sh` pass, including the `--json` contract test against the extended key list.

Six new cases in `tests/test_pr_status_errored_review.sh` cover the marker write, the generic outage that must NOT write one, both suppressed branches (with and without the ruleset), the previous-month marker being ignored, an unwritable cache directory, and the `--watch` exemption firing without any error row. Each was checked against a targeted mutation rather than assumed to bite: reverting the ladder to `copilot_quota_hit` fails Q3/Q4, dropping the month from the filename fails Q1/Q3/W5, removing the persist call fails Q1, and reverting only the watch-loop reads fails W5 alone.

The suite now pins `XDG_CACHE_HOME` into its own throwaway stub directory and clears the marker in `make_stub`/`make_stub_reviews`. The marker is the first piece of state that survives an invocation, so without that the suite would answer differently on a machine whose operator has hit the wall this month, would write into their real cache, and case W1 (watch must hold to timeout) would flip.

`references/pull-request-workflow.md` gains a paragraph on the quota case, which the surrounding text described only as a second-strike outage.
