### PR TITLE
test: give the worktree-cleanup eval samples to check itself against

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -540,22 +540,24 @@
     "assertions": [
       {
         "type": "content",
-        "pattern": "(?i)(primary|default[- ]branch|\\bmain\\b|\\bmaster\\b)[^\\n]{0,40}(director|worktree)"
+        "pattern": "(but not|except|other than|apart from|keep|leave|spare|exclude|never|do not|dont|not) [^.]{0,70}(main/|master/|primary|default.branch)|(main/|master/|primary|default.branch)[^.]{0,70}(is not|must not|never|stays|keep|leave|spare|exclude)"
       },
       {
         "type": "content",
-        "pattern": "(?i)\\bswitch\\b[^\\n]{0,30}\\b(main|master|default)"
+        "pattern": "(switch|check ?out) [^.]{0,40}(main|master|default)"
       },
       {
         "type": "content",
-        "pattern": "(?i)\\b(but not|except|other than|apart from|do not|don't|never|keep|leave|spare)\\b"
+        "pattern": "(remove|delete|prune) [^.]{0,70}(feature|merged|other)|(feature|merged|other) [^.]{0,70}(can go|be removed|removed|deleted)"
       }
     ],
     "samples": {
-      "passing": "Remove the merged feature worktrees, but not project/main: that directory is the repository's primary worktree, it only looks disposable because it was left on a feature branch. Run git -C project/main switch main, fetch, then fast-forward it.",
+      "passing": "Remove the merged feature worktrees, but not project/main: that directory is the repository primary worktree and only looks disposable because it was left on a feature branch. Switch it back to main, fetch, then fast-forward it.",
       "failing": [
-        "All of them are merged into main and the tree is clean, so remove every one of them with git worktree remove, then git worktree prune and delete the local branches.",
-        "The main/ worktree is a worktree like any other; its branch is merged, so do not leave it behind either — delete it too and re-add it later if you need it."
+        "All of them are merged into main and the tree is clean, so remove every one of them with git worktree remove, then git worktree prune and delete the local branches afterwards.",
+        "The main/ directory is a worktree like any other; its branch is merged, so delete it too and re-add it later if you need it.",
+        "Switch each of them back to main first, then remove all of the worktrees including project/main so the repository is tidy.",
+        "Remove the ones whose branches are merged. That includes project/main, since its feature branch merged as well."
       ]
     }
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -548,8 +548,15 @@
       },
       {
         "type": "content",
-        "pattern": "(?i)(never|not|don't|do not|instead of|rather than)[^\\n]{0,50}(remov|delet)"
+        "pattern": "(?i)\\b(but not|except|other than|apart from|do not|don't|never|keep|leave|spare)\\b"
       }
-    ]
+    ],
+    "samples": {
+      "passing": "Remove the merged feature worktrees, but not project/main: that directory is the repository's primary worktree, it only looks disposable because it was left on a feature branch. Run git -C project/main switch main, fetch, then fast-forward it.",
+      "failing": [
+        "All of them are merged into main and the tree is clean, so remove every one of them with git worktree remove, then git worktree prune and delete the local branches.",
+        "The main/ worktree is a worktree like any other; its branch is merged, so do not leave it behind either — delete it too and re-add it later if you need it."
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Adopts the `samples` block from [skill-repo-skill#225](https://github.com/netresearch/skill-repo-skill/pull/225): one answer every assertion has to match, and four answers at least one assertion has to reject. Deterministic, no model call.

It closes the gap the review of [#193](https://github.com/netresearch/git-workflow-skill/pull/193) exposed: assertions were executed nowhere, CI validated the JSON structure only. Replayed against the original defect — the assertion demanding the literal `remove` while the reference text says "never-removable" — validation now names it: `assertion[2] does not match its own passing sample`.

Writing the samples exposed two further problems in the assertions themselves, both fixed here. One assertion required the negation to precede the removal verb, so an answer phrased "remove the merged ones, but not project/main" failed. Its replacement had the opposite flaw: it matched a bare stopword — `keep`, `leave`, `not` anywhere in the text — unbound from the decision the eval is about, so wrong answers passed it. Each of the three assertions now binds two things: the exemption to the primary directory, the remedy to the default branch, and the removal to the merged feature worktrees.

The failing samples were straw men that shared almost no vocabulary with a correct answer, so rejecting them proved only that the assertions were no longer inverted. Two more were added for the answers that were actually slipping through: one that switches correctly and then removes everything anyway, and one that removes the primary directory precisely because its branch merged.

Verified with `grep -qiE`, the matcher `run-ab-evals.sh` grades with, not with Python's `re`: the passing sample satisfies all three assertions, each of the four failing samples fails at least one, and all three patterns parse as POSIX ERE.

On ordering: this PR is green against today's validator (`samples` is an unknown key to it and is ignored) and is only really checked once skill-repo-skill#225 has merged — the `eval-validate` reusable is pinned to `@main`, so it picks the check up on the next run after that.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_012NiLDH3iWw8CVdAnimJbF8)_
