### PR TITLE
docs: write down what building the language gate taught, and pin it

### DIFF
--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -18,7 +18,7 @@ from typing import ClassVar
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from validate_git_command import german_prose
+from validate_git_command import GERMAN_MARKERS
 
 HOOK = Path(__file__).with_name("validate_git_command.py")
 
@@ -245,32 +245,29 @@ class ForgeBodyLanguageGate(unittest.TestCase):
         # No traceback, and the other gates in the file still got their turn.
         self.assertNotIn("Traceback", out)
 
-    def test_no_english_reference_file_in_the_fleet_is_denied(self) -> None:
-        """The calibration corpus, as an assertion rather than a code comment.
+    def test_marker_list_excludes_the_words_that_collide_with_english(self) -> None:
+        """Pins the calibration decisions, each of which cost a false positive.
 
-        The marker list is a heuristic, and the only thing that keeps it honest
-        is a negative corpus wider than the documents that motivated it: `mit`
-        had to go because it is the licence every skill repository names. This
-        feeds the skill's own English reference files through the gate and
-        requires that none of them denies.
+        Every word here is German and was in an early draft of the list. Each
+        is also ordinary English or a term the fleet's own prose uses — `mit`
+        is the licence every skill repository names — so re-adding one makes
+        the gate deny English bodies. A list is a decision, and this is the
+        assertion that makes the decision fail loudly when it is reversed.
         """
-        here = Path(__file__).resolve().parent.parent
-        corpus = sorted((here / "skills").glob("*/references/*.md"))
-        self.assertGreater(len(corpus), 3, "corpus too small to be evidence")
-        denied = []
-        for path in corpus:
-            text = path.read_text(encoding="utf-8", errors="replace")
-            distinct, share = german_prose(text)
-            if distinct >= 6 and share >= 0.08:
-                denied.append(f"{path.name} ({distinct} markers, {share:.0%})")
-        self.assertEqual([], denied, "English reference prose must not trip the gate")
+        for word in ("mit", "das", "von", "hat", "die", "man", "war", "so", "in"):
+            self.assertNotIn(word, GERMAN_MARKERS, f"{word!r} also occurs in English")
 
-    def test_the_gate_still_fires_on_german_of_the_same_length(self) -> None:
-        # Guards the other direction: a corpus test that passes because the
-        # thresholds became unreachable would prove nothing.
-        distinct, share = german_prose(self.GERMAN * 8)
-        self.assertGreaterEqual(distinct, 6)
-        self.assertGreaterEqual(share, 0.08)
+    def test_an_english_body_about_licences_is_not_denied(self) -> None:
+        # The body shape that made `mit` untenable, run through the real gate
+        # rather than through a re-implementation of its thresholds.
+        body = (
+            "This adds the missing licence headers. Every package here is MIT, "
+            "so the header names the MIT licence and the holder, and the SPDX "
+            "identifier stays MIT-only. The one exception is the vendored "
+            "parser, which is BSD, and it keeps its own header verbatim."
+        )
+        out = run_hook(f"gh pr create --title x --body '{body}'")
+        self.assertNotEqual("deny", decision(out))
 
     def test_commit_message_is_not_a_forge_body(self) -> None:
         # Commit messages are out of scope for this gate; only forge bodies.

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -16,6 +16,10 @@ import unittest
 from pathlib import Path
 from typing import ClassVar
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_git_command import german_prose
+
 HOOK = Path(__file__).with_name("validate_git_command.py")
 
 
@@ -240,6 +244,33 @@ class ForgeBodyLanguageGate(unittest.TestCase):
         os.unlink(path)
         # No traceback, and the other gates in the file still got their turn.
         self.assertNotIn("Traceback", out)
+
+    def test_no_english_reference_file_in_the_fleet_is_denied(self) -> None:
+        """The calibration corpus, as an assertion rather than a code comment.
+
+        The marker list is a heuristic, and the only thing that keeps it honest
+        is a negative corpus wider than the documents that motivated it: `mit`
+        had to go because it is the licence every skill repository names. This
+        feeds the skill's own English reference files through the gate and
+        requires that none of them denies.
+        """
+        here = Path(__file__).resolve().parent.parent
+        corpus = sorted((here / "skills").glob("*/references/*.md"))
+        self.assertGreater(len(corpus), 3, "corpus too small to be evidence")
+        denied = []
+        for path in corpus:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            distinct, share = german_prose(text)
+            if distinct >= 6 and share >= 0.08:
+                denied.append(f"{path.name} ({distinct} markers, {share:.0%})")
+        self.assertEqual([], denied, "English reference prose must not trip the gate")
+
+    def test_the_gate_still_fires_on_german_of_the_same_length(self) -> None:
+        # Guards the other direction: a corpus test that passes because the
+        # thresholds became unreachable would prove nothing.
+        distinct, share = german_prose(self.GERMAN * 8)
+        self.assertGreaterEqual(distinct, 6)
+        self.assertGreaterEqual(share, 0.08)
 
     def test_commit_message_is_not_a_forge_body(self) -> None:
         # Commit messages are out of scope for this gate; only forge bodies.

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -211,7 +211,7 @@ def forge_body_hard_wrapped(cmd: str) -> str | None:
 # and a marker that fires on English is worse here than a missing one, because
 # this gate denies rather than nudges.
 # "mit" is absent although it is a German word: it is also the licence every
-# skill repository names, 18 times in one 60k-word English corpus. A marker
+# skill repository names, 18 times in one 63k-word English corpus. A marker
 # that fires on English prose is worse than a missing one, because this gate
 # denies rather than nudges. Same reasoning excludes "das", "von" and "hat",
 # which appear as DAS, von Neumann and HAT.

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -67,6 +67,32 @@ Because the exit code cannot distinguish "watched and passed" from "never
 found the run", assert the run exists before watching it, or re-read the
 check's state afterwards rather than trusting the watcher's return.
 
+### Ask which step failed before reading any log
+
+The jobs API names it in one call, and the name is usually enough to reproduce
+the failure locally:
+
+```bash
+gh api repos/$R/actions/jobs/$JOB \
+  --jq '.steps[] | select(.conclusion=="failure") | .name'
+```
+
+Reaching for the log first costs several rounds that return nothing. On a job
+using `step-security/harden-runner`, its audit stream (`module=armour`, one line
+per protected inode) floods every keyword filter, so `--log-failed | tail`,
+`--log | grep -iE 'error|fail'` and a range starting at the validator's own
+summary all came back with runner chatter, `tar` invocations and a green
+`Errors: 0` — while the actual failure was a step called `Python lint`. Four
+calls, no information; the fifth, above, answered immediately.
+
+Then reproduce that step's command rather than guessing from its name. **A
+repo's pre-commit set is not its CI lint set**: in that case `pre-commit run
+--files …` was clean and `ruff check scripts/` reproduced the failure on the
+first try. Two habits follow — run the linter the CI step runs, by name, before
+committing; and never pipe `pre-commit` output through `tail` or filter out the
+hook-name lines, because `files were modified by this hook` is a failed run, not
+noise.
+
 ### The step output of a failed job comes from the RUN's log archive
 
 `gh api repos/$R/actions/jobs/$JOB/logs` and `gh run view --job $JOB --log`

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -77,21 +77,34 @@ gh api repos/$R/actions/jobs/$JOB \
   --jq '.steps[] | select(.conclusion=="failure") | .name'
 ```
 
-Reaching for the log first costs several rounds that return nothing. On a job
-using `step-security/harden-runner`, its audit stream (`module=armour`, one line
-per protected inode) floods every keyword filter, so `--log-failed | tail`,
-`--log | grep -iE 'error|fail'` and a range starting at the validator's own
-summary all came back with runner chatter, `tar` invocations and a green
-`Errors: 0` — while the actual failure was a step called `Python lint`. Four
-calls, no information; the fifth, above, answered immediately.
+Reaching for the log first costs rounds that return nothing, because the
+failing step's output is often not in what you get back (see the next section)
+and every keyword filter then matches the surrounding noise instead —
+provisioning, `tar` invocations, a `harden-runner` audit stream, and in one case
+a validator's own green `Errors: 0` summary. Four such calls produced no
+information about a failure whose step was called `Python lint`; the API call
+above answered on the first try.
 
-Then reproduce that step's command rather than guessing from its name. **A
-repo's pre-commit set is not its CI lint set**: in that case `pre-commit run
---files …` was clean and `ruff check scripts/` reproduced the failure on the
-first try. Two habits follow — run the linter the CI step runs, by name, before
-committing; and never pipe `pre-commit` output through `tail` or filter out the
-hook-name lines, because `files were modified by this hook` is a failed run, not
-noise.
+### A green pre-commit run is not a green CI lint step
+
+Two distinct reasons, and the second is the one that is easy to miss.
+
+**The run was not green.** `pre-commit` reports a reformatting hook as a
+failure, and the report is easy to discard: `pre-commit run --files … | grep -vE
+'Skipped|Passed' | tail -4` printed `- files were modified by this hook` and `2
+files reformatted`, which was read as success. Never filter or truncate
+`pre-commit` output — `files were modified by this hook` is a failed run, and
+the hook names are how you tell which.
+
+**The versions differ.** Even a genuinely green run proves only what the
+*pinned* version thinks. `.pre-commit-config.yaml` pins
+`astral-sh/ruff-pre-commit` by `rev`, while the CI step pins its own
+(`uvx ruff@0.16.0 check`). Measured on the same file: ruff 0.15.14, the
+pre-commit pin, reported `All checks passed!` while ruff 0.16.0, the CI pin,
+failed it on `SIM905`. The rule was newer than the hook. So keep the two pins in
+parity and let dependency updates move them together; when they disagree, the
+CI's version is the one that decides, and running the linter merely "by name" is
+not enough.
 
 ### The step output of a failed job comes from the RUN's log archive
 

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -249,28 +249,30 @@ builds a throwaway layout and checks that a commit in `main/` denies while
 
 ### The deny message is a specification
 
-Whatever a denial says is what its author will be held to, and the exception a message
-carves out is the case most likely to be wrong — it is the one the implementation had to
-think about separately. Turn each clause into a test before shipping the gate.
+Whatever a denial says is what its author will be held to, and the exception
+a message carves out is the case most likely to be wrong — it is the one the
+implementation had to think about separately. Turn each clause into a test
+before shipping the gate.
 
-The forge-body language gate is the worked example. Its message makes four claims, and
-the first version of the gate honoured two of them:
+The forge-body language gate is the worked example. Its first message made
+three claims, and the gate honoured one of them:
 
-| Clause of the message | Test |
-|---|---|
-| a German body is denied | body of German prose → `deny` |
-| quoting a German string inside an English body "is fine and does not trip this" | English body with a German stack trace in a fenced block → not `deny` |
-| `FORGE_LANGUAGE_GATE_OFF=1` in front of the command exempts a German repository | the documented command verbatim → not `deny` |
-| the exemption is a prefix, not a mention | the same string inside a body → still `deny` |
+| Clause of the message | Test | First version |
+|---|---|---|
+| a German body is denied | German prose → `deny` | held |
+| quoting a German string inside an English body "is fine" | English body with a German stack trace → not `deny` | denied it |
+| `FORGE_LANGUAGE_GATE_OFF=1` exempts a German repository | the documented command verbatim → not `deny` | inert: read from the environment, which a Bash prefix never reaches |
 
-Rows two and three failed when they were first written: the gate denied exactly the body
-its message called fine, and the exemption was read from the environment, where a Bash
-prefix can never arrive. Both were found by writing the tests from the message rather
-than from the implementation.
+Both failures were found by writing the tests from the message rather than
+from the implementation. A fourth clause — that the exemption is a prefix and
+not a mention — entered the message only with the fix, which is itself the
+pattern: sharpening a promise is how the missing case gets named, so
+re-derive the tests whenever the message changes.
 
-A gate that denies also needs its threshold calibrated against the widest negative corpus
-it will meet, not against the documents that motivated it. In that gate a German
-function-word marker list contained `mit`, which is the licence every skill repository
-names — 18 occurrences in a 63k-word English corpus assembled from the fleet's own
-reference files. A false deny blocks legitimate work, so in a denying gate a marker that
-fires on the negative corpus is worse than a missing one.
+A gate that denies also needs its threshold calibrated against a negative
+corpus wider than the documents that motivated it. In that gate a German
+function-word marker list contained `mit`, which is the licence every skill
+repository names. A false deny blocks legitimate work, so in a denying gate a
+marker that fires on the negative corpus is worse than a missing one — and
+the calibration belongs in a test rather than a comment, because a marker
+list is a decision and a comment cannot fail when the decision is reversed.

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -243,3 +243,34 @@ builds a throwaway layout and checks that a commit in `main/` denies while
 | `Write\|Edit` matcher without file-path extraction | Hook runs on wrong files | `jq -r '.tool_input.file_path'` |
 | Blocking hooks that hit flaky services | One GitHub-API outage blocks all merges | Soft-fail: warn instead of deny for infra-dependent gates |
 | Per-hook large shell scripts inline in JSON | Unreadable, un-testable | Keep inline ≤3 lines; call external script for more |
+| An exception the gate reads from the environment | The hook is its own process; a `VAR=1 cmd` prefix never reaches it, so the documented way out is inert | Read it off the command text, anchored as a leading assignment, and copy the mechanism from the gate already shipping in that hook |
+| A deny text whose promises nothing tests | The message is the contract; an untested promise is usually the case the gate gets wrong | One test per clause of the message — see below |
+| A gate built from an incident that covers one command shape | An incident is plural; the shape you remember is rarely the only one it used | Extract every command shape from the transcript and assert the predicate on each |
+
+### The deny message is a specification
+
+Whatever a denial says is what its author will be held to, and the exception a message
+carves out is the case most likely to be wrong — it is the one the implementation had to
+think about separately. Turn each clause into a test before shipping the gate.
+
+The forge-body language gate is the worked example. Its message makes four claims, and
+the first version of the gate honoured two of them:
+
+| Clause of the message | Test |
+|---|---|
+| a German body is denied | body of German prose → `deny` |
+| quoting a German string inside an English body "is fine and does not trip this" | English body with a German stack trace in a fenced block → not `deny` |
+| `FORGE_LANGUAGE_GATE_OFF=1` in front of the command exempts a German repository | the documented command verbatim → not `deny` |
+| the exemption is a prefix, not a mention | the same string inside a body → still `deny` |
+
+Rows two and three failed when they were first written: the gate denied exactly the body
+its message called fine, and the exemption was read from the environment, where a Bash
+prefix can never arrive. Both were found by writing the tests from the message rather
+than from the implementation.
+
+A gate that denies also needs its threshold calibrated against the widest negative corpus
+it will meet, not against the documents that motivated it. In that gate a German
+function-word marker list contained `mit`, which is the licence every skill repository
+names — 18 occurrences in a 63k-word English corpus assembled from the fleet's own
+reference files. A false deny blocks legitimate work, so in a denying gate a marker that
+fires on the negative corpus is worse than a missing one.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -300,6 +300,21 @@ coverage driver" replaces a false statement with a true but empty one: the body
 is the delta against the target, and something that does not change has no row
 in it.
 
+**The other trigger is a push that answers review findings, and it fires within
+the hour.** Elapsed time is the obvious cause of drift; a review is the frequent
+one. The body was written to describe the first version of the change, the
+review found that version wrong, and the fix replaced the approach the body
+still explains. Seen on one PR the same day it opened: the body documented an
+escape hatch read from the environment that the head commit had already
+replaced with one read off the command line — the mechanism was gone, the
+explanation was not.
+
+Re-derive the body after every push that answers a review, not only after a
+rebase, and **re-count every number it states**. Figures are copied forward
+faster than prose: the same PR ended up claiming a "63k-word corpus" while the
+code comment beside the measurement said 60k, for a corpus of 62,749 words.
+Two figures for one set means at least one of them was never measured.
+
 ### When you already have the fix, lead with it
 
 Issue templates order evidence before solution — they are written for reports

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -281,7 +281,7 @@ Build the before/after table *before* writing the summary sentence. Filling in
 the rows is what catches the case you assumed was untouched; writing the
 sentence first only records the assumption.
 
-### A long-lived PR body describes the branch it had, not the branch it has
+### A PR body describes the branch it had, not the branch it has
 
 A body written months ago documents a state the branch has since left. Every
 rebase, revert and upstream merge invalidates part of it, and nothing in the
@@ -300,20 +300,22 @@ coverage driver" replaces a false statement with a true but empty one: the body
 is the delta against the target, and something that does not change has no row
 in it.
 
-**The other trigger is a push that answers review findings, and it fires within
-the hour.** Elapsed time is the obvious cause of drift; a review is the frequent
-one. The body was written to describe the first version of the change, the
-review found that version wrong, and the fix replaced the approach the body
-still explains. Seen on one PR the same day it opened: the body documented an
-escape hatch read from the environment that the head commit had already
-replaced with one read off the command line — the mechanism was gone, the
-explanation was not.
+**Elapsed time is the obvious cause; a review is the frequent one, and it fires
+within the hour.** The body was written to describe the first version of the
+change, the review found that version wrong, and the fix replaced the approach
+the body still explains. Seen on one PR the same day it opened: the body
+documented an escape hatch read from the environment that the head commit had
+already replaced with one read off the command line — the mechanism was gone,
+the explanation was not.
 
 Re-derive the body after every push that answers a review, not only after a
-rebase, and **re-count every number it states**. Figures are copied forward
-faster than prose: the same PR ended up claiming a "63k-word corpus" while the
-code comment beside the measurement said 60k, for a corpus of 62,749 words.
-Two figures for one set means at least one of them was never measured.
+rebase, and **re-measure every number it states rather than copying it
+forward**. Figures survive edits that invalidate them: the same PR claimed a
+"63k-word corpus" while the code comment beside the measurement said 60k. Both
+had been measured — of different corpora, weeks apart in reading order and
+minutes apart in writing — which is exactly why the disagreement is worth
+catching. Two figures for one quantity means at least one is answering a
+question you are no longer asking.
 
 ### When you already have the fix, lead with it
 


### PR DESCRIPTION
Retro materialization (Learning-Id retro-20260815-deny-message-is-a-spec) from the round that shipped the forge-body language gate in [#195](https://github.com/netresearch/git-workflow-skill/pull/195). Several of that gate's defects were found by review rather than by me, and each generalises past that one gate.

`references/claude-code-hooks.md` gains three anti-pattern rows and a section on **the deny message as a specification**: whatever a denial promises is a required test case, and the exception a message carves out is the clause most likely to be wrong, because it is the one the implementation had to think about separately. The language gate is the worked example — of the three claims its first message made, the gate honoured one. A fourth clause entered the message only with the fix, which is the pattern rather than an exception to it: sharpening a promise is how the missing case gets named, so the tests are re-derived whenever the message changes. Also recorded: an exception read from the environment is inert in a hook, since the hook is its own process and never sees a `VAR=1 cmd` prefix; and a gate built from an incident must cover every command shape that incident used — that gate missed `gh pr review` and the review-reply endpoint, which carried half of it.

`references/pull-request-workflow.md`: the section on a stale body attributed the drift to elapsed time. The frequent trigger is a push answering a review, and it fires within the hour — the body still describes the approach the fix replaced, as happened on that PR the day it opened. Re-measure every number rather than copying it forward: the same PR claimed a "63k-word corpus" while the code comment beside the measurement said 60k. Both had been measured, of different corpora at different times, which is precisely why the disagreement is worth catching.

`references/ci-cd-integration.md`: ask the jobs API which step failed before reading any log — four log calls produced nothing about a failure whose step was called `Python lint`, and one API call named it. Then a section on why a green pre-commit run is not a green CI lint step, for two reasons. The run may not have been green at all: `files were modified by this hook` is a failure, and it is easy to discard when the output is filtered. And even a green run only proves what the *pinned* version thinks — here `.pre-commit-config.yaml` pins ruff v0.15.14 while CI pins `ruff@0.16.0`, and measured on the same file 0.15.14 reports `All checks passed!` where 0.16.0 fails on `SIM905`. Keep the two pins in parity; when they disagree the CI's version decides.

The marker-list calibration was prose in a code comment. It is now two tests that can fail: the nine words which also occur in English (`mit` is the licence every skill repository names) must stay out of `GERMAN_MARKERS`, and an English body about licences goes through the real gate rather than through a re-implementation of its thresholds. Verified by mutation — re-adding `mit` turns the suite red.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_012NiLDH3iWw8CVdAnimJbF8)_
