### PR TITLE
docs(git-workflow): fetch a failed job's log while the run is still live

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -144,10 +144,11 @@ gh api "repos/$R/actions/jobs/$JOB/logs" --allow-escape-sequences \
 Without the flag the only output is
 `the response contains terminal escape sequences; pass --allow-escape-sequences
 to output it anyway` — one line, exit 0, easy to mistake for an empty log.
-Measured on 2026-08-18 (matrix leg failed at 42% of the run): the job-level
-body carried the full PHPUnit failure, so "job logs show only preamble" (above)
-is a per-job lottery, not a law — try the job endpoint first while the run
-lives, fall back to the run archive once it is complete.
+Measured on 2026-08-18 (a matrix leg had failed while the rest of the run was
+still executing): the job-level body carried the full PHPUnit failure, so "job
+logs show only preamble" (above) is a per-job lottery, not a law — try the job
+endpoint first while the run lives, fall back to the run archive once it is
+complete.
 
 Note the archive is per *run*, so for a queue ejection you need the
 `gh-readonly-queue/*` run, not the pull request's own:

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -129,6 +129,26 @@ ejections and one line — `[ERROR] Undefined constant …PHPUnitSetList::PHPUNI
 — that named the cause outright. The job-level calls had been tried first and
 showed nothing but setup.
 
+**While the run is still in progress, the archive does not exist yet** —
+`gh run view --log` answers `run … is still in progress; logs will be
+available when it is complete`, and so does the run-archive endpoint. A job
+that has already FAILED inside that running run is still readable through the
+job endpoint, with two traps: `gh api` refuses a body containing terminal
+escape sequences unless told otherwise, and the body arrives ANSI-colored:
+
+```bash
+gh api "repos/$R/actions/jobs/$JOB/logs" --allow-escape-sequences \
+  | sed 's/\x1b\[[0-9;]*m//g'
+```
+
+Without the flag the only output is
+`the response contains terminal escape sequences; pass --allow-escape-sequences
+to output it anyway` — one line, exit 0, easy to mistake for an empty log.
+Measured on 2026-08-18 (matrix leg failed at 42% of the run): the job-level
+body carried the full PHPUnit failure, so "job logs show only preamble" (above)
+is a per-job lottery, not a law — try the job endpoint first while the run
+lives, fall back to the run archive once it is complete.
+
 Note the archive is per *run*, so for a queue ejection you need the
 `gh-readonly-queue/*` run, not the pull request's own:
 


### PR DESCRIPTION
The ci-cd-integration reference sends readers to the run's log archive for a failed job's real output — but that archive does not exist until the run completes (`gh run view --log` and the run-archive endpoint both answer "run … is still in progress"), which is exactly when you want the log of a matrix leg that already failed. The job endpoint works mid-run, with two traps now documented: `gh api` refuses a body containing terminal escape sequences unless `--allow-escape-sequences` is passed (the refusal is a single line with exit 0 — easy to read as an empty log), and the body arrives ANSI-colored, so the recipe pipes through an ANSI strip.

Also softens the section's implicit "job logs only carry runner preamble" into what it is — a per-job lottery: measured 2026-08-18 on netresearch/t3x-nr-vault (unit leg failed at 42% of a live run), the job-level body carried the full PHPUnit failure. Guidance: job endpoint first while the run lives, run archive once it is complete.

Source session: the t3x-nr-vault #303–#306 sweep, where discovering the flag cost several round trips.