### PR TITLE
docs(pull-request-workflow): superseded-PR conflicts and silent Copilot-request drops

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -152,6 +152,43 @@ command. The month is in the **filename**, so the marker stops applying at the
 reset rather than being aged out; delete the file to undo a verdict recorded in
 error.
 
+The quota wall has a second, earlier face: the `requested_reviewers` POST
+itself can be **silently dropped** — HTTP 200, but the response's
+`requested_reviewers` array is empty and a read-back seconds later still shows
+no pending request, with no errored review anywhere yet. That empty read-back
+right after the POST is the earliest quota tell there is; it looks like "the
+bot will pick it up asynchronously" and is not (five requests across four repos
+were swallowed this way on 2026-08-18 before a later errored review named the
+quota). Read `requested_reviewers` back after the **first** request of a
+session; empty means stop requesting — everywhere — and go straight to the
+self-review path above.
+
+## A Rebase Conflict Can Mean the PR Is Superseded
+
+When `NEXT: rebase` turns into a conflict, look at **what the main side of the
+hunk contains** before resolving anything. If main's side already implements
+what the PR implements — the same feature, ported independently or landed via a
+sibling PR — the conflict is not a merge problem, it is the discovery that the
+PR is superseded. This is the normal fate of a fix PR that sat for days while
+the incident it came from was also worked elsewhere.
+
+The reflexive resolution — keep the PR's side, it is what you came to merge —
+is exactly wrong here: main's version has usually moved on (hardening, an extra
+call, review feedback the PR never saw), and preferring the PR side silently
+**reverts** that. Observed 2026-08-18 on `netresearch/jira-skill` #194: main's
+copy of the identical stdin feature had a mention-gate call integrated
+(`check_mentions_cli`); taking the PR's hunk would have merged green and
+dropped the gate.
+
+What to do instead: diff the PR's intent against current main and keep only the
+delta main lacks (`git reset --hard origin/main`, re-apply just that delta,
+reword the commit) — or close the PR outright if nothing remains. Either way,
+update the PR title and body to describe what it now is; a re-scoped PR wearing
+its old description misleads its reviewer. And when reviewing a PR that is more
+than a couple of days old, check `mergeable`/`mergeStateStatus` first — a
+`CONFLICTING` docs-or-fix PR is a "has this landed already?" prompt before it
+is a content-review task.
+
 ## Check the Default Branch Before Operating
 
 Not every repo uses `main` — older repos often use `master`, and some use


### PR DESCRIPTION
## Summary

Two additions to `references/pull-request-workflow.md` from a five-PR review/merge sweep on 2026-08-18.

**A rebase conflict can mean the PR is superseded.** New section: when the main side of a conflict hunk already implements the PR's feature, the job changes from "resolve" to "re-scope to the delta main lacks, or close" — the reflexive keep-the-PR-side resolution silently reverts whatever main's version gained since. Concrete case: netresearch/jira-skill#194, where main's copy of the same stdin feature had a mention-gate call the PR predated; preferring the PR hunk would have merged green and dropped the gate.

**The Copilot review-request POST can be silently swallowed under quota.** Extends the existing quota section with the earliest tell: HTTP 200 with an empty `requested_reviewers` read-back, before any errored review exists. Five requests across four repos were spent this way before an errored review finally named the quota; the rule is to read back after the first request of a session and stop everywhere on an empty result.

## Came from

`/retro` sweep of the same session. Docs only, no script changes; markdownlint clean.
