### PR TITLE
docs: a probe command is read-only; write the PR body in its own call

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -185,6 +185,36 @@ git merge --no-ff cherry-pick-fixes
 
 ## Stashing
 
+### A probe command is read-only
+
+Comparing two revisions, checking what a script used to do, reproducing a bug
+against an older build — that work is exploratory, and it must not move the
+working tree. Never put `git stash`, `git reset`, `git checkout --` or
+`git restore` inside a command whose purpose is to find something out.
+
+The failure is silent, which is what makes it worth a rule. A probe that
+stashes uncommitted work looks exactly like a probe that found nothing: the
+command prints its output, the tree is quietly a different tree, and the next
+edit lands on top of a state nobody chose. Recovery is `git stash pop`, but
+only if you notice.
+
+Extract the other revision instead of moving to it:
+
+```bash
+# ✅ Compare against another revision without touching the tree
+git show origin/main:path/to/script.sh > /tmp/old-script.sh
+bash /tmp/old-script.sh --check
+
+# ✅ A whole old tree, still without moving
+git worktree add /tmp/old-tree origin/main
+
+# ❌ Wrong — mutates the working tree in the middle of an inspection
+old=$(cd src && git stash -q; ./script.sh; true)
+```
+
+If a probe genuinely needs a clean tree, commit first (see the sibling rules on
+selective revert and selective commit) — do not stash your way there.
+
 ### Basic Stash Operations
 
 ```bash

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -365,6 +365,38 @@ minutes apart in writing — which is exactly why the disagreement is worth
 catching. Two figures for one quantity means at least one is answering a
 question you are no longer asking.
 
+### Write the body in its own tool call, after the push
+
+A body that cites a commit can only be written once that commit is on the
+remote, and the hash belongs in it by lookup — `git rev-parse --short HEAD` or
+`git log -1 --format=%h` — never typed from memory. A reader who follows a
+wrong hash finds nothing, and the claim it supported becomes unverifiable.
+
+That ordering has a second, sharper reason: **a denied command loses every side
+effect it contained.** Bundling the push, a heredoc that writes the body file,
+and `gh pr edit --body-file` into one shell invocation means a gate that rejects
+any part of it rejects all of it — and the parts that already ran do not roll
+back. Observed: the push landed, the heredoc never ran because the same call was
+rejected for naming a not-yet-pushed hash, and the following command failed with
+`no such file or directory` — a confusing error two steps downstream of the
+actual refusal.
+
+```bash
+# ✅ Three calls, each with one job
+git push
+git rev-parse --short HEAD          # take the hash from here
+# …write body.md…
+gh pr edit 123 --body-file body.md
+
+# ❌ One call: the gate rejects the whole thing, the push already happened,
+#    and the body file that the next step needs was never created
+git push && cat > body.md <<'EOF' … EOF && gh pr edit 123 --body-file body.md
+```
+
+The general rule: never bundle a file write with a push or an API call. Keep
+state-changing steps separable, so a refusal costs you the step and not the
+scaffolding around it.
+
 ### When you already have the fix, lead with it
 
 Issue templates order evidence before solution — they are written for reports


### PR DESCRIPTION
Two rules from one session, both from failures that produced no error at the moment they happened.

**A probe command is read-only** (`references/advanced-git.md`). An exploratory one-liner comparing two revisions of a script carried `git stash -q`. It stashed the uncommitted work it was inspecting. Nothing failed — the probe printed its output and the tree was quietly a different tree, which is what makes this worth a rule rather than a note: a probe that reverts looks exactly like a probe that found nothing. Recovery was `git stash pop`, available only because the harness happened to print file-change notices. The section states the rule beside the existing selective-revert and selective-commit siblings, and gives the alternatives that make moving the tree unnecessary (`git show REV:path > /tmp/…`, a throwaway worktree).

**Write the PR body in its own call, after the push** (`references/pull-request-workflow.md`). A body citing a commit was composed before the push, so the hash was not yet resolvable on the remote and the call was refused. Because the push, the heredoc writing the body file, and `gh pr edit --body-file` were one shell invocation, the refusal discarded the heredoc — while the push had already run. The next command failed with `no such file or directory`, two steps downstream of the actual cause and reading like an unrelated problem.

The second half generalizes past PR bodies: a denied command loses every side effect it contained, and the parts that already ran do not roll back. So never bundle a file write with a push or an API call — keep state-changing steps separable, so a refusal costs the step rather than the scaffolding around it. The hash belongs in the body by lookup (`git rev-parse --short HEAD`), never typed from memory; a reader who follows a wrong hash finds nothing.

Docs only, no behaviour change.
