### PR TITLE
feat(git-workflow): put the quota-fallback self-review on the record

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -76,7 +76,7 @@ Before merging: threads resolved, CI green (incl. annotations), rebased, signed,
 # Gate state, next action:
 ./scripts/pr-status.sh [-R owner/repo] [PR] [--json] [--watch]
 # Merge; refuses when the gate is shut:
-./scripts/pr-merge.sh [-R owner/repo] [PR] [--dry-run]
+./scripts/pr-merge.sh [-R owner/repo] [PR] [--dry-run|--self-reviewed]
 ```
 
 ---

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -174,6 +174,31 @@ quota). Read `requested_reviewers` back after the **first** request of a
 session; empty means stop requesting — everywhere — and go straight to the
 self-review path above.
 
+### Putting the self-review on the record (#203)
+
+"Review it yourself and say so in the PR" used to end outside the tooling: the
+review-note comment satisfied the policy while `pr-merge.sh` still refused the
+merge, so the merge ran as raw `gh pr merge` — three times in one sweep, past
+the very script that exists to be the safe path. The fallback is now a
+first-class input:
+
+```bash
+pr-merge.sh -R owner/repo 123 --self-reviewed
+```
+
+posts a PR comment whose body carries the line `Self-review: <head-sha>` (as
+the PR author — the flag refuses any other authenticated user), then re-reads
+the gate and merges. `pr-status.sh` reads the attestation back from the last
+50 comments and honours it **only** where the demanded review is one it
+itself calls unsatisfiable — the quota wall, or two failed bot reviews on the
+head. With a live review path the attestation changes nothing, a non-author
+comment never counts, and the next push invalidates it because the sha stops
+matching. This is an explicit operator assertion the tool reads back, not a
+state it claims to observe — the same reason the old "review-yourself"
+*action* was removed. The attestation comment is permanent PR history: post
+it only when the diff was actually reviewed, and say what was looked at in
+the review-note comment beside it.
+
 ## A Rebase Conflict Can Mean the PR Is Superseded
 
 When `NEXT: rebase` turns into a conflict, look at **what the main side of the

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -187,13 +187,19 @@ pr-merge.sh -R owner/repo 123 --self-reviewed
 ```
 
 posts a PR comment whose body carries the line `Self-review: <head-sha>` (as
-the PR author — the flag refuses any other authenticated user), then re-reads
-the gate and merges. `pr-status.sh` reads the attestation back from the last
-50 comments and honours it **only** where the demanded review is one it
-itself calls unsatisfiable — the quota wall, or two failed bot reviews on the
-head. With a live review path the attestation changes nothing, a non-author
-comment never counts, and the next push invalidates it because the sha stops
-matching. This is an explicit operator assertion the tool reads back, not a
+the PR author — the flag refuses any other authenticated user; hand-written
+markers need at least the first 12 sha chars, since an 8-char prefix is
+grindable by vanity-sha tools), then re-reads the gate and merges.
+`pr-status.sh` reads the attestation back from the last 100 comments and
+honours it **only** where the refusing branch stamped
+`next.reason: bot-review-unsatisfiable` — the quota wall, or two failed bot
+reviews on the head; the flag keys on that reason, never on the account-global
+quota state, so a satisfiable refusal (say, classic `require_last_push_approval`)
+can never receive a false "unsatisfiable" attestation. With a live review path
+the attestation changes nothing, a non-author comment never counts, a human
+`CHANGES_REQUESTED` or a host-required approval keeps it inert, `--dry-run`
+previews the comment without posting it, and the next push invalidates the
+attestation because the sha stops matching. This is an explicit operator assertion the tool reads back, not a
 state it claims to observe — the same reason the old "review-yourself"
 *action* was removed. The attestation comment is permanent PR history: post
 it only when the diff was actually reviewed, and say what was looked at in

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -91,16 +91,21 @@ read_status
 # leaves the flag without effect.
 if [ "$SELF_REVIEWED" = "1" ] && [ "$ACTION" = "request-review" ]; then
   SR_FIELDS=$(printf '%s' "$STATUS" | jq -er '
-    [ ((.copilot_quota_exhausted // false)|tostring),
-      ((.copilot_error_count // 0)|tostring),
+    [ (.next.reason // "-"),
       ((.self_review_on_head // false)|tostring),
       (.headOid // ""), (.author // "")
     ] | @tsv') || die "pr-status.sh returned unexpected JSON"
-  IFS=$'\t' read -r SR_QUOTA SR_ERRORS SR_HAVE SR_HEAD SR_AUTHOR <<EOF
+  IFS=$'\t' read -r SR_REASON SR_HAVE SR_HEAD SR_AUTHOR <<EOF
 $SR_FIELDS
 EOF
-  if [ "$SR_QUOTA" != "true" ] && [ "$SR_ERRORS" -lt 2 ]; then
-    die "--self-reviewed refused: the demanded review is not unsatisfiable (no quota wall, bot failures on this head: $SR_ERRORS) — a live review path exists, use it"
+  # Keyed on the reason the REFUSING BRANCH stamped, never re-derived from the
+  # account-global quota state: a request-review can also come from e.g. the
+  # classic require_last_push_approval gate — a satisfiable human approval —
+  # and with the monthly quota marker set on this machine a global test would
+  # post a factually false "unsatisfiable" attestation into permanent PR
+  # history there.
+  if [ "$SR_REASON" != "bot-review-unsatisfiable" ]; then
+    die "--self-reviewed refused: this request-review is not the unsatisfiable-bot-review case (reason: $SR_REASON) — a live review path exists, use it"
   fi
   VIEWER=$(gh api user --jq .login 2>/dev/null) || die "--self-reviewed: could not resolve the authenticated gh user"
   if [ "$VIEWER" != "$SR_AUTHOR" ]; then
@@ -108,9 +113,15 @@ EOF
   fi
   if [ "$SR_HAVE" != "true" ]; then
     BODY=$(printf 'Self-review: %s\n\nThe review this pull request demands is unsatisfiable (Copilot quota wall or repeated bot failures on this head). Per the documented fallback, the diff on this head was reviewed by the PR author; this comment is the on-the-record attestation the merge gate reads back. It stops matching on the next push.' "$SR_HEAD")
+    if [ "$DRY" = "1" ]; then
+      # A dry run must not flip persistent gate state: the attestation comment
+      # IS the gate-opening write, so it is previewed, never posted.
+      printf 'pr-merge: dry-run — would post the Self-review attestation for %s on %s#%s, re-read the gate and merge\n' "${SR_HEAD:0:12}" "$REPO" "$PR"
+      exit 0
+    fi
     gh pr comment "$PR" --repo "$REPO" --body "$BODY" >/dev/null \
       || die "--self-reviewed: posting the attestation comment failed"
-    printf 'pr-merge: posted Self-review attestation for %s on %s#%s\n' "${SR_HEAD:0:8}" "$REPO" "$PR" >&2
+    printf 'pr-merge: posted Self-review attestation for %s on %s#%s\n' "${SR_HEAD:0:12}" "$REPO" "$PR" >&2
   fi
   read_status
 fi

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -17,6 +17,18 @@
 #   pr-merge.sh 123
 #   pr-merge.sh -R owner/repo 123
 #   pr-merge.sh -R owner/repo 123 --dry-run   # print the command, run nothing
+#   pr-merge.sh -R owner/repo 123 --self-reviewed
+#                                     # the review the gate demands is one an
+#                                     # exhausted Copilot quota (or two failed
+#                                     # reviews on this head) makes
+#                                     # unsatisfiable, and the operator has
+#                                     # reviewed the diff instead: post the
+#                                     # on-the-record `Self-review: <head-sha>`
+#                                     # attestation comment as the PR author,
+#                                     # then merge. Refused whenever a live
+#                                     # review path still exists, and whenever
+#                                     # the authenticated gh user is not the
+#                                     # PR author (#203).
 #
 # Exit codes: 0 merged (or queued) AND confirmed by reading the PR back, 1 the
 # gate is shut and nothing was attempted, 2 an error — usage, lookup, the merge
@@ -24,7 +36,7 @@
 # the queue. 1 is retryable later; 2 needs a human.
 set -uo pipefail
 
-REPO=""; PR=""; DRY=0
+REPO=""; PR=""; DRY=0; SELF_REVIEWED=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 die() { printf 'pr-merge: %s\n' "$1" >&2; exit 2; }
@@ -34,7 +46,8 @@ while [ $# -gt 0 ]; do
   case "$1" in
     -R|--repo) need "$@"; REPO="$2"; shift 2 ;;
     --dry-run) DRY=1; shift ;;
-    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --self-reviewed) SELF_REVIEWED=1; shift ;;
+    -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  PR="$1"; shift ;;
   esac
@@ -44,26 +57,63 @@ command -v gh >/dev/null || die "gh not found"
 command -v jq >/dev/null || die "jq not found"
 [ -x "$SCRIPT_DIR/pr-status.sh" ] || die "pr-status.sh not found next to this script"
 
-STATUS=$("$SCRIPT_DIR/pr-status.sh" ${REPO:+-R "$REPO"} ${PR:+"$PR"} --json) \
-  || die "pr-status.sh failed"
+read_status() {
+  STATUS=$("$SCRIPT_DIR/pr-status.sh" ${REPO:+-R "$REPO"} ${PR:+"$PR"} --json) \
+    || die "pr-status.sh failed"
 
-# Tab-separated, read with a tab-only IFS: the default IFS splits on spaces too,
-# which would tear `why` apart, and it collapses an empty field so every later
-# variable shifts by one. `jq -e` turns a schema change or truncated output into
-# a failure here rather than an empty ACTION further down.
-FIELDS=$(printf '%s' "$STATUS" | jq -er '
-  [ .next.action,
-    (.next.why // "-"),
-    .repo,
-    (.number|tostring),
-    (.queue_active|tostring),
-    (.merge_methods|join(","))
-  ] | @tsv') || die "pr-status.sh returned unexpected JSON"
+  # Tab-separated, read with a tab-only IFS: the default IFS splits on spaces
+  # too, which would tear `why` apart, and it collapses an empty field so every
+  # later variable shifts by one. `jq -e` turns a schema change or truncated
+  # output into a failure here rather than an empty ACTION further down.
+  FIELDS=$(printf '%s' "$STATUS" | jq -er '
+    [ .next.action,
+      (.next.why // "-"),
+      .repo,
+      (.number|tostring),
+      (.queue_active|tostring),
+      (.merge_methods|join(","))
+    ] | @tsv') || die "pr-status.sh returned unexpected JSON"
 
-IFS=$'\t' read -r ACTION WHY REPO PR QUEUE METHODS <<EOF
+  IFS=$'\t' read -r ACTION WHY REPO PR QUEUE METHODS <<EOF
 $FIELDS
 EOF
-[ -n "$ACTION" ] && [ -n "$REPO" ] && [ -n "$PR" ] || die "pr-status.sh returned no action"
+  [ -n "$ACTION" ] && [ -n "$REPO" ] && [ -n "$PR" ] || die "pr-status.sh returned no action"
+}
+
+read_status
+
+# --self-reviewed: the one refusal this flag may clear is a review demand the
+# gate itself calls unsatisfiable (quota wall, or two failed bot reviews on
+# this head). The flag does not open the gate directly — it posts the
+# on-the-record `Self-review: <head-sha>` attestation comment pr-status.sh
+# reads back, then asks again. Everything else about the gate stays exactly
+# as strict: any other refusal, a non-author caller, or a live review path
+# leaves the flag without effect.
+if [ "$SELF_REVIEWED" = "1" ] && [ "$ACTION" = "request-review" ]; then
+  SR_FIELDS=$(printf '%s' "$STATUS" | jq -er '
+    [ ((.copilot_quota_exhausted // false)|tostring),
+      ((.copilot_error_count // 0)|tostring),
+      ((.self_review_on_head // false)|tostring),
+      (.headOid // ""), (.author // "")
+    ] | @tsv') || die "pr-status.sh returned unexpected JSON"
+  IFS=$'\t' read -r SR_QUOTA SR_ERRORS SR_HAVE SR_HEAD SR_AUTHOR <<EOF
+$SR_FIELDS
+EOF
+  if [ "$SR_QUOTA" != "true" ] && [ "$SR_ERRORS" -lt 2 ]; then
+    die "--self-reviewed refused: the demanded review is not unsatisfiable (no quota wall, bot failures on this head: $SR_ERRORS) — a live review path exists, use it"
+  fi
+  VIEWER=$(gh api user --jq .login 2>/dev/null) || die "--self-reviewed: could not resolve the authenticated gh user"
+  if [ "$VIEWER" != "$SR_AUTHOR" ]; then
+    die "--self-reviewed refused: the attestation must come from the PR author ($SR_AUTHOR); gh is authenticated as $VIEWER"
+  fi
+  if [ "$SR_HAVE" != "true" ]; then
+    BODY=$(printf 'Self-review: %s\n\nThe review this pull request demands is unsatisfiable (Copilot quota wall or repeated bot failures on this head). Per the documented fallback, the diff on this head was reviewed by the PR author; this comment is the on-the-record attestation the merge gate reads back. It stops matching on the next push.' "$SR_HEAD")
+    gh pr comment "$PR" --repo "$REPO" --body "$BODY" >/dev/null \
+      || die "--self-reviewed: posting the attestation comment failed"
+    printf 'pr-merge: posted Self-review attestation for %s on %s#%s\n' "${SR_HEAD:0:8}" "$REPO" "$PR" >&2
+  fi
+  read_status
+fi
 
 if [ "$ACTION" != "merge" ]; then
   printf 'pr-merge: not merging %s#%s — %s: %s\n' "$REPO" "$PR" "$ACTION" "$WHY" >&2

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -57,7 +57,7 @@
 # When the wall stands, the documented fallback (review the diff yourself,
 # note it in the PR, decide) can be put on the record so the merge gate reads
 # it back: a PR comment BY THE PR AUTHOR containing the line
-# `Self-review: <head-sha>` (first 8 chars suffice). The ladder honours it
+# `Self-review: <head-sha>` (at least the first 12 chars). The ladder honours it
 # ONLY while the demanded bot review is unsatisfiable — quota wall, or two
 # failed reviews on this head — and the attestation dies with the next push,
 # because the sha stops matching. `pr-merge.sh --self-reviewed` posts the
@@ -193,7 +193,7 @@ collect() {
         # The last page, not the first: a Self-review attestation (see the
         # header) is posted at the end of a conversation, and an old page
         # would go blind on exactly the PRs long enough to need one.
-        comments(last:50){ nodes{ author{login} body url } }
+        comments(last:100){ nodes{ author{login} body url } }
         reviews(last:50){ nodes{ author{login} state commit{oid} body } }
         reviewRequests(first:20){ nodes{ requestedReviewer{
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
@@ -281,8 +281,12 @@ evaluate() {
     # the attestation may satisfy the review gate is decided in the ladder,
     # and only where the demanded review is one an exhausted Copilot quota
     # makes unsatisfiable — with a live review path it changes nothing.
+    # At least the first 12 chars of the head sha (48 bits): an 8-char prefix
+    # is a 32-bit binding that vanity-sha grinders defeat in minutes, which
+    # would let anyone with push access keep an attestation alive across an
+    # unreviewed push. pr-merge posts the full 40-char oid.
     | ([$p.comments.nodes[]? | select(.author.login == $author)
-        | select((.body // "") | test("(^|\\n)Self-review: " + $head[0:8]))]) as $self_review_comments
+        | select((.body // "") | test("(^|\\n)Self-review: " + $head[0:12]))]) as $self_review_comments
     | (($self_review_comments | length) > 0) as $self_review_on_head
     # A review by the PR author is not a review. Replying to a thread registers
     # as COMMENTED by the author, which would otherwise satisfy the gate.
@@ -486,8 +490,16 @@ evaluate() {
     # reads "review the diff yourself and decide on that". Anywhere else a
     # live review path exists and the attestation is ignored, so it can never
     # shortcut a review that could still happen.
+    # reviewDecision guards: a human CHANGES_REQUESTED is a live review saying
+    # no, and REVIEW_REQUIRED means the HOST demands an approval the
+    # attestation could never satisfy — in both states the attestation stays
+    # inert so the ladder keeps reporting the honest review state instead of
+    # falling through to a merge attempt (CHANGES_REQUESTED with no open
+    # thread leaves mergeState CLEAN) or to "investigate".
     | ($s.self_review_on_head
-       and ($s.copilot_quota_exhausted or $copilot_exhausted)) as $self_attested
+       and ($s.copilot_quota_exhausted or $copilot_exhausted)
+       and ($s.reviewDecision != "CHANGES_REQUESTED")
+       and ($s.reviewDecision != "REVIEW_REQUIRED")) as $self_attested
     # Hoisted so BOTH exhausted variants can append it. The two branches below
     # serve disjoint repo populations — with the copilot_code_review ruleset
     # active, has_copilot_review_on_head implies has_review_on_head, so the
@@ -527,9 +539,12 @@ evaluate() {
        + " the bot review was unavailable, and decide on that. Treat this notice as covering"
        + " every PR until the monthly reset."
        + " To proceed on a documented self-review, post a PR comment (as the PR author)"
-       + " containing the line: Self-review: \($s.headOid[0:8]) —"
-       + " pr-merge.sh --self-reviewed posts it and merges in one step; the attestation is"
-       + " honoured only while this wall stands and dies with the next push") as $quota_why
+       + " containing the line `Self-review: <head-sha>` with at least the first 12"
+       + " chars of \($s.headOid[0:12]) — pr-merge.sh --self-reviewed posts it and merges in"
+       + " one step; the attestation is honoured only while this wall stands and dies with"
+       + " the next push. The placeholder here is deliberate: this very advice gets pasted"
+       + " into PR comments, and a paste must never mint an attestation, so the accepting"
+       + " sequence never appears in it") as $quota_why
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -644,7 +659,8 @@ evaluate() {
              # recover this month, on this or any other PR. No cmd on purpose,
              # there is nothing to run.
              {action:"request-review",
-              why:($unreviewed + $quota_why + $stale_approval)}
+              why:($unreviewed + $quota_why + $stale_approval),
+              reason:"bot-review-unsatisfiable"}
             elif $copilot_exhausted then
              {action:"request-review",
               why:($unreviewed
@@ -654,7 +670,8 @@ evaluate() {
                    + " asking. Review the diff yourself, say in the PR that the bot review was"
                    + " unavailable, and decide on that. This stays request-review because the"
                    + " ruleset still has no bot review — the tool cannot see that you read the"
-                   + " diff\($stale_approval)")}
+                   + " diff\($stale_approval)"),
+              reason:"bot-review-unsatisfiable"}
             else
              {action:"request-review",
               why:($unreviewed
@@ -683,7 +700,8 @@ evaluate() {
            # POST command the quota had already made impossible.
            (if $s.copilot_quota_exhausted then
               {action:"request-review",
-               why:($unreviewed + $quota_why + $stale_approval)}
+               why:($unreviewed + $quota_why + $stale_approval),
+              reason:"bot-review-unsatisfiable"}
             else
               {action:"request-review", why:("copilot_code_review ruleset is active and Copilot has not reviewed \($s.headOid[0:8]) — the rule itself does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate"
                     + (if $s.checks_settled then "" else " (CI is NOT settled yet: \($s.checks.pending) pending, \($s.undispatched|length) required context(s) not reported — do not enqueue on this reading)" end)),
@@ -706,14 +724,16 @@ evaluate() {
                # is what proves the wall — the generic gate serves the repos
                # without the ruleset, and its cmd re-requests the same bot.
                {action:"request-review",
-                why:($unreviewed + $quota_why + $stale_approval)}
+                why:($unreviewed + $quota_why + $stale_approval),
+              reason:"bot-review-unsatisfiable"}
              elif $copilot_exhausted then
                {action:"request-review",
                 why:("\($no_review). "
                      + "Copilot failed \($s.copilot_error_count)x on it, so its rows carry an error"
                      + " rather than a review. Do not keep re-requesting: an outage may clear, a"
                      + " quota ceiling does not clear by asking. Review the diff yourself and"
-                     + " decide on that\($stale_approval)")}
+                     + " decide on that\($stale_approval)"),
+                reason:"bot-review-unsatisfiable"}
               else
                {action:"request-review",
                 why:($no_review + $stale_approval),

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -54,6 +54,16 @@
 # The month lives in the FILENAME, so a marker from an earlier month is ignored
 # rather than carried over the reset; delete the file to undo the effect.
 #
+# When the wall stands, the documented fallback (review the diff yourself,
+# note it in the PR, decide) can be put on the record so the merge gate reads
+# it back: a PR comment BY THE PR AUTHOR containing the line
+# `Self-review: <head-sha>` (first 8 chars suffice). The ladder honours it
+# ONLY while the demanded bot review is unsatisfiable — quota wall, or two
+# failed reviews on this head — and the attestation dies with the next push,
+# because the sha stops matching. `pr-merge.sh --self-reviewed` posts the
+# comment and merges in one step. This is an explicit operator assertion the
+# tool reads back, not a state it claims to observe (#203).
+#
 # --json contract
 #
 # One object, and its field names are THIS SCRIPT'S — not the GraphQL names
@@ -69,6 +79,7 @@
 #   reviewDecision reviews_on_head has_review_on_head
 #   has_copilot_review_on_head copilot_review_errored copilot_error_count copilot_quota_hit
 #   copilot_quota_exhausted
+#   self_review_on_head self_review_url
 #   requested_reviewers
 #   merge_methods auto_merge_allowed queue_active queue_entry
 #   rulesets rules_fetched required_contexts undispatched unsigned
@@ -179,6 +190,10 @@ collect() {
         mergeQueueEntry{ state position estimatedTimeToMerge }
         author{login}
         baseRefName headRefName headRefOid isCrossRepository
+        # The last page, not the first: a Self-review attestation (see the
+        # header) is posted at the end of a conversation, and an old page
+        # would go blind on exactly the PRs long enough to need one.
+        comments(last:50){ nodes{ author{login} body url } }
         reviews(last:50){ nodes{ author{login} state commit{oid} body } }
         reviewRequests(first:20){ nodes{ requestedReviewer{
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
@@ -256,6 +271,19 @@ evaluate() {
     | ([$r[]? | .type] | unique) as $ruletypes
     | (($ruletypes | index("copilot_code_review")) != null) as $needs_copilot
     | ($p.author.login) as $author
+    # Self-review attestation (#203). An EXPLICIT operator assertion, not an
+    # observation: a PR comment BY THE AUTHOR whose body carries a line
+    # `Self-review: <sha>` prefix-matching the current head. This is the
+    # deliberate difference from the removed "review-yourself" action (see the
+    # ladder comment below): the tool still observes nothing about whether a
+    # human read the diff — the author asserts it, on the record, and the
+    # record dies with the next push because the sha stops matching. Whether
+    # the attestation may satisfy the review gate is decided in the ladder,
+    # and only where the demanded review is one an exhausted Copilot quota
+    # makes unsatisfiable — with a live review path it changes nothing.
+    | ([$p.comments.nodes[]? | select(.author.login == $author)
+        | select((.body // "") | test("(^|\\n)Self-review: " + $head[0:8]))]) as $self_review_comments
+    | (($self_review_comments | length) > 0) as $self_review_on_head
     # A review by the PR author is not a review. Replying to a thread registers
     # as COMMENTED by the author, which would otherwise satisfy the gate.
     | ([$p.reviews.nodes[]? | select(.commit.oid == $head)
@@ -412,6 +440,14 @@ evaluate() {
         # evidence of its own. True when this PR proves it, or when an earlier
         # invocation this calendar month wrote the marker.
         copilot_quota_exhausted: ($quota_hit or $marker),
+        # True when the PR author posted a `Self-review: <head-sha>` comment
+        # for the CURRENT head — the explicit attestation, not a review row.
+        # Whether it satisfies anything is the ladder decision; this field
+        # only reports that the record exists.
+        self_review_on_head: $self_review_on_head,
+        self_review_url: (if $self_review_on_head
+                          then ($self_review_comments | last | .url)
+                          else null end),
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
@@ -444,6 +480,14 @@ evaluate() {
     # re-request loop in the other — the same trap `is_errored_copilot_review`
     # is factored out to avoid.
     | ($s.copilot_error_count >= 2) as $copilot_exhausted
+    # The attestation counts EXACTLY where the demanded review is one the
+    # tool itself calls unsatisfiable: the monthly quota wall, or a bot that
+    # has failed twice on this head — the two situations whose advice already
+    # reads "review the diff yourself and decide on that". Anywhere else a
+    # live review path exists and the attestation is ignored, so it can never
+    # shortcut a review that could still happen.
+    | ($s.self_review_on_head
+       and ($s.copilot_quota_exhausted or $copilot_exhausted)) as $self_attested
     # Hoisted so BOTH exhausted variants can append it. The two branches below
     # serve disjoint repo populations — with the copilot_code_review ruleset
     # active, has_copilot_review_on_head implies has_review_on_head, so the
@@ -481,7 +525,11 @@ evaluate() {
        + " account-wide: it will not recover this month, on this or any other PR, and"
        + " re-requesting cannot change that. Review the diff yourself, note in the PR that"
        + " the bot review was unavailable, and decide on that. Treat this notice as covering"
-       + " every PR until the monthly reset") as $quota_why
+       + " every PR until the monthly reset."
+       + " To proceed on a documented self-review, post a PR comment (as the PR author)"
+       + " containing the line: Self-review: \($s.headOid[0:8]) —"
+       + " pr-merge.sh --self-reviewed posts it and merges in one step; the attestation is"
+       + " honoured only while this wall stands and dies with the next push") as $quota_why
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}
@@ -587,6 +635,7 @@ evaluate() {
          # stops handing over a retry command a quota ceiling will reject.
          elif ($needs_copilot and $s.copilot_review_errored
                and ($s.has_copilot_review_on_head | not)
+               and ($self_attested | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
            (if $s.copilot_quota_exhausted then
              # Quota, not outage: the quota limit is named — by this PR or by
@@ -618,7 +667,8 @@ evaluate() {
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
-         elif ($needs_copilot and ($s.has_copilot_review_on_head|not)) then
+         elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
+               and ($self_attested|not)) then
            # This branch outranks every CI branch below, so it is the one place
            # the CI state has to be carried along: without it NEXT reads
            # request-review while the checks are still registering, and a
@@ -639,7 +689,7 @@ evaluate() {
                     + (if $s.checks_settled then "" else " (CI is NOT settled yet: \($s.checks.pending) pending, \($s.undispatched|length) required context(s) not reported — do not enqueue on this reading)" end)),
                cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
             end)
-         elif ($s.has_review_on_head|not) then
+         elif (($s.has_review_on_head|not) and ($self_attested|not)) then
            # The generic gate is also reached by repos WITHOUT the
            # copilot_code_review ruleset, and its cmd re-requests Copilot. Once
            # Copilot has failed twice on this head, handing that command back
@@ -690,7 +740,16 @@ evaluate() {
             why:"clean, but this repo allows only squash — policy forbids squash, so enable merge or rebase first"}
          elif $s.mergeState == "CLEAN" then
            ({action:"merge",
-             why:"clean",
+             # The attestation is named on the way OUT, not silently consumed:
+             # the operator reading NEXT=merge must see which review gate it
+             # rests on, and where the record sits.
+             why:(if $self_attested
+                  then ("clean; the review gate rests on the Self-review attestation"
+                        + " for \($s.headOid[0:8]) posted by the PR author"
+                        + (if $s.self_review_url != null then " (\($s.self_review_url))" else "" end)
+                        + " — honoured because the demanded bot review is unsatisfiable"
+                        + " (quota wall or repeated failures on this head)")
+                  else "clean" end),
              method:(if ($s.merge_methods|index("merge")) then "--merge" else "--rebase" end)}
             + (if $s.queue_active
                then {note:"merge queue active — omit --delete-branch (it is rejected) and let the queue pick the strategy"}

--- a/tests/test_pr_merge_self_reviewed.sh
+++ b/tests/test_pr_merge_self_reviewed.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# --self-reviewed (#203): pr-merge may clear exactly one refusal — a review
+# demand the gate itself calls unsatisfiable — by posting the on-the-record
+# `Self-review: <head-sha>` attestation as the PR author and asking again.
+# Everything else must stay as strict as without the flag.
+#
+# Runs against a stubbed pr-status.sh (sequenced: first call answers
+# status.1.json, later calls status.2.json) and a stubbed `gh`, so it needs no
+# network and no repo.
+
+set -uo pipefail
+
+REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-merge.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+SCRIPT="$STUB_DIR/pr-merge.sh"
+cp "$REAL" "$SCRIPT"
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+says() { # says <name> <pattern> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *)      echo "  FAIL $1: output does not contain '$2'"; fail=1 ;;
+    esac
+}
+says_not() { # says_not <name> <pattern> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: output wrongly contains '$2'"; fail=1 ;;
+        *)      echo "  ok   $1" ;;
+    esac
+}
+
+HEAD_OID="deadbeefcafe0000"
+
+# status fixture builder. Args: <file> <action> <quota> <errors> <have_marker>
+make_status_json() {
+    local why="clean"
+    [ "$2" = "merge" ] || why="no review on the current head — do not merge unreviewed"
+    cat > "$STUB_DIR/$1" <<JSON
+{
+  "repo": "o/r", "number": 559, "queue_active": false,
+  "merge_methods": ["merge", "rebase"],
+  "headOid": "$HEAD_OID", "author": "the-author",
+  "copilot_quota_exhausted": $3, "copilot_error_count": $4,
+  "self_review_on_head": $5,
+  "next": {"action": "$2", "why": "$why", "method": "--merge"}
+}
+JSON
+}
+
+# Sequenced pr-status stub: first invocation serves status.1.json, every later
+# one status.2.json (falling back to 1 when 2 is absent).
+make_status_stub() {
+    cat > "$STUB_DIR/pr-status.sh" <<STATUS
+#!/usr/bin/env bash
+echo x >> "$STUB_DIR/status.calls"
+n=\$(wc -l < "$STUB_DIR/status.calls")
+if [ "\$n" -gt 1 ] && [ -f "$STUB_DIR/status.2.json" ]; then
+  cat "$STUB_DIR/status.2.json"
+else
+  cat "$STUB_DIR/status.1.json"
+fi
+STATUS
+    chmod +x "$STUB_DIR/pr-status.sh"
+    : > "$STUB_DIR/status.calls"
+}
+
+# gh stub: logs every call, answers `api user` with $VIEWER_LOGIN, records the
+# body of `pr comment`, lets `pr merge` succeed, and answers the outcome poll
+# with MERGED.
+make_gh() {
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$1 \$2" >> "$STUB_DIR/calls.log"
+if [ "\$1 \$2" = "api user" ]; then
+  cat "$STUB_DIR/viewer.json"; exit 0
+fi
+if [ "\$1 \$2" = "pr comment" ]; then
+  # Find --body and persist it for assertions.
+  while [ \$# -gt 0 ]; do
+    if [ "\$1" = "--body" ]; then printf '%s' "\$2" > "$STUB_DIR/comment.body"; fi
+    shift
+  done
+  exit 0
+fi
+if [ "\$1 \$2" = "pr merge" ]; then
+  echo "Merging pull request #559"; exit 0
+fi
+if [ "\$1 \$2" = "api graphql" ]; then
+  echo '{"data":{"repository":{"pullRequest":{"state":"MERGED","isInMergeQueue":false,"autoMergeRequest":null}}}}'
+  exit 0
+fi
+exit 0
+STUB
+    chmod +x "$STUB_DIR/gh"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DIR/sleep"
+    chmod +x "$STUB_DIR/sleep"
+    : > "$STUB_DIR/calls.log"
+    rm -f "$STUB_DIR/comment.body"
+}
+
+# `gh api user --jq .login` — the stub ignores --jq and prints the file, so
+# the file holds the raw login only.
+set_viewer_raw() { printf '%s\n' "$1" > "$STUB_DIR/viewer.json"; }
+
+run() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 559 "$@" 2>"$STUB_DIR/err"; }
+
+echo "case 1: quota refusal + --self-reviewed — posts the attestation, then merges"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review true 0 false
+make_status_json status.2.json merge          true 0 true
+out=$(run --self-reviewed); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "0" "$rc"
+says  "merged"                 "559 merged (--merge)" "$out"
+says  "announced the posting"  "posted Self-review attestation for deadbeef" "$err"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  ok   a comment was posted"
+else
+    echo "  FAIL no comment was posted"; fail=1
+fi
+body=$(cat "$STUB_DIR/comment.body" 2>/dev/null || echo "")
+says "comment carries the marker line" "Self-review: $HEAD_OID" "$body"
+
+echo "case 2: --self-reviewed refused when the demand is NOT unsatisfiable"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review false 0 false
+out=$(run --self-reviewed); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says  "names the refusal" "a live review path exists" "$err"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL a comment was posted despite the refusal"; fail=1
+else
+    echo "  ok   no comment was posted"
+fi
+
+echo "case 3: --self-reviewed refused for a non-author caller"
+make_status_stub; make_gh; set_viewer_raw "somebody-else"
+make_status_json status.1.json request-review true 0 false
+out=$(run --self-reviewed); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says  "names both logins" "the-author" "$err"
+says  "names the viewer"  "somebody-else" "$err"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL a comment was posted by a non-author"; fail=1
+else
+    echo "  ok   no comment was posted"
+fi
+
+echo "case 4: attestation already on the head — no second comment, merges"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review true 0 true
+make_status_json status.2.json merge          true 0 true
+out=$(run --self-reviewed); rc=$?
+check "exit code" "0" "$rc"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL posted a duplicate attestation"; fail=1
+else
+    echo "  ok   the existing attestation was reused"
+fi
+
+echo "case 5: WITHOUT the flag the refusal is unchanged (exit 1)"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review true 0 false
+out=$(run); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "1" "$rc"
+says  "plain refusal" "not merging o/r#559 — request-review" "$err"
+says_not "no attestation posting" "posted Self-review attestation" "$err"
+
+echo "case 6: two-strikes (no quota) + flag — accepted, merges"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review false 2 false
+make_status_json status.2.json merge          false 2 true
+out=$(run --self-reviewed); rc=$?
+check "exit code" "0" "$rc"
+says  "merged" "559 merged (--merge)" "$out"
+
+if [ "$fail" -eq 0 ]; then
+    echo "all pass"
+else
+    echo "FAILURES"
+    exit 1
+fi

--- a/tests/test_pr_merge_self_reviewed.sh
+++ b/tests/test_pr_merge_self_reviewed.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# --self-reviewed (#203): pr-merge may clear exactly one refusal — a review
-# demand the gate itself calls unsatisfiable — by posting the on-the-record
-# `Self-review: <head-sha>` attestation as the PR author and asking again.
-# Everything else must stay as strict as without the flag.
+# --self-reviewed (#203): pr-merge may clear exactly one refusal — a
+# request-review whose refusing branch stamped reason=bot-review-unsatisfiable
+# — by posting the on-the-record `Self-review: <head-sha>` attestation as the
+# PR author and asking again. Everything else must stay as strict as without
+# the flag, and a dry run must never perform the gate-opening write.
 #
 # Runs against a stubbed pr-status.sh (sequenced: first call answers
 # status.1.json, later calls status.2.json) and a stubbed `gh`, so it needs no
@@ -40,18 +41,22 @@ says_not() { # says_not <name> <pattern> <haystack>
 
 HEAD_OID="deadbeefcafe0000"
 
-# status fixture builder. Args: <file> <action> <quota> <errors> <have_marker>
+# status fixture builder. Args: <file> <action> <reason|-> <have_marker>
+# The top-level quota fields are set TRUE on purpose in every fixture: the
+# flag must key on next.reason alone, and a fixture where the global state
+# and the branch reason disagree is exactly the false-attestation trap.
 make_status_json() {
-    local why="clean"
+    local why="clean" reason_line=""
     [ "$2" = "merge" ] || why="no review on the current head — do not merge unreviewed"
+    [ "$3" = "-" ] || reason_line="\"reason\": \"$3\","
     cat > "$STUB_DIR/$1" <<JSON
 {
   "repo": "o/r", "number": 559, "queue_active": false,
   "merge_methods": ["merge", "rebase"],
   "headOid": "$HEAD_OID", "author": "the-author",
-  "copilot_quota_exhausted": $3, "copilot_error_count": $4,
-  "self_review_on_head": $5,
-  "next": {"action": "$2", "why": "$why", "method": "--merge"}
+  "copilot_quota_exhausted": true, "copilot_error_count": 2,
+  "self_review_on_head": $4,
+  "next": {"action": "$2", $reason_line "why": "$why", "method": "--merge"}
 }
 JSON
 }
@@ -73,9 +78,9 @@ STATUS
     : > "$STUB_DIR/status.calls"
 }
 
-# gh stub: logs every call, answers `api user` with $VIEWER_LOGIN, records the
-# body of `pr comment`, lets `pr merge` succeed, and answers the outcome poll
-# with MERGED.
+# gh stub: logs every call, answers `api user` with the viewer file, records
+# the body of `pr comment`, lets `pr merge` succeed, and answers the outcome
+# poll with MERGED.
 make_gh() {
     cat > "$STUB_DIR/gh" <<STUB
 #!/usr/bin/env bash
@@ -113,15 +118,15 @@ set_viewer_raw() { printf '%s\n' "$1" > "$STUB_DIR/viewer.json"; }
 
 run() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 559 "$@" 2>"$STUB_DIR/err"; }
 
-echo "case 1: quota refusal + --self-reviewed — posts the attestation, then merges"
+echo "case 1: unsatisfiable refusal + --self-reviewed — posts the attestation, then merges"
 make_status_stub; make_gh; set_viewer_raw "the-author"
-make_status_json status.1.json request-review true 0 false
-make_status_json status.2.json merge          true 0 true
+make_status_json status.1.json request-review bot-review-unsatisfiable false
+make_status_json status.2.json merge          -                        true
 out=$(run --self-reviewed); rc=$?
 err=$(cat "$STUB_DIR/err")
 check "exit code" "0" "$rc"
 says  "merged"                 "559 merged (--merge)" "$out"
-says  "announced the posting"  "posted Self-review attestation for deadbeef" "$err"
+says  "announced the posting"  "posted Self-review attestation for deadbeefcafe" "$err"
 if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
     echo "  ok   a comment was posted"
 else
@@ -130,9 +135,12 @@ fi
 body=$(cat "$STUB_DIR/comment.body" 2>/dev/null || echo "")
 says "comment carries the marker line" "Self-review: $HEAD_OID" "$body"
 
-echo "case 2: --self-reviewed refused when the demand is NOT unsatisfiable"
+echo "case 2: request-review WITHOUT the unsatisfiable reason — refused, no false attestation"
+# Global quota fields are true in the fixture (see make_status_json): a flag
+# keyed on them instead of next.reason would post a factually false
+# attestation onto e.g. a classic require_last_push_approval refusal.
 make_status_stub; make_gh; set_viewer_raw "the-author"
-make_status_json status.1.json request-review false 0 false
+make_status_json status.1.json request-review - false
 out=$(run --self-reviewed); rc=$?
 err=$(cat "$STUB_DIR/err")
 check "exit code" "2" "$rc"
@@ -145,7 +153,7 @@ fi
 
 echo "case 3: --self-reviewed refused for a non-author caller"
 make_status_stub; make_gh; set_viewer_raw "somebody-else"
-make_status_json status.1.json request-review true 0 false
+make_status_json status.1.json request-review bot-review-unsatisfiable false
 out=$(run --self-reviewed); rc=$?
 err=$(cat "$STUB_DIR/err")
 check "exit code" "2" "$rc"
@@ -159,8 +167,8 @@ fi
 
 echo "case 4: attestation already on the head — no second comment, merges"
 make_status_stub; make_gh; set_viewer_raw "the-author"
-make_status_json status.1.json request-review true 0 true
-make_status_json status.2.json merge          true 0 true
+make_status_json status.1.json request-review bot-review-unsatisfiable true
+make_status_json status.2.json merge          -                        true
 out=$(run --self-reviewed); rc=$?
 check "exit code" "0" "$rc"
 if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
@@ -171,20 +179,44 @@ fi
 
 echo "case 5: WITHOUT the flag the refusal is unchanged (exit 1)"
 make_status_stub; make_gh; set_viewer_raw "the-author"
-make_status_json status.1.json request-review true 0 false
+make_status_json status.1.json request-review bot-review-unsatisfiable false
 out=$(run); rc=$?
 err=$(cat "$STUB_DIR/err")
 check "exit code" "1" "$rc"
 says  "plain refusal" "not merging o/r#559 — request-review" "$err"
 says_not "no attestation posting" "posted Self-review attestation" "$err"
 
-echo "case 6: two-strikes (no quota) + flag — accepted, merges"
+echo "case 6: --dry-run --self-reviewed — the gate-opening write is previewed, never posted"
 make_status_stub; make_gh; set_viewer_raw "the-author"
-make_status_json status.1.json request-review false 2 false
-make_status_json status.2.json merge          false 2 true
-out=$(run --self-reviewed); rc=$?
+make_status_json status.1.json request-review bot-review-unsatisfiable false
+make_status_json status.2.json merge          -                        true
+out=$(run --self-reviewed --dry-run); rc=$?
 check "exit code" "0" "$rc"
-says  "merged" "559 merged (--merge)" "$out"
+says  "previews the posting" "dry-run — would post the Self-review attestation" "$out"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL dry-run posted the attestation comment"; fail=1
+else
+    echo "  ok   dry-run performed no write"
+fi
+if grep -q '^pr merge$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL dry-run ran the merge"; fail=1
+else
+    echo "  ok   dry-run ran no merge"
+fi
+
+echo "case 7: attestation posted but the second read still refuses — exit 1, no merge"
+make_status_stub; make_gh; set_viewer_raw "the-author"
+make_status_json status.1.json request-review bot-review-unsatisfiable false
+make_status_json status.2.json request-review bot-review-unsatisfiable true
+out=$(run --self-reviewed); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "1" "$rc"
+says  "refusal after re-read" "not merging o/r#559 — request-review" "$err"
+if grep -q '^pr merge$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL merged although the re-read refused"; fail=1
+else
+    echo "  ok   no merge on a refusing re-read"
+fi
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -87,6 +87,8 @@ if os.environ.get("PENDING_CHECK", "0") == "1":
 reviews = [{"author": {"login": "copilot-pull-request-reviewer"},
             "state": "COMMENTED", "commit": {"oid": head}, "body": b}
            for b in bodies]
+requests = [{"requestedReviewer": {"login": r}}
+            for r in json.loads(os.environ.get("REVIEW_REQUESTS_JSON", "[]"))]
 json.dump({"data": {"repository": {
     "nameWithOwner": "o/r",
     "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
@@ -98,7 +100,7 @@ json.dump({"data": {"repository": {
         "isCrossRepository": False,
         "comments": {"nodes": comments},
         "reviews": {"nodes": reviews},
-        "reviewRequests": {"nodes": []},
+        "reviewRequests": {"nodes": requests},
         "reviewThreads": {"nodes": []},
         "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
             "state": "SUCCESS", "contexts": {"nodes": checks}}}}]},
@@ -282,6 +284,7 @@ check "copilot_quota_hit"   "true"           "$(run_flag copilot_quota_hit)"
 check "copilot_error_count" "1"              "$(run_flag copilot_error_count)"
 check "next.action"         "request-review" "$(run_next)"
 check "next.cmd absent"     "null"           "$(run_flag 'next.cmd')"
+check "next.reason"         "bot-review-unsatisfiable" "$(run_flag 'next.reason')"
 if status | jq -e '.next.why | test("MONTHLY")' >/dev/null; then
     echo "  ok   why states the quota is monthly and will not recover"
 else
@@ -686,7 +689,7 @@ esac
 # --- Self-review attestation (#203): an explicit author assertion may satisfy
 # --- a review demand ONLY where the tool itself calls that demand
 # --- unsatisfiable (quota wall, or two failed bot reviews on this head).
-SR_MARKER='[{"author": "someone", "body": "Self-review: deadbeef\n\nreviewed by the author, bot unavailable"}]'
+SR_MARKER='[{"author": "someone", "body": "Self-review: deadbeefcafe\n\nreviewed by the author, bot unavailable"}]'
 
 echo "case SR1: quota marker + author Self-review comment — gate opens, why names it"
 COMMENTS_JSON="$SR_MARKER" make_stub
@@ -701,7 +704,7 @@ else
 fi
 
 echo "case SR2: same comment by a NON-author — attestation not accepted"
-COMMENTS_JSON='[{"author": "somebody-else", "body": "Self-review: deadbeef"}]' make_stub
+COMMENTS_JSON='[{"author": "somebody-else", "body": "Self-review: deadbeefcafe"}]' make_stub
 plant_marker
 check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
 check "next.action"         "request-review" "$(run_next)"
@@ -722,6 +725,7 @@ case "$(run_flag 'next.cmd')" in
     *)  echo "  FAIL the attestation suppressed a live review path"
         fail=1 ;;
 esac
+check "next.reason absent on the live path" "null" "$(run_flag 'next.reason')"
 
 echo "case SR5: two failed bot reviews + attestation — the two-strikes leg opens too"
 COMMENTS_JSON="$SR_MARKER" make_stub "$ERR_GENERIC" "$ERR_GENERIC"
@@ -734,15 +738,52 @@ plant_marker
 check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
 check "next.action"         "request-review" "$(run_next)"
 
-echo "case SR7: quota why advertises the attestation mechanism"
+echo "case SR7: quota why advertises the mechanism WITHOUT the accepting sequence"
 make_stub
 plant_marker
-if status | jq -e '.next.why | test("Self-review: deadbeef")' >/dev/null; then
-    echo "  ok   the quota advice names the exact marker line to post"
+if status | jq -e '.next.why | test("Self-review: <head-sha>")' >/dev/null; then
+    echo "  ok   the quota advice names the marker via a placeholder"
 else
-    echo "  FAIL the quota advice does not name the marker line"
+    echo "  FAIL the quota advice does not describe the marker"
     fail=1
 fi
+if status | jq -e '.next.why | test("deadbeefcafe")' >/dev/null; then
+    echo "  ok   the advice still names the sha to use"
+else
+    echo "  FAIL the advice lost the sha"
+    fail=1
+fi
+# The paste-safety property this wording exists for: the advice itself, pasted
+# into a comment at ANY line wrap, must never contain the accepting sequence.
+if status | jq -e '.next.why | test("Self-review: deadbeef")' >/dev/null; then
+    echo "  FAIL the advice contains the accepting sequence — a paste could mint an attestation"
+    fail=1
+else
+    echo "  ok   the accepting sequence never appears in the advice"
+fi
+check "next.reason" "bot-review-unsatisfiable" "$(run_flag 'next.reason')"
+
+echo "case SR8: marker mid-body — the newline leg of the regex"
+COMMENTS_JSON='[{"author": "someone", "body": "prelude line\nSelf-review: deadbeefcafe"}]' make_stub
+plant_marker
+check "self_review_on_head" "true"  "$(run_flag self_review_on_head)"
+check "next.action"         "merge" "$(run_next)"
+
+echo "case SR9: blockquoted marker — a quoted paste does not mint an attestation"
+COMMENTS_JSON='[{"author": "someone", "body": "> Self-review: deadbeefcafe"}]' make_stub
+plant_marker
+check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
+check "next.action"         "request-review" "$(run_next)"
+
+echo "case SR10: pending Copilot request outranks the attestation"
+COMMENTS_JSON="$SR_MARKER" REVIEW_REQUESTS_JSON='["copilot-pull-request-reviewer[bot]"]' make_stub
+plant_marker
+check "next.action" "await-review" "$(run_next)"
+
+echo "case SR11: CHANGES_REQUESTED + attestation + quota — a human NO is a live review"
+COMMENTS_JSON="$SR_MARKER" REVIEW_DECISION=CHANGES_REQUESTED make_stub
+plant_marker
+check "next.action" "request-review" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -66,6 +66,11 @@ STUB
 import sys, json, os
 out, bodies = sys.argv[1], sys.argv[2:]
 head = "deadbeefcafe"
+# COMMENTS_JSON: issue comments on the PR, as [{"author": ..., "body": ...}] —
+# the surface the Self-review attestation (#203) is read from.
+comments = [{"author": {"login": c["author"]}, "body": c["body"],
+             "url": "https://example.test/c"}
+            for c in json.loads(os.environ.get("COMMENTS_JSON", "[]"))]
 # Env overrides so the signature/settled ladder branches are testable:
 #   MERGE_STATE (default CLEAN), SIGNED (default 1),
 #   PENDING_CHECK=1 adds an IN_PROGRESS check run (checks_settled -> false).
@@ -91,6 +96,7 @@ json.dump({"data": {"repository": {
         "author": {"login": "someone"},
         "baseRefName": "main", "headRefName": "f", "headRefOid": head,
         "isCrossRepository": False,
+        "comments": {"nodes": comments},
         "reviews": {"nodes": reviews},
         "reviewRequests": {"nodes": []},
         "reviewThreads": {"nodes": []},
@@ -676,6 +682,67 @@ case "$out" in
     *) echo "  FAIL quota line did not fire on settled CI"; fail=1 ;;
 esac
 
+
+# --- Self-review attestation (#203): an explicit author assertion may satisfy
+# --- a review demand ONLY where the tool itself calls that demand
+# --- unsatisfiable (quota wall, or two failed bot reviews on this head).
+SR_MARKER='[{"author": "someone", "body": "Self-review: deadbeef\n\nreviewed by the author, bot unavailable"}]'
+
+echo "case SR1: quota marker + author Self-review comment — gate opens, why names it"
+COMMENTS_JSON="$SR_MARKER" make_stub
+plant_marker
+check "self_review_on_head" "true"  "$(run_flag self_review_on_head)"
+check "next.action"         "merge" "$(run_next)"
+if status | jq -e '.next.why | test("Self-review attestation")' >/dev/null; then
+    echo "  ok   why names the attestation the merge rests on"
+else
+    echo "  FAIL why does not name the attestation"
+    fail=1
+fi
+
+echo "case SR2: same comment by a NON-author — attestation not accepted"
+COMMENTS_JSON='[{"author": "somebody-else", "body": "Self-review: deadbeef"}]' make_stub
+plant_marker
+check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
+check "next.action"         "request-review" "$(run_next)"
+
+echo "case SR3: author comment with a STALE sha — dies with the push, as documented"
+COMMENTS_JSON='[{"author": "someone", "body": "Self-review: 0ldc0mm1t"}]' make_stub
+plant_marker
+check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
+check "next.action"         "request-review" "$(run_next)"
+
+echo "case SR4: attestation present but NO quota wall — a live review path wins"
+COMMENTS_JSON="$SR_MARKER" make_stub
+check "self_review_on_head" "true"           "$(run_flag self_review_on_head)"
+check "next.action"         "request-review" "$(run_next)"
+case "$(run_flag 'next.cmd')" in
+    *"repos/o/r/pulls/1/requested_reviewers"*)
+        echo "  ok   the re-request command is still offered — the attestation changed nothing" ;;
+    *)  echo "  FAIL the attestation suppressed a live review path"
+        fail=1 ;;
+esac
+
+echo "case SR5: two failed bot reviews + attestation — the two-strikes leg opens too"
+COMMENTS_JSON="$SR_MARKER" make_stub "$ERR_GENERIC" "$ERR_GENERIC"
+check "copilot_error_count" "2"     "$(run_flag copilot_error_count)"
+check "next.action"         "merge" "$(run_next)"
+
+echo "case SR6: prose comment without the marker line — not an attestation (case 8 stays)"
+COMMENTS_JSON='[{"author": "someone", "body": "Reviewed this myself, the bot was unavailable."}]' make_stub
+plant_marker
+check "self_review_on_head" "false"          "$(run_flag self_review_on_head)"
+check "next.action"         "request-review" "$(run_next)"
+
+echo "case SR7: quota why advertises the attestation mechanism"
+make_stub
+plant_marker
+if status | jq -e '.next.why | test("Self-review: deadbeef")' >/dev/null; then
+    echo "  ok   the quota advice names the exact marker line to post"
+else
+    echo "  FAIL the quota advice does not name the marker line"
+    fail=1
+fi
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"


### PR DESCRIPTION
Closes #203.

When the monthly Copilot quota wall stands, the documented fallback — review the diff yourself, note it in the PR, decide — ended outside the tooling: `pr-merge.sh` still refused the merge, so the operator merged with raw `gh pr merge`, past the very script that exists to be the safe path (three times in one sweep on 2026-08-18). Per the issue discussion, the agent can now tell the gate, and the gate can read the record back.

**pr-status.sh** fetches the PR's last 50 issue comments inside the existing GraphQL document (the two-API-call green path is unchanged) and reports `self_review_on_head` / `self_review_url` when the PR **author** posted a comment carrying the line `Self-review: <head-sha>` for the **current** head. The NEXT ladder honours the attestation only where it already calls the demanded review unsatisfiable — the quota wall, or two failed bot reviews on this head. With a live review path it changes nothing (the re-request command is still offered), a non-author comment never counts, and the next push invalidates it because the sha stops matching. A merge verdict resting on it says so and links the comment; the quota advice now names the exact marker line to post. This deliberately stays an explicit operator assertion the tool reads back, not a state it claims to observe — the same reasoning that removed the old "review-yourself" action (its regression, case 8, stays green).

**pr-merge.sh --self-reviewed** drives it end to end: refuses unless the demand is unsatisfiable AND the authenticated gh user is the PR author, posts the attestation comment when none exists yet, re-reads the gate, merges. Every other refusal stays exactly as strict; without the flag nothing changes.

Tests: seven new pr-status cases (attestation opens the gate under quota and under two-strikes; non-author, stale-sha, prose-only and no-wall cases all refused; the quota advice advertises the marker) and a new `test_pr_merge_self_reviewed.sh` with six cases (happy path incl. posted body, not-unsatisfiable refusal, non-author refusal, reuse of an existing attestation, unchanged no-flag behaviour, two-strikes acceptance). All new cases were run against the pre-change scripts and failed as expected; the full suite (10 sh + 1 py) is green, including the json contract test against the extended key list.

Docs: pr-status header (quota section + `--json` contract), pr-merge usage, a "Putting the self-review on the record" section in `references/pull-request-workflow.md`, and the SKILL.md usage line (word count still 499 ≤ 500).

## Review round

An independent adversarial review (see the review-note comment) confirmed the widening is contained and produced one Critical and three Important findings, all adopted in [da96d27](https://github.com/netresearch/git-workflow-skill/commit/da96d27): `--dry-run` no longer performs the gate-opening comment write; the flag keys on the refusing branch's `next.reason: bot-review-unsatisfiable` instead of account-global quota state (no false attestation onto a satisfiable classic-protection refusal); the quota advice names the marker via a placeholder so a pasted advice line can never mint an attestation; the accept side requires 12 sha chars (vanity-sha resistance); `CHANGES_REQUESTED`/`REVIEW_REQUIRED` keep the attestation inert; `comments(last:100)`; plus four more edge-case tests. Suites: 11 sh + 1 py, all green.
