### PR TITLE
docs(skill): add When to Use section, align structure with sibling skills

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -12,34 +12,38 @@ allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 
 # Git Workflow Skill
 
+## When to Use
+
+- Branching, Conventional Commits; PRs: open, review, resolve threads, merge (CI gate, queues, cleanup)
+- Conflicts, rebasing a long-lived branch, splitting a PR, git hooks (incl. worktree installs)
+- **Not here**: releases (`github-release`); BLOCKED-PR diagnosis (`github-project`)
+
 ## Critical Rules (Non-Negotiable)
 
 1. **No direct push to main** — always open a PR.
-2. **No merge before all threads resolved** — see `references/pull-request-workflow.md`.
+2. **No merge before all threads resolved** (`references/pull-request-workflow.md`).
 3. **No squash unless asked** — preserves atomic commits, signatures, bisection.
 4. **No "tested/verified/working" without pasted command output** — else say so.
 5. **No edits to installed skill/plugin cache paths** (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the repo worktree, verified by `pwd`.
 6. **Force-push only with `--force-with-lease`** — never plain `--force`.
-7. **Commit before rebase** — `add → commit → fetch → rebase → push`; a dirty tree aborts it.
-8. **No editorializing** — state what changed, not how good it is. See `references/no-editorializing.md`.
+7. **Commit before rebase** — `add → commit → fetch → rebase → push` (a dirty tree aborts it).
+8. **No editorializing** — state what changed, not how good it is (`references/no-editorializing.md`).
 
 ## Reference Files
-
-Load on demand:
 
 | Reference | Content Triggers |
 |-----------|-----------------|
 | `references/commit-conventions.md` | Conventional commits, DCO sign-off |
-| `references/pull-request-workflow.md` | Default-branch check, PR merge, merge gate, signed rebase |
-| `references/ci-cd-integration.md` | Watching CI from the CLI, git mirrors |
+| `references/pull-request-workflow.md` | PR merge gate, signed rebase |
+| `references/ci-cd-integration.md` | CI watching, git mirrors |
 | `references/advanced-git.md` | Rebase, cherry-pick, bisect, stash, worktrees, reflog |
-| `references/github-releases.md` | Pointer to the `github-release` skill |
-| `references/git-hooks-setup.md` | Hook frameworks, detection, hooks per stage |
-| `references/claude-code-hooks.md` | `settings.json` hooks — merge gate, cache-path rejection, auto-lint |
+| `references/github-releases.md` | → `github-release` skill |
+| `references/git-hooks-setup.md` | Hook frameworks, hooks per stage |
+| `references/claude-code-hooks.md` | `settings.json` merge gate, cache-path rejection, auto-lint |
 | `references/code-quality-tools.md` | shellcheck, shfmt, git-absorb, difftastic |
 | `references/merge-gate-watcher.md` | Merge-driver loop, check taxonomy, stale-SHA rerun |
-| `references/spec-cleanup.md` | Planning artifacts off the base branch; guard, capture-to-ADR |
-| `references/no-editorializing.md` | Writing without self-praise or narrating the expected |
+| `references/spec-cleanup.md` | Planning artifacts off the base branch |
+| `references/no-editorializing.md` | No self-praise, no narrating the expected |
 
 ## Conventional Commits
 
@@ -51,12 +55,7 @@ Load on demand:
 
 **Breaking change**: Add `!` after type or `BREAKING CHANGE:` in footer.
 
-## Branch Naming
-
-```
-feature/TICKET-123-description
-release/1.2.0
-```
+**Branches**: `feature/TICKET-123-description`, `release/1.2.0`
 
 ## Hook Detection
 
@@ -64,7 +63,7 @@ release/1.2.0
 ls lefthook.yml .lefthook.yml captainhook.json .pre-commit-config.yaml .husky/pre-commit 2>/dev/null || echo "No hooks"
 ```
 
-Install: `lefthook install` | `composer install` | `npm install` | `pre-commit install`
+Install: `lefthook install`, `composer install`, `npm install`, `pre-commit install`
 
 ## PR Merge Requirements
 
@@ -74,9 +73,9 @@ Before merging: threads resolved, CI green (incl. annotations), rebased, signed,
 
 ```bash
 ./scripts/verify-git-workflow.sh /path/to/repository
-# Merge-gate state + next valid action, 2 API calls:
+# Gate state, next action:
 ./scripts/pr-status.sh [-R owner/repo] [PR] [--json] [--watch]
-# Merge with the method the repo allows; refuses when the gate is shut:
+# Merge; refuses when the gate is shut:
 ./scripts/pr-merge.sh [-R owner/repo] [PR] [--dry-run]
 ```
 


### PR DESCRIPTION
Closes #7.

Issue #7 dates from the 2026-02 marketplace quality sweep ([claude-code-marketplace#32](https://github.com/netresearch/claude-code-marketplace/issues/32)). Re-checked against the current tree, two of its four findings are already resolved: the description is trigger-first (the sweep's recommended wording was applied verbatim and later extended), and the wordy "Expertise Areas" / "Explicit Content Triggers" sections no longer exist. The SKILL.md is also at the 500-word cap rather than the 800 words the issue measured.

What remained was the missing formal `## When to Use` section. This PR adds it at the top of the body, following the pattern of the eleven sibling skills that carry one (github-project, agent-rules, concourse-ci, context7, enterprise-readiness, typo3-*). No separate "Overview" section: the sibling pattern omits it under the 500-word hard cap, and the frontmatter description carries the summary — a body overview would duplicate it, which `skill-repo`'s quality rules list as an anti-pattern.

The added section is offset in the same pass so the hard cap holds: reference-table trigger columns tightened, "Branch Naming" folded into Conventional Commits as a one-liner, Verification fence comments shortened. No reference file, script, or test asserts the removed section names (checked repo-wide).

Result: 499 words, `Build/Scripts/validate-skill.sh` passes with 0 errors, markdownlint clean.