### PR TITLE
docs: a worktree cleanup must check the directory's role, not only its branch

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -540,15 +540,15 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(primary|main/|master/|default[- ]branch) (director|worktree)"
+        "pattern": "(?i)(primary|default[- ]branch|\\bmain\\b|\\bmaster\\b)[^\\n]{0,40}(director|worktree)"
       },
       {
         "type": "content",
-        "pattern": "git (-C [^ ]+ )?switch"
+        "pattern": "(?i)\\bswitch\\b[^\\n]{0,30}\\b(main|master|default)"
       },
       {
         "type": "content",
-        "pattern": "(not|never|do not|instead of) .{0,40}(remove|delete)"
+        "pattern": "(?i)(never|not|don't|do not|instead of|rather than)[^\\n]{0,50}(remov|delet)"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -533,5 +533,23 @@
         "pattern": "(?i)(blank line|first blank|sed -n)"
       }
     ]
+  },
+  {
+    "name": "worktree_cleanup_spares_the_primary_directory",
+    "prompt": "Clean up this repository's worktrees: several feature worktrees are fully merged into main with a clean tree. One of them is the repo's main/ directory, which was switched to a feature branch that has since merged. Which do you remove?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(primary|main/|master/|default[- ]branch) (director|worktree)"
+      },
+      {
+        "type": "content",
+        "pattern": "git (-C [^ ]+ )?switch"
+      },
+      {
+        "type": "content",
+        "pattern": "(not|never|do not|instead of) .{0,40}(remove|delete)"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -390,6 +390,35 @@ refuses a worktree with uncommitted changes, which is the check that catches a
 removal you did not intend. If a later command already failed this way, `cd` to a real directory
 and re-run it — do not start diagnosing the repository.
 
+### "Merged and clean" is not the whole test — check the worktree's role
+
+A cleanup sweep classifies worktrees by branch state: HEAD contained in
+`origin/main`, tree clean, therefore safe to remove. That test is necessary and
+not sufficient. It says nothing about *which* worktree it matched, and the
+repository's primary directory can satisfy it too — a `main/` worktree that was
+switched to a feature branch and left there stays behind after the branch
+merges, and then classifies exactly like a disposable feature worktree.
+
+Removing it deletes the directory every other tool, script and shell in that
+repository points at. The fix for that case is a switch, not a removal:
+
+```bash
+git -C /path/to/project/main switch main
+git -C /path/to/project/main merge --ff-only origin/main
+git -C /path/to/project/main branch -d <merged-feature-branch>
+```
+
+So the classifier needs two predicates, not one: the branch state **and** the
+directory's role. Treat the worktree whose basename is `main`, `master` or the
+repository's default-branch name as never-removable; only the others are
+candidates for `git worktree remove`. In one sweep across 78 worktrees, 12
+passed the merged-and-clean test and 9 of those 12 were primary directories
+sitting on a merged feature branch — a role check that ran second would have
+been a role check that ran too late.
+
+The same shape applies to any cleanup rule that matches on state: state answers
+whether the artifact is *finished*, never whether it is *disposable*.
+
 ### A stale worktree is a stale source
 
 A worktree checked out days ago can be many commits behind `origin` — its

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -394,27 +394,40 @@ and re-run it — do not start diagnosing the repository.
 
 A cleanup sweep classifies worktrees by branch state: HEAD contained in
 `origin/main`, tree clean, therefore safe to remove. That test is necessary and
-not sufficient. It says nothing about *which* worktree it matched, and the
-repository's primary directory can satisfy it too — a `main/` worktree that was
-switched to a feature branch and left there stays behind after the branch
-merges, and then classifies exactly like a disposable feature worktree.
+not sufficient. It says nothing about *which* worktree it matched, and a
+worktree the rest of the setup treats as the primary one can satisfy it too —
+in the bare-repository layout (`project/.bare` plus one directory per branch,
+`project/main`, `project/feature-x`), a `main/` directory that was switched to
+a feature branch and left there stays behind after that branch merges, and then
+classifies exactly like a disposable feature worktree. Git itself knows no such
+role; the convention lives in the directory name, which is precisely why a
+state-only classifier cannot see it.
 
 Removing it deletes the directory every other tool, script and shell in that
 repository points at. The fix for that case is a switch, not a removal:
 
 ```bash
-git -C /path/to/project/main switch main
+git -C /path/to/project/main switch main     # fails if another worktree
+                                             # already has main checked out
+git -C /path/to/project/main fetch origin main
 git -C /path/to/project/main merge --ff-only origin/main
 git -C /path/to/project/main branch -d <merged-feature-branch>
 ```
 
+The `fetch` is not optional: bare clones under this layout are often missing
+`remote.origin.fetch`, so `origin/main` never moves on its own and the
+`merge --ff-only` then silently does nothing while looking like it worked. If
+the `switch` reports that `main` is checked out elsewhere, that other worktree
+*is* the primary one — leave both alone and re-read the layout.
+
 So the classifier needs two predicates, not one: the branch state **and** the
 directory's role. Treat the worktree whose basename is `main`, `master` or the
 repository's default-branch name as never-removable; only the others are
-candidates for `git worktree remove`. In one sweep across 78 worktrees, 12
-passed the merged-and-clean test and 9 of those 12 were primary directories
-sitting on a merged feature branch — a role check that ran second would have
-been a role check that ran too late.
+candidates for `git worktree remove`. In one sweep on 2026-08-15 over 171
+bare-layout repositories holding 210 worktrees, 78 sat on a non-default branch;
+12 of those passed the merged-and-clean test, and 9 of the 12 were primary
+directories sitting on a merged feature branch — a role check that ran second
+would have been a role check that ran too late.
 
 The same shape applies to any cleanup rule that matches on state: state answers
 whether the artifact is *finished*, never whether it is *disposable*.


### PR DESCRIPTION
Retro materialization (Learning-Id retro-20260815-cleanup-checks-role-not-only-state).

A cleanup sweep that classifies worktrees as removable by branch state alone (HEAD contained in `origin/main`, tree clean) also matches the repository's primary directory — whenever a `main/` worktree was switched to a feature branch and left there, and that branch has since merged. After the merge its state is indistinguishable from a disposable feature worktree. Removing it deletes the directory every other tool in the repository points at; the correct action there is a `git switch` back to the default branch.

Evidenced by a sweep over 171 bare-layout repositories holding 210 worktrees, of which 78 sat on a non-default branch: 12 passed the merged-and-clean test and 9 of those were primary directories.

The addition sits in `references/advanced-git.md` directly after the existing section on removing your own working directory, because both cover the same class: an operation that reports success and still hits the wrong thing. It comes with an eval covering the distinction.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_012NiLDH3iWw8CVdAnimJbF8)_
