### PR TITLE
feat: upstream PR etiquette and a repo contribution preflight

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -2740,14 +2740,13 @@ issue is filler that pushes the reviewable part below the fold.
 
 ### Read the repository before the first artifact
 
-Not the README — the parts that encode rules no prose mentions. See
-`scripts/repo-contribution-preflight.sh`, which returns them in one call:
-contribution docs and the pages they link, issue and PR templates, the CI
-matrix that actually runs, `.gitattributes` export rules, and the pinned tool
-versions the pipeline uses.
+The README **and** the parts that encode rules no prose mentions. Reading only the second half is a trap of its own: a small repository often has no `CONTRIBUTING` at all and states the entire contract in the README — target branch, sign-off, the one command CI runs, whether issues are wanted before PRs. A preflight that skips it reports "no contribution docs" about a repository that documented everything.
 
-Discovering `CONTRIBUTING.rst` after three artifacts are already public means
-retrofitting them in view of the people you are contributing to.
+`scripts/repo-contribution-preflight.sh` returns all of it in one call: contribution and community-health docs (`CONTRIBUTING`, `CODE_OF_CONDUCT`, `SUPPORT`, `GOVERNANCE`, `SECURITY`, found case-insensitively under the root, `.github/` and `docs/`) with the pages they link, the README headings that carry rules, issue and PR templates including the `PULL_REQUEST_TEMPLATE/` directory form, the CI matrix that actually runs, `.gitattributes` export rules, and the pinned tool versions the pipeline uses.
+
+Two things it deliberately does not do. It never answers "there are no rules": when a repository has no contribution docs of its own, GitHub serves the owner's `.github` repository defaults instead, and those bind identically — so the script prints the query for that fallback rather than an absence it did not check. And it does not treat a missing heading as a missing rule: a three-line README can require a sign-off in running prose.
+
+Discovering `CONTRIBUTING.rst` after three artifacts are already public means retrofitting them in view of the people you are contributing to.
 
 ## Full PR Lifecycle Checklist
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -2681,6 +2681,74 @@ git push --force-with-lease origin <source-branch>
 Re-run the preflight afterwards: the rebase produces a new head SHA, so the
 pipeline result you looked at no longer applies.
 
+## Upstream and Community PRs: the Maintainer Is Watching Every Push
+
+In your own repository, churn is private until someone looks. In a foreign
+repository it is the contribution. A maintainer sees each force-push, each body
+rewrite and each comment as it happens, and a PR that changes shape three times
+costs them the attention they were going to spend reviewing it.
+
+### A maintainer's question is a question
+
+The single most expensive mistake in this shape: a maintainer asks whether
+something *should* also happen, and you build it.
+
+> *"`SKIP_LINKS` affects every `listContents()` call, not just the index lookup.
+> Should `FileCollector` also check `listSkippedLinks()` and warn when
+> non-empty?"*
+
+That was read as an instruction. The answer produced roughly 250 lines of
+diagnostics, a logger threaded into a collector, a path-traversal guard and a
+second directory walk — all of which were deleted two hours later when the
+right answer turned out to be "remove the half-wired diagnostic instead of
+wiring it everywhere". The maintainer had spotted an inconsistency, not
+specified a feature.
+
+Answer the question first, in a comment, with the evidence. Build only what the
+answer turns out to require. If a proposal is worth building, say what it would
+involve and let the maintainer choose — the reply costs one comment, the build
+costs a review cycle for both of you.
+
+### Land the minimal fix, propose the rest separately
+
+The fix that closes the reported bug and the improvement you noticed while
+reading the code are two contributions. Shipping them together means the bug
+fix waits for agreement on the improvement.
+
+The same branch above finished as two changed lines and one regression test.
+Everything else became its own issue and its own pull request, and each could
+then be accepted or rejected on its own merits. Split at the point where a
+maintainer could plausibly say "yes to this, no to that".
+
+### Batch the noise
+
+Three consecutive comments answering one review are three notifications and one
+readable answer. A body rewritten after every push is a diff nobody can follow.
+
+- Answer a review in **one** comment, after the work, not as you go.
+- Rewrite the body **once**, when the branch has its final shape.
+- Prefer one force-push over four: finish the local sequence, verify it, then push.
+- When you do rewrite history on a PR under review, say in a comment what
+  changed and why the previous discussion still applies — or no longer does.
+
+### Do not repeat in the PR what the issue already says
+
+If a PR references an issue that catalogues everything out of scope, the PR
+body does not need that catalogue. It needs what this diff does, why it is
+safe, how it was verified, and one line pointing at the issue. Restating the
+issue is filler that pushes the reviewable part below the fold.
+
+### Read the repository before the first artifact
+
+Not the README — the parts that encode rules no prose mentions. See
+`scripts/repo-contribution-preflight.sh`, which returns them in one call:
+contribution docs and the pages they link, issue and PR templates, the CI
+matrix that actually runs, `.gitattributes` export rules, and the pinned tool
+versions the pipeline uses.
+
+Discovering `CONTRIBUTING.rst` after three artifacts are already public means
+retrofitting them in view of the people you are contributing to.
+
 ## Full PR Lifecycle Checklist
 
 Complete end-to-end workflow for merging a PR, from CI verification through post-merge cleanup.

--- a/skills/git-workflow/scripts/repo-contribution-preflight.sh
+++ b/skills/git-workflow/scripts/repo-contribution-preflight.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # repo-contribution-preflight.sh — what this repository expects, before the first artifact.
 #
-# A repository's binding rules are rarely in its README. They sit in contribution
-# docs two links deep, in issue and PR templates, in .gitattributes export rules,
-# in the CI matrix, and in pinned tool versions. Each is one command; together they
-# are fifteen, which is why they get skipped and then discovered afterwards — with
-# three artifacts already public and a maintainer watching the retrofit.
+# A repository's binding rules are scattered: some in the README, some in
+# contribution docs two links deep, some in issue and PR templates, in
+# .gitattributes export rules, in the CI matrix, and in pinned tool versions.
+# Each is one command; together they are fifteen, which is why they get skipped
+# and then discovered afterwards — with three artifacts already public and a
+# maintainer watching the retrofit.
+#
+# The README is checked, not skipped. A small repository often states the whole
+# contract there — target branch, sign-off, the command CI runs — and never
+# writes a CONTRIBUTING at all. This script therefore reports the README
+# headings that carry rules, fence-aware, so a "# Contributing" line inside a
+# fenced example is not mistaken for a section.
 #
 # This returns all of it in one call. It reads; it changes nothing.
 #
@@ -26,7 +33,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --repo) REPO="${2:?--repo needs a directory}"; shift 2 ;;
         --section) SECTION="${2:?--section needs a name}"; shift 2 ;;
-        -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+        -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -42,17 +49,93 @@ none()  { printf '  (none)\n'; }
 if want docs; then
     head_ "Contribution docs"
     found=0
-    for f in CONTRIBUTING.md CONTRIBUTING.rst CONTRIBUTING.txt AGENTS.md CLAUDE.md \
-             .github/CONTRIBUTING.md docs/CONTRIBUTING.md CODE_OF_CONDUCT.md; do
+    # -iname rather than a fixed list: GitHub resolves these case-insensitively,
+    # so a repository carrying contributing.md is not one carrying nothing. The
+    # community-health set is here in full (SUPPORT, GOVERNANCE, SECURITY,
+    # CODE_OF_CONDUCT) because each can carry a rule that decides whether a
+    # contribution is accepted, and each is served from .github/ or docs/ just
+    # as often as from the root.
+    while IFS= read -r f; do
         [ -f "$f" ] || continue
         found=1
-        printf '  %-32s %s lines\n' "$f" "$(grep -c "" "$f")"
+        printf '  %-34s %s lines\n' "${f#./}" "$(grep -c "" "$f")"
         # A short CONTRIBUTING is usually a signpost: surface what it points at.
         # shellcheck disable=SC2016  # backticks and $ are regex syntax here, not shell
-        grep -oE '\[[^]]+\]\([^)]+\)|<https?://[^>]+>|`[^`]+\.(md|rst)`' "$f" 2>/dev/null \
-            | head -8 | sed 's/^/      -> /'
-    done
-    [ "$found" = 1 ] || none
+        links=$(grep -oE '\[[^]]+\]\([^)]+\)|<https?://[^>]+>|`[^`]+\.(md|rst)`' "$f" 2>/dev/null)
+        [ -n "$links" ] || continue
+        printf '%s\n' "$links" | head -8 | sed 's/^/      -> /'
+        n=$(printf '%s\n' "$links" | grep -c "")
+        # Never truncate silently: a capped list reads as a complete one.
+        [ "$n" -gt 8 ] && printf '      -> (%s more link(s) not shown — read the file)\n' "$((n - 8))"
+    done < <(find . -maxdepth 3 \
+                  \( -path ./.git -o -path ./node_modules -o -path ./vendor \) -prune -o \
+                  -type f \( -iname 'CONTRIBUTING*' -o -iname 'CODE_OF_CONDUCT*' \
+                             -o -iname 'SUPPORT*'    -o -iname 'GOVERNANCE*' \
+                             -o -iname 'SECURITY*'   -o -iname 'AGENTS.md' \
+                             -o -iname 'CLAUDE.md' \) -print 2>/dev/null | sort)
+    if [ "$found" = 0 ]; then
+        # Deliberately not "(none)". GitHub serves CONTRIBUTING, CODE_OF_CONDUCT,
+        # SUPPORT, SECURITY and both template kinds from the OWNER's .github
+        # repository whenever the repository itself has none, and those defaults
+        # bind exactly like local ones. This script does not go to the network,
+        # so it names the query rather than answering it: an unchecked fallback
+        # must never be reported as an absence.
+        printf '  none IN THIS REPOSITORY — the owner default may still supply them\n'
+        owner=$(git remote get-url origin 2>/dev/null \
+                | sed -E 's#^[^:]*://[^/]+/##; s#^[^:]*:##; s#/.*$##')
+        if [ -n "$owner" ]; then
+            printf '    -> gh api repos/%s/.github/contents --jq ".[].name"\n' "$owner"
+        else
+            printf '    -> gh api repos/<owner>/.github/contents --jq ".[].name"\n'
+        fi
+    fi
+fi
+
+# --- The README, which is where a small repository states the whole contract -
+if want docs; then
+    head_ "README sections that carry rules"
+    found=0
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        # Fence-aware on purpose: a heading regex is blind to code blocks, and a
+        # README demonstrating `## Contributing` inside a fenced example would
+        # otherwise be reported as having that section. Handles ATX (#) and the
+        # underline form used by RST and setext Markdown.
+        hits=$(awk '
+            function rulebearing(h) {
+                return tolower(h) ~ /contribut|pull request|merge request|code of conduct|commit|sign|coding|style|standard|develop|hacking|test|build|releas|governance|support|securit|licen[cs]e|getting started|setup|workflow|branch|patch/
+            }
+            /^[ \t]*(```|~~~)/ { fence = !fence; prev = ""; next }
+            fence { prev = $0; next }
+            /^[ \t]*#{1,6}[ \t]+/ {
+                h = $0
+                sub(/^[ \t]*#+[ \t]+/, "", h)
+                sub(/[ \t]*#*[ \t]*$/, "", h)
+                if (rulebearing(h)) printf "    %5d  %s\n", NR, h
+                prev = $0; next
+            }
+            /^[ \t]*[=~^*+#"-]{3,}[ \t]*$/ {
+                if (prev ~ /[^ \t]/) {
+                    h = prev
+                    gsub(/^[ \t]+|[ \t]+$/, "", h)
+                    if (rulebearing(h)) printf "    %5d  %s\n", NR - 1, h
+                }
+                prev = $0; next
+            }
+            { prev = $0 }
+        ' "$f")
+        [ -n "$hits" ] || continue
+        found=1
+        printf '  %s\n' "${f#./}"
+        printf '%s\n' "$hits"
+    done < <(find . -maxdepth 2 \
+                  \( -path ./.git -o -path ./node_modules -o -path ./vendor \) -prune -o \
+                  -type f -iname 'README*' -print 2>/dev/null | sort)
+    if [ "$found" = 0 ]; then
+        printf '  no rule-bearing headings in the README\n'
+        printf '    -> absence of a heading is not absence of a rule: a short README\n'
+        printf '       can state the target branch or the sign-off in running prose\n'
+    fi
 fi
 
 # --- Issue and PR templates -------------------------------------------------
@@ -66,9 +149,17 @@ if want templates; then
         # blank_issues_enabled: false means a template is mandatory.
         grep -E 'blank_issues_enabled' "$f" | sed 's/^/    /'
     done
+    # PULL_REQUEST_TEMPLATE has a DIRECTORY form for multiple templates, and
+    # both template kinds are also honoured at the root and under docs/ — a
+    # .github-only list reports "no template" for repositories that have one.
     for f in .github/ISSUE_TEMPLATE/*.yml .github/ISSUE_TEMPLATE/*.yaml \
              .github/ISSUE_TEMPLATE/*.md .github/PULL_REQUEST_TEMPLATE.md \
-             .github/pull_request_template.md .gitlab/issue_templates/* \
+             .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE/* \
+             .github/ISSUE_TEMPLATE.md .github/issue_template.md \
+             ISSUE_TEMPLATE.md PULL_REQUEST_TEMPLATE.md pull_request_template.md \
+             docs/ISSUE_TEMPLATE.md docs/PULL_REQUEST_TEMPLATE.md \
+             docs/pull_request_template.md \
+             .gitlab/issue_templates/* \
              .gitlab/merge_request_templates/*; do
         [ -f "$f" ] || continue
         case "$f" in */config.y*ml) continue ;; esac

--- a/skills/git-workflow/scripts/repo-contribution-preflight.sh
+++ b/skills/git-workflow/scripts/repo-contribution-preflight.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# repo-contribution-preflight.sh — what this repository expects, before the first artifact.
+#
+# A repository's binding rules are rarely in its README. They sit in contribution
+# docs two links deep, in issue and PR templates, in .gitattributes export rules,
+# in the CI matrix, and in pinned tool versions. Each is one command; together they
+# are fifteen, which is why they get skipped and then discovered afterwards — with
+# three artifacts already public and a maintainer watching the retrofit.
+#
+# This returns all of it in one call. It reads; it changes nothing.
+#
+# Usage: repo-contribution-preflight.sh [--repo <dir>] [--section <name>]
+#
+#   --repo <dir>      repository to inspect (default: current directory)
+#   --section <name>  one of: docs, templates, packaging, ci, tools
+#
+# Exit status is 0 whenever the repository could be read. Absence of a file is a
+# finding, not an error — "no CONTRIBUTING" is the answer to the question asked.
+
+set -uo pipefail
+
+REPO="."
+SECTION="all"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo) REPO="${2:?--repo needs a directory}"; shift 2 ;;
+        --section) SECTION="${2:?--section needs a name}"; shift 2 ;;
+        -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+cd "$REPO" || { echo "cannot enter $REPO" >&2; exit 2; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repository: $REPO" >&2; exit 2; }
+
+want() { [ "$SECTION" = "all" ] || [ "$SECTION" = "$1" ]; }
+head_() { printf '\n=== %s ===\n' "$1"; }
+none()  { printf '  (none)\n'; }
+
+# --- Contribution docs, and the pages they link -----------------------------
+if want docs; then
+    head_ "Contribution docs"
+    found=0
+    for f in CONTRIBUTING.md CONTRIBUTING.rst CONTRIBUTING.txt AGENTS.md CLAUDE.md \
+             .github/CONTRIBUTING.md docs/CONTRIBUTING.md CODE_OF_CONDUCT.md; do
+        [ -f "$f" ] || continue
+        found=1
+        printf '  %-32s %s lines\n' "$f" "$(grep -c "" "$f")"
+        # A short CONTRIBUTING is usually a signpost: surface what it points at.
+        # shellcheck disable=SC2016  # backticks and $ are regex syntax here, not shell
+        grep -oE '\[[^]]+\]\([^)]+\)|<https?://[^>]+>|`[^`]+\.(md|rst)`' "$f" 2>/dev/null \
+            | head -8 | sed 's/^/      -> /'
+    done
+    [ "$found" = 1 ] || none
+fi
+
+# --- Issue and PR templates -------------------------------------------------
+if want templates; then
+    head_ "Issue / PR templates"
+    found=0
+    for f in .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/config.yaml; do
+        [ -f "$f" ] || continue
+        found=1
+        printf '  %s\n' "$f"
+        # blank_issues_enabled: false means a template is mandatory.
+        grep -E 'blank_issues_enabled' "$f" | sed 's/^/    /'
+    done
+    for f in .github/ISSUE_TEMPLATE/*.yml .github/ISSUE_TEMPLATE/*.yaml \
+             .github/ISSUE_TEMPLATE/*.md .github/PULL_REQUEST_TEMPLATE.md \
+             .github/pull_request_template.md .gitlab/issue_templates/* \
+             .gitlab/merge_request_templates/*; do
+        [ -f "$f" ] || continue
+        case "$f" in */config.y*ml) continue ;; esac
+        found=1
+        printf '  %s\n' "$f"
+    done
+    [ "$found" = 1 ] || none
+fi
+
+# --- What a published package actually ships --------------------------------
+if want packaging; then
+    head_ "Packaging (what ships, what is a separate package)"
+
+    # export-ignore decides whether tests/docs exist in the published artifact.
+    found=0
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        ignored=$(grep -E 'export-ignore' "$f" | awk '{print $1}' | tr '\n' ' ')
+        [ -n "$ignored" ] || continue
+        found=1
+        printf '  %-44s export-ignore: %s\n' "$f" "$ignored"
+    done < <(printf '%s\n' .gitattributes packages/*/.gitattributes */.gitattributes 2>/dev/null)
+    [ "$found" = 1 ] || printf '  no export-ignore rules\n'
+
+    # Sub-splitting makes per-package metadata load-bearing rather than cosmetic.
+    splits=""
+    for f in .github/workflows/*split*; do
+        [ -f "$f" ] && splits="$splits $f"
+    done
+    if [ -n "$splits" ]; then
+        printf '  sub-split workflow present:%s\n' "$splits"
+        printf '    -> each packages/* is published on its own; its composer.json is the contract\n'
+    fi
+
+    # An empty production autoload at the root makes root-level checks blind.
+    if [ -f composer.json ] && command -v jq >/dev/null 2>&1; then
+        root_autoload=$(jq -r 'if (.autoload | type) == "object" then "present" else "ABSENT" end' composer.json)
+        printf '  root composer.json production autoload: %s\n' "$root_autoload"
+        [ "$root_autoload" = "ABSENT" ] && \
+            printf '    -> checks run at the root scan nothing; run them per package\n'
+    fi
+fi
+
+# --- The matrix that actually runs ------------------------------------------
+if want ci; then
+    head_ "CI"
+    found=0
+    for f in .github/workflows/*.y*ml .gitlab-ci.yml Jenkinsfile .concourse/*.y*ml; do
+        [ -f "$f" ] || continue
+        found=1
+        printf '  %s\n' "$f"
+        if command -v yq >/dev/null 2>&1; then
+            case "$f" in
+              *.yml|*.yaml)
+                # `//` not an if-expression: the go-yq lexer rejects inline `if` here.
+                yq -r '(.jobs // {}) | to_entries[] | "    " + .key + " -> " + (.value.uses // "inline")' \
+                    "$f" 2>/dev/null | head -12
+                ;;
+            esac
+        fi
+    done
+    [ "$found" = 1 ] || none
+    printf '\n  The matrix a reusable workflow expands to is only visible on a real run:\n'
+    printf '    gh api "repos/<owner>/<repo>/commits/<sha>/check-runs?per_page=100" --jq ".check_runs[].name" | sort -u\n'
+fi
+
+# --- Pinned tool versions ---------------------------------------------------
+if want tools; then
+    head_ "Pinned tools"
+    found=0
+    if [ -f .phive/phars.xml ]; then
+        found=1
+        printf '  .phive/phars.xml\n'
+        grep -oE 'name="[^"]+" version="[^"]+"( installed="[^"]+")?' .phive/phars.xml \
+            | sed 's/^/    /'
+        printf '    -> a pinned analyser can be older than the code it parses; an abort\n'
+        printf '       can print nothing and read exactly like a clean run\n'
+    fi
+    for f in .tool-versions .php-version .nvmrc rust-toolchain.toml; do
+        [ -f "$f" ] || continue
+        found=1
+        printf '  %-24s %s\n' "$f" "$(tr '\n' ' ' < "$f")"
+    done
+    [ "$found" = 1 ] || none
+fi
+
+printf '\n'
+exit 0

--- a/tests/test_repo_contribution_preflight.sh
+++ b/tests/test_repo_contribution_preflight.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Regression test: repo-contribution-preflight.sh must find the rules where
+# repositories actually put them.
+#
+# The script shipped answering only for CONTRIBUTING-style files in a fixed,
+# case-sensitive list, and its own header said a repository's rules "are rarely
+# in its README" — so a repository stating its whole contract in the README was
+# reported as having no contribution docs at all.
+#
+# Builds throwaway git repositories; needs no network and no fixtures on disk.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/repo-contribution-preflight.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+
+# A fresh repository per case: the script reads the working tree and a leftover
+# file from a previous case would answer for the next one.
+#
+# mktemp, not a counter: this runs inside $(newrepo), so any variable it
+# increments lives in the subshell and dies with it — a counter hands every case
+# the SAME directory, and the assertions that only check for an ABSENCE then
+# pass without ever exercising anything.
+newrepo() {
+    local r
+    r="$(mktemp -d "$TMP/repo.XXXXXX")"
+    git -C "$r" init -q
+    git -C "$r" remote add origin "https://github.com/some-owner/some-repo.git"
+    printf '%s\n' "$r"
+}
+
+run() { bash "$SCRIPT" --repo "$1" 2>&1; }
+
+# The output is captured into a variable and matched from there — NEVER piped
+# straight into `grep -q`. Under `set -o pipefail`, grep -q exits at the first
+# match and closes the pipe, the script dies of SIGPIPE (141), and the pipeline
+# reports failure BECAUSE the match succeeded. That inverts every assertion
+# here: a found string reads as FAIL and a missing one as ok, which is the
+# worst possible direction for a test to be wrong in.
+says() { # says <name> <repo> <regex>   — output must match
+    local out; out="$(run "$2")"
+    if printf '%s\n' "$out" | grep -qE "$3"; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: output does not match /$3/"
+        fail=1
+    fi
+}
+
+# Pulls ONE "=== <name> ===" block out of the report. Needed because `(none)`
+# is a correct answer for the CI and template sections in most fixtures, so a
+# grep over the whole output cannot say anything about the docs section alone.
+section_of() { # section_of <repo> <section title>
+    run "$1" | awk -v want="=== $2 ===" '
+        $0 ~ /^=== / { inside = ($0 == want); next }
+        inside { print }
+    '
+}
+
+silent() { # silent <name> <repo> <regex> — output must NOT match
+    local out; out="$(run "$2")"
+    if printf '%s\n' "$out" | grep -qE "$3"; then
+        echo "  FAIL $1: output unexpectedly matches /$3/"
+        fail=1
+    else
+        echo "  ok   $1"
+    fi
+}
+
+echo "case 1: rules live ONLY in the README — the sections must be reported"
+R=$(newrepo)
+cat > "$R/README.md" <<'MD'
+# some-repo
+
+A thing that does a thing.
+
+## Contributing
+
+Target the `develop` branch. Every commit needs a sign-off.
+
+## Running the tests
+
+    make test
+MD
+says "README Contributing heading found"   "$R" '^ +[0-9]+ +Contributing$'
+says "README test heading found"           "$R" 'Running the tests'
+# The absence claim is the dangerous half. `(none)` is a correct answer for the
+# CI and template sections here, so this asserts against the docs block ALONE:
+# it must not be a bare absence, and it must name what was not checked.
+docs1="$(section_of "$R" "Contribution docs")"
+if printf '%s\n' "$docs1" | grep -qE '^\s*\(none\)\s*$'; then
+    echo "  FAIL contribution-docs block claims a bare (none)"
+    fail=1
+else
+    echo "  ok   contribution-docs block avoids a bare (none)"
+fi
+
+echo "case 2: a heading inside a fenced block is an example, not a section"
+R=$(newrepo)
+cat > "$R/README.md" <<'MD'
+# some-repo
+
+Write your own README like this:
+
+```markdown
+## Contributing
+Please sign your commits.
+```
+
+That is all.
+MD
+silent "fenced ## Contributing not reported" "$R" '[0-9]+ +Contributing'
+says   "says no rule-bearing headings"       "$R" 'no rule-bearing headings'
+
+echo "case 3: lowercase contributing.md — GitHub matches case-insensitively"
+R=$(newrepo)
+printf '# contributing\n\nRun make lint.\n' > "$R/contributing.md"
+says "lowercase contributing.md found" "$R" 'contributing\.md +[0-9]+ lines'
+
+echo "case 4: community-health files under .github/ and docs/"
+R=$(newrepo)
+mkdir -p "$R/.github" "$R/docs"
+printf 'ask here\n'   > "$R/.github/SUPPORT.md"
+printf 'we govern\n'  > "$R/docs/GOVERNANCE.md"
+printf 'be nice\n'    > "$R/CODE_OF_CONDUCT.md"
+says "SUPPORT.md under .github found"  "$R" '\.github/SUPPORT\.md'
+says "GOVERNANCE.md under docs found"  "$R" 'docs/GOVERNANCE\.md'
+says "CODE_OF_CONDUCT.md found"        "$R" 'CODE_OF_CONDUCT\.md'
+
+echo "case 5: PULL_REQUEST_TEMPLATE as a DIRECTORY (multiple templates)"
+R=$(newrepo)
+mkdir -p "$R/.github/PULL_REQUEST_TEMPLATE"
+printf 'bugfix\n'  > "$R/.github/PULL_REQUEST_TEMPLATE/bug.md"
+printf 'feature\n' > "$R/.github/PULL_REQUEST_TEMPLATE/feature.md"
+says "directory-form PR templates listed" "$R" 'PULL_REQUEST_TEMPLATE/bug\.md'
+
+echo "case 6: no docs at all — must NOT claim absence, must name the org fallback"
+R=$(newrepo)
+printf 'nothing here\n' > "$R/notes.txt"
+# GitHub serves the owner .github repository defaults when the repo has none,
+# and this script never goes to the network — so it may only name the query.
+says   "names the owner fallback repo" "$R" 'some-owner/\.github'
+says   "prints a runnable query"       "$R" 'gh api repos/some-owner/\.github/contents'
+# The point of the whole branch: with nothing found locally, the block must
+# still not be the word "(none)" on its own, because the owner default was
+# never consulted.
+docs6="$(section_of "$R" "Contribution docs")"
+if printf '%s\n' "$docs6" | grep -qE '^\s*\(none\)\s*$'; then
+    echo "  FAIL contribution-docs block reports a bare (none) it did not verify"
+    fail=1
+else
+    echo "  ok   unchecked owner fallback is not reported as an absence"
+fi
+
+echo "case 7: README.rst with underline headings"
+R=$(newrepo)
+cat > "$R/README.rst" <<'RST'
+some-repo
+=========
+
+Prose.
+
+Contributing
+------------
+
+Sign off every commit.
+RST
+says "RST underline heading found" "$R" '[0-9]+ +Contributing'
+
+echo "case 8: a missing heading is not a missing rule — the caveat must be said"
+R=$(newrepo)
+printf 'Just a sentence, no headings at all.\n' > "$R/README.md"
+says "warns that prose can still carry a rule" "$R" 'absence of a heading is not absence of a rule'
+
+echo "case 9: --section docs still answers, other sections do not leak in"
+R=$(newrepo)
+printf '# some-repo\n\n## Contributing\n\nrules\n' > "$R/README.md"
+sec_out="$(bash "$SCRIPT" --repo "$R" --section docs 2>&1)"
+if printf '%s\n' "$sec_out" | grep -qE 'Contributing' \
+   && ! printf '%s\n' "$sec_out" | grep -qE '^=== CI ==='; then
+    echo "  ok   --section docs scopes correctly"
+else
+    echo "  FAIL --section docs did not scope correctly"
+    fail=1
+fi
+
+echo "case 10: exit status stays 0 for a repository with nothing to report"
+R=$(newrepo)
+if bash "$SCRIPT" --repo "$R" >/dev/null 2>&1; then
+    echo "  ok   empty repository exits 0"
+else
+    echo "  FAIL empty repository did not exit 0"
+    fail=1
+fi
+
+echo "case 11: --help still prints the whole header, including the README note"
+help_out="$(bash "$SCRIPT" --help 2>&1)"
+if printf '%s\n' "$help_out" | grep -qE 'README is checked, not skipped'; then
+    echo "  ok   --help covers the README behaviour"
+else
+    echo "  FAIL --help window no longer reaches the README note"
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "all pass"
+else
+    echo "FAILURES"
+    exit 1
+fi


### PR DESCRIPTION
Two additions from contributing to a foreign repository, where the process is visible to people who did not ask for it.

## The etiquette section

`references/pull-request-workflow.md` gains **Upstream and Community PRs: the Maintainer Is Watching Every Push**.

In your own repository churn is private until someone looks. In someone else's, every force-push and body rewrite is the contribution as the maintainer experiences it.

The most expensive item is the first one: **a maintainer's question is a question**. On the branch this came from, a maintainer asked whether a second call site should also warn about something. That was read as an instruction, and it produced roughly 250 lines of diagnostics, a logger threaded into a collector, a traversal guard and a second directory walk — all deleted two hours later, because the correct answer turned out to be to remove the half-wired diagnostic rather than wire it everywhere. They had pointed at an inconsistency, not specified a feature.

The rest: land the minimal fix on its own and propose the improvement separately, so a bug fix does not wait on agreement about something else; answer a review in one comment rather than three; rewrite the body once, when the branch has its final shape; and do not restate in a PR what its linked issue already catalogues, since that pushes the reviewable part below the fold.

## The preflight script

`scripts/repo-contribution-preflight.sh` returns a repository's binding rules in one call. It reads and changes nothing. Sections are selectable with `--section docs|templates|packaging|ci|tools`.

On the repository this came from, the rules were: a 19-line `CONTRIBUTING.rst` that is a signpost to two other pages, `blank_issues_enabled: false` (so an issue must use a template), `/tests export-ignore` in every package (so published packages ship no tests), a sub-split workflow (so each package's `composer.json` is a real contract), a root `composer.json` with no production `autoload` at all (so any check run at the root scans nothing), and a `composer-require-checker` pinned at 3.5.1 that aborts on current `symfony/config` and prints empty output indistinguishable from a pass.

Each of those is one command. Together they are fifteen, which is why they get skipped — and then discovered with three artifacts already public and a maintainer watching the retrofit.

## Second commit: what the review changed

The first version of this PR — script and prose together — rested on the premise that a repository's rules *"are rarely in the README"*, and the script consequently never opened one. For small repositories the opposite is the common case: no `CONTRIBUTING` at all, and the whole contract in the README. Target branch, sign-off, the command CI runs. Such a repository was reported as having **no contribution docs**, which is the one answer a preflight must never give wrongly.

- **The README is read**, and its rule-bearing headings reported — **fence-aware**, because a heading regex is blind to code blocks and a README demonstrating `## Contributing` inside a fenced example would otherwise be reported as having that section. ATX and the underline form used by RST and setext are both handled.
- **`(none)` was a claim the script had not checked.** GitHub serves `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SUPPORT`, `SECURITY` and both template kinds from the **owner's `.github` repository** when the repository itself has none, and those defaults bind identically. This script does not go to the network, so it now prints the query for that fallback instead of an absence it never verified.
- **Case-insensitive discovery** — `contributing.md` counts.
- **The full community-health set** — `SUPPORT`, `GOVERNANCE`, `SECURITY`, `CODE_OF_CONDUCT` — under the root, `.github/` and `docs/`.
- **The `PULL_REQUEST_TEMPLATE/` directory form**, plus the root and `docs/` locations for both template kinds.
- The link list **says how many it dropped** rather than truncating at eight silently.

The prose changed with it: the section no longer tells the reader to skip the README, and it now states the two things the script deliberately does not do — it never answers "there are no rules", and it does not treat a missing heading as a missing rule, since a three-line README can require a sign-off in running prose.

## Tests

New `tests/test_repo_contribution_preflight.sh` — 16 assertions over throwaway git repositories, no network, no fixtures on disk. **Every new assertion fails against the previous version of the script.** The three that still pass there are correct to: `CODE_OF_CONDUCT` was already in the old list, exit 0 always held, and the fenced-heading case passes vacuously because the old script read no README at all.

Two harness bugs surfaced while writing it, both of the kind that makes a test *lie* rather than fail, so they are named in the commit:

- A `newrepo` helper incrementing a counter handed every case the **same** directory, because it runs inside `$( )`. Absence assertions then pass without exercising anything.
- Piping the script into `grep -q` under `set -o pipefail` **inverts every assertion**: grep exits at the first match, the script dies of `SIGPIPE`, and the pipeline reports failure *because* the match succeeded. Output is captured into a variable and matched from there.

All 11 files in `tests/` pass. `verify-harness.sh --status`: Level 1 4/4, Level 2 3/3, Level 3 3/3. `shellcheck` clean on both files.

## One open question, unchanged from the first version

`SKILL.md` is at **499 of its 500-word cap**, so this script is still not in the `Verification` block where `verify-git-workflow.sh`, `pr-status.sh` and `pr-merge.sh` are listed. It is reachable only from the reference section. Listing it needs about fourteen words cut from somewhere else — a maintainer's call about what the entry point should carry, not one to make silently while fixing something adjacent.

_Assisted by claude-code:claude-fable-5 ([Session](https://claude.ai/code/session_0114KJz3vqq2WWfx4FUdmcss)) and claude-code:claude-opus-5 ([Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU))_
