### PR TITLE
feat: pr-status sees classic protection; --watch holds through the quota dead-end

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -28,7 +28,9 @@ bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --json # for scripts and merge
 bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --watch
 ```
 
-Two API calls, and the output ends in a computed `NEXT:` — rebase, fix-ci,
+Two API calls (a third, admin-only, when the PR is review-blocked — it reads
+classic branch protection, whose review gates like `require_last_push_approval`
+are invisible to the rules endpoint), and the output ends in a computed `NEXT:` — rebase, fix-ci,
 triage-ci, resolve-threads, request-review, wait, or merge (with the method
 this repo actually allows and a warning when a merge queue is active). The
 JSON form carries each unresolved thread's `threadId` *and* `commentId`, which

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -9,9 +9,12 @@
 # the rulesets endpoint was queried exactly once, and `copilot_code_review`
 # blocked four merges by surprise.
 #
-# Two API calls: one GraphQL document for the PR, its checks, reviews, threads
-# and the repository's merge configuration; one REST call for the effective
-# branch rules (which is the only place rulesets show up).
+# Two API calls on the green path: one GraphQL document for the PR, its
+# checks, reviews, threads and the repository's merge configuration; one REST
+# call for the effective branch rules (which is the only place rulesets show
+# up). A review-blocked PR costs a third, admin-only call for classic branch
+# protection, whose review gates (require_last_push_approval, approval count,
+# code-owner reviews) no other endpoint exposes.
 #
 # Usage:
 #   pr-status.sh                      # PR for the current branch
@@ -69,6 +72,7 @@
 #   requested_reviewers
 #   merge_methods auto_merge_allowed queue_active queue_entry
 #   rulesets rules_fetched required_contexts undispatched unsigned
+#   classic_protection
 #   next
 #
 # `checks` is {total,pass,fail,pending,skip,...} and `next` is
@@ -204,9 +208,10 @@ collect() {
 # would discard the status flag.
 
 evaluate() {
-  local gql="$1" rules="$2" ok="$3" marker="$4"
+  local gql="$1" rules="$2" ok="$3" marker="$4" prot="${5:-null}"
   jq -n --argjson g "$gql" --argjson r "$rules" --argjson ok "$ok" \
-        --argjson marker "$marker" --arg marker_path "$QUOTA_MARKER" '
+        --argjson marker "$marker" --arg marker_path "$QUOTA_MARKER" \
+        --argjson prot "$prot" '
     # Defined once and used by BOTH the error list and the $head_reviews filter.
     # Two hand-kept copies would have to stay byte-identical: loosening one to
     # match a third error body and not the other puts the row back into
@@ -356,6 +361,19 @@ evaluate() {
                                and ($checks|length) > 0)
                          else null end),
         rulesets: $ruletypes,
+        # Review gates from CLASSIC branch protection, which the rules
+        # endpoint never shows (require_last_push_approval, approval count,
+        # code-owner reviews). Admin-only endpoint, fetched lazily and only
+        # when the PR looks review-blocked — null means "not fetched or not
+        # visible", never "no classic protection".
+        classic_protection: (if $prot == null or ($prot | type) != "object"
+                             then null
+                             else ($prot.required_pull_request_reviews // null
+                                   | if . == null then null else {
+                                       approvals_required: (.required_approving_review_count // 0),
+                                       last_push_approval: (.require_last_push_approval // false),
+                                       code_owner_reviews: (.require_code_owner_reviews // false)
+                                     } end) end),
         # Every distinct state per author, not just the last one. `add` over
         # map({login: state}) overwrites, so a reviewer who approves and then
         # replies to a thread displayed as COMMENTED and the approval vanished
@@ -537,6 +555,21 @@ evaluate() {
             # No single quotes in here: the whole jq program lives in a
             # single-quoted shell string (same trap as the sibling cmd below).
             cmd:"git rebase --exec \"git commit --amend --no-edit -S\" $(git merge-base HEAD origin/\($s.base)) ; git push --force-with-lease"}
+         # An approval that does not count: classic protection with
+         # require_last_push_approval discounts an approval from whoever
+         # pushed last, so reviewDecision sits at REVIEW_REQUIRED with an
+         # APPROVED row on the head and nothing visible names the reason
+         # (go-cron#399: this gate surfaced only after every other gate was
+         # green, because it lives in the admin-only classic endpoint the
+         # rules query cannot see). classic_protection is null for
+         # non-admin callers, so the branch never fires on guesswork.
+         elif ($s.classic_protection != null
+               and $s.classic_protection.last_push_approval
+               and $s.reviewDecision == "REVIEW_REQUIRED"
+               and $s.has_review_on_head
+               and ([$s.reviews_on_head[] | select(test("APPROVED"))] | length) > 0) then
+           {action:"request-review",
+            why:("classic branch protection sets require_last_push_approval — the APPROVED on \($s.headOid[0:8]) does not count if the approver made the most recent push. Someone OTHER than the last pusher must approve; alternatively the author pushes again and a previous approver re-approves")}
          # `|` binds looser than `and`, so the negation needs its own parens:
          # `a and b|not` parses as `(a and b)|not` and inverts the whole test.
          # has_copilot_review_on_head must be false too: the error row stays on
@@ -721,6 +754,9 @@ render() {
     (if .checks.stale > 0 then "  stale       : \(.checks.stale) cancelled row(s) from a superseded run, ignored" else empty end),
     (if (.checks.failing_required|length) > 0 then "  ^ REQUIRED  : \(.checks.failing_required|join(", "))" else empty end),
     "  rulesets    : \(if (.rulesets|length)>0 then (.rulesets|join(", ")) else "none" end)",
+    (if .classic_protection then
+       "  classic     : approvals>=\(.classic_protection.approvals_required)\(if .classic_protection.last_push_approval then ", last-push-approval" else "" end)\(if .classic_protection.code_owner_reviews then ", code-owner-reviews" else "" end) (classic branch protection — invisible to the rulesets endpoint)"
+     else empty end),
     "  reviews     : \(if .has_review_on_head then (.reviews_on_head|to_entries|map("\(.key)=\(.value)")|join(", ")) else "NONE on current head" end)  decision=\(if .reviewDecision=="" then "-" else .reviewDecision end)",
     "  threads     : \(.unresolved_threads) unresolved",
     "  merge       : methods=[\(.merge_methods|join(","))] auto=\(.auto_merge_allowed) queue=\(.queue_active)",
@@ -757,7 +793,22 @@ snapshot() {
   local enc r ok out
   enc=$(printf '%s' "$base" | jq -sRr @uri)
   if r=$(gh api "repos/$REPO/rules/branches/$enc" 2>/dev/null); then ok=1; else ok=0; r='[]'; fi
-  out=$(evaluate "$g" "$r" "$ok" "$(quota_marker_seen)")
+
+  # Classic branch protection holds review gates the rules endpoint never
+  # shows (require_last_push_approval, approval count, code-owner reviews;
+  # go-cron#399 sat review-blocked with every visible gate green because of
+  # one). Admin-only endpoint: a 403/404 leaves it null and the ladder says
+  # nothing. Fetched lazily — only when the PR is BLOCKED or a review is
+  # demanded — so the common green path keeps its two API calls.
+  local prot='null' st2 rd
+  st2=$(jq -r '.data.repository.pullRequest.mergeStateStatus // ""' <<<"$g")
+  rd=$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$g")
+  if [ "$st2" = "BLOCKED" ] || [ "$rd" = "REVIEW_REQUIRED" ] || [ "$rd" = "CHANGES_REQUESTED" ]; then
+    local pr_raw
+    if pr_raw=$(gh api "repos/$REPO/branches/$enc/protection" 2>/dev/null); then prot="$pr_raw"; fi
+  fi
+
+  out=$(evaluate "$g" "$r" "$ok" "$(quota_marker_seen)" "$prot")
   # Written from the EVIDENCE field, never from the verdict: with
   # copilot_quota_exhausted the marker would re-assert itself, and the PR named
   # inside it would be whichever one read the file rather than the one that

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -863,9 +863,11 @@ while :; do
     # ladder itself stamps "do not enqueue on this reading" onto the why.
     # Keep waiting: a failing check fires the branch above, and once the
     # checks settle this returns on the review state (#186). The quota
-    # dead-end is exempt — waiting cannot clear it, return immediately.
-    if [ "$(jq -r '.checks_settled' <<<"$s")" != "true" ] \
-       && [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" != "true" ]; then
+    # dead-end holds here too: waiting cannot clear the quota, but the
+    # checks are the thing that still moves, and returning early hands the
+    # operator a manual re-arm for every push (observed twice on
+    # 2026-08-18). It returns below once CI settles.
+    if [ "$(jq -r '.checks_settled' <<<"$s")" != "true" ]; then
       :
     # A request-review whose cause is an exhausted review bot is a standing
     # condition, not an event: waiting cannot clear a quota ceiling, so every
@@ -875,8 +877,9 @@ while :; do
     elif [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" = "true" ]; then
       echo "ACTIONABLE: request-review (UNSATISFIABLE — Copilot is OUT OF REVIEW QUOTA" \
            "for the month; this will NOT change until the monthly reset, on this or any" \
-           "other PR. Do not re-request — review the diff yourself and decide. To wait" \
-           "for the checks instead, re-arm with:" \
+           "other PR. Checks are settled — do not re-request and do not re-arm, a" \
+           "re-arm returns immediately with this same line. Review the diff yourself" \
+           "and decide; to hold through this standing action for other reasons:" \
            "pr-status.sh -R $(jq -r '.repo' <<<"$s") $(jq -r '.number' <<<"$s") --watch --ignore-action request-review)"
     elif [ "$(jq -r '.copilot_error_count // 0' <<<"$s")" -ge 2 ]; then
       echo "ACTIONABLE: request-review (UNSATISFIABLE — the review bot has failed" \
@@ -887,8 +890,10 @@ while :; do
       echo "ACTIONABLE: request-review"
     fi
     # Unsettled-CI hold: emit nothing, fall through to the wait line.
-    if [ "$(jq -r '.checks_settled' <<<"$s")" = "true" ] \
-       || [ "$(jq -r '.copilot_quota_exhausted // false' <<<"$s")" = "true" ]; then
+    # The quota dead-end returns only here, WITH the checks settled — a
+    # re-arm on a settled PR still comes straight back with the same
+    # UNSATISFIABLE line, which is what its message says.
+    if [ "$(jq -r '.checks_settled' <<<"$s")" = "true" ]; then
       emit "$s"; exit 0
     fi
   elif in_list "$ACTIONABLE" "$act"; then

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -620,20 +620,21 @@ case "$out" in
     *) echo "  FAIL expected immediate ACTIONABLE: request-review"; fail=1 ;;
 esac
 
-echo "case W3: watch + pending check + QUOTA error — quota exemption still returns immediately"
+echo "case W3: watch + pending check + QUOTA error — holds for CI, no premature return"
 PENDING_CHECK=1 make_stub "$ERR_QUOTA"
-# Assert the discriminating signal: the exemption path's unique ACTIONABLE
-# prefix AND no TIMEOUT. The bare quota phrase also appears in every
-# "waiting:" line's why-text, so matching it passes vacuously when the
-# exemption is broken and the watch holds to timeout (found by mutation d).
+# Contract since 2026-08-18: the quota dead-end no longer exempts the watch
+# from the CI hold. Waiting cannot clear the quota, but the pending checks
+# are the thing that still moves — an immediate return here forced a manual
+# `gh pr checks --watch` re-arm after every push (observed twice in one
+# session). The UNSATISFIABLE line may only appear once CI has settled, so
+# with a permanently-pending stub the watch must run into TIMEOUT without it.
 out=$(watch || true)
 case "$out" in
     *"ACTIONABLE: request-review (UNSATISFIABLE"*)
-        case "$out" in
-            *TIMEOUT*) echo "  FAIL exemption fired only at timeout"; fail=1 ;;
-            *) echo "  ok   quota dead-end returns immediately despite unsettled CI" ;;
-        esac ;;
-    *) echo "  FAIL quota exemption did not fire (no UNSATISFIABLE ACTIONABLE line)"; fail=1 ;;
+        echo "  FAIL quota line fired while CI was unsettled"; fail=1 ;;
+    *TIMEOUT*)
+        echo "  ok   quota dead-end holds for unsettled CI (timeout)" ;;
+    *)  echo "  FAIL unexpected watch output: $(printf '%s' "$out" | head -2)"; fail=1 ;;
 esac
 
 echo "case W4: watch + BLOCKED + unsigned + settled — fix-signatures is an actionable event"
@@ -645,20 +646,34 @@ case "$out" in
     *) echo "  FAIL unexpected watch output"; fail=1 ;;
 esac
 
-# Same exemption as W3, reached through the marker instead of an error body:
-# waiting cannot clear a wall proven on another PR either, so a watch armed on
-# a PR with no Copilot row of its own must not hold to timeout.
-echo "case W5: watch + pending check + MARKER — exemption fires without an error row"
+# Same hold as W3, reached through the marker instead of an error body: a
+# remembered wall changes nothing about the pending checks, so the watch
+# keeps waiting for them too.
+echo "case W5: watch + pending check + MARKER — holds for CI like W3"
 PENDING_CHECK=1 make_stub
 plant_marker
 out=$(watch || true)
 case "$out" in
     *"ACTIONABLE: request-review (UNSATISFIABLE"*)
+        echo "  FAIL marker quota line fired while CI was unsettled"; fail=1 ;;
+    *TIMEOUT*)
+        echo "  ok   remembered quota holds for unsettled CI (timeout)" ;;
+    *)  echo "  FAIL unexpected watch output: $(printf '%s' "$out" | head -2)"; fail=1 ;;
+esac
+
+# The immediate return the old W3/W5 asserted still exists — one step later.
+# Once CI is settled the quota dead-end IS the final state: a re-arm comes
+# straight back with the same line, which is what its message warns about.
+echo "case W6: watch + settled + QUOTA error — UNSATISFIABLE returns immediately"
+make_stub "$ERR_QUOTA"
+out=$(watch || true)
+case "$out" in
+    *"ACTIONABLE: request-review (UNSATISFIABLE"*)
         case "$out" in
-            *TIMEOUT*) echo "  FAIL exemption fired only at timeout"; fail=1 ;;
-            *) echo "  ok   remembered quota returns immediately despite unsettled CI" ;;
+            *TIMEOUT*) echo "  FAIL quota line fired only at timeout"; fail=1 ;;
+            *) echo "  ok   settled CI + quota returns immediately" ;;
         esac ;;
-    *) echo "  FAIL marker exemption did not fire (no UNSATISFIABLE ACTIONABLE line)"; fail=1 ;;
+    *) echo "  FAIL quota line did not fire on settled CI"; fail=1 ;;
 esac
 
 


### PR DESCRIPTION
Two findings from the 2026-08-18 go-cron#399 session, each its own commit:

**Classic branch protection is invisible to pr-status.** The rules endpoint never shows classic protection's review settings, so go-cron#399 sat at BLOCKED with an APPROVED review on the head and every visible gate green — the approver was the last pusher and `require_last_push_approval` discounted the approval, but nothing named it. pr-status now lazily fetches the admin-only protection endpoint (only when BLOCKED or review-demanded, so the green path keeps two API calls), prints a `classic` line, exposes `classic_protection` in the JSON contract, and the NEXT ladder explains the discounted-approval case. Null for non-admin callers.

**--watch returned on the quota dead-end while checks were still pending**, forcing a manual `gh pr checks --watch` re-arm after every push (twice in one session). The watch now holds until required checks settle and only then returns the UNSATISFIABLE line; on settled CI the immediate return is unchanged.

Tests: the classic branch was exercised with a stubbed protection payload (fires on the deadlock state, inert on null); W3/W5 rewritten to assert the hold and verified failing against the previous script; new W6 guards the remaining immediate return. Full suite passes; JSON-contract test updated via the documented key list.