### PR TITLE
feat(hooks): deny a blanket git add while untracked files are lying around

### DIFF
--- a/scripts/test_promoted_gates.py
+++ b/scripts/test_promoted_gates.py
@@ -68,6 +68,86 @@ class RunPoll(unittest.TestCase):
         self.assertEqual("", run_hook("gh run list --limit 5"))
 
 
+class BlanketGitAdd(unittest.TestCase):
+    """`git add -A` / `.` with untracked files lying around is denied; named paths pass."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self.repo = tempfile.mkdtemp()
+        subprocess.run(["git", "-C", self.repo, "init", "-q"], check=True)
+        Path(self.repo, "tracked.txt").write_text("a\n")
+        subprocess.run(["git", "-C", self.repo, "add", "tracked.txt"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                self.repo,
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-qm",
+                "init",
+            ],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def _run(self, command: str) -> str:
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": command},
+                    "cwd": self.repo,
+                }
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout
+
+    def test_add_all_with_an_untracked_file_is_denied(self) -> None:
+        Path(self.repo, "stray.txt").write_text("junk\n")
+        out = self._run("git add -A && git commit -m x")
+        self.assertEqual("deny", decision(out))
+        self.assertIn("stray.txt", out)
+
+    def test_add_dot_with_an_untracked_file_is_denied(self) -> None:
+        Path(self.repo, "var").mkdir()
+        Path(self.repo, "var", "cache.json").write_text("{}")
+        self.assertEqual("deny", decision(self._run("git add .")))
+
+    def test_add_all_on_a_clean_tree_passes(self) -> None:
+        self.assertNotEqual("deny", decision(self._run("git add -A")))
+
+    def test_add_all_with_only_tracked_edits_passes(self) -> None:
+        Path(self.repo, "tracked.txt").write_text("b\n")
+        self.assertNotEqual("deny", decision(self._run("git add -A")))
+
+    def test_named_path_beside_an_untracked_file_passes(self) -> None:
+        Path(self.repo, "stray.txt").write_text("junk\n")
+        self.assertNotEqual("deny", decision(self._run("git add tracked.txt")))
+
+    def test_named_directory_is_honoured(self) -> None:
+        Path(self.repo, "stray.txt").write_text("junk\n")
+        self.assertEqual("deny", decision(self._run(f"git -C {self.repo} add -A")))
+
+    def test_escape_hatch(self) -> None:
+        Path(self.repo, "stray.txt").write_text("junk\n")
+        self.assertNotEqual(
+            "deny", decision(self._run("DESTRUCTIVE_GIT_GATE_OFF=1 git add -A"))
+        )
+
+
 class GitReadDirectory(unittest.TestCase):
     """A measurement that does not say which repository it measured."""
 

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -7,6 +7,7 @@ Checks conventional commits, branch naming, and common mistakes.
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -568,6 +569,77 @@ GIT_MEASURING_READ = re.compile(
 CD_BEFORE = re.compile(r"(?:^|[|&;\n])\s*cd\s+\S")
 
 
+# --- blanket `git add` (promoted from a harness-local hook, 2026-08-20) ------
+# `git add -A` / `git add .` / `--all` stages every untracked, non-ignored file
+# in the tree. Named paths are the rule (CLAUDE.md, Git / PR / release); the
+# rule was written down and still violated: a var/ DI-container cache — 40k
+# lines across four files — rode into a commit and had to be amended and
+# force-pushed out again. The gate is state-aware and narrow: it looks at the
+# repository the command names (or the payload's cwd), and denies only when
+# untracked, non-ignored files exist — a clean tree and a named path pass.
+
+_GIT_ADD = re.compile(
+    r"(?:^|[\s;&|(])git\s+(?:-C\s+(?P<dir>\S+)\s+)?(?:-\S+\s+)*add\b(?P<rest>[^;&|\n]*)"
+)
+_WHOLE_TREE = {".", "./", ":/", "*", "'*'", '"*"', ":(top)"}
+
+
+def _untracked_files(repo_dir: str) -> list[str] | None:
+    """Untracked, non-ignored paths, or None when git could not be asked."""
+    try:
+        p = subprocess.run(
+            ["git", "-C", repo_dir, "status", "--porcelain", "--untracked-files=all"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if p.returncode != 0:
+        return None
+    return [line[3:] for line in p.stdout.splitlines() if line.startswith("?? ")]
+
+
+def blanket_git_add(cmd: str, cwd: str = "", untracked=_untracked_files) -> str | None:
+    """Deny `git add -A|--all|.` while untracked, non-ignored files exist."""
+    cmd = QUOTED_HEREDOC.sub(" ", cmd or "")
+    if "DESTRUCTIVE_GIT_GATE_OFF=1" in cmd:
+        return None
+    for m in _GIT_ADD.finditer(cmd):
+        rest = m.group("rest")
+        try:
+            tokens = shlex.split(rest)
+        except ValueError:
+            tokens = rest.split()
+        options = [t for t in tokens if t.startswith("-")]
+        operands = [t for t in tokens if not t.startswith("-")]
+        blanket = any(
+            o in {"-A", "--all", "--no-ignore-removal"} for o in options
+        ) or any(o in _WHOLE_TREE for o in operands)
+        if not blanket:
+            continue
+        repo_dir = m.group("dir") or cwd or os.getcwd()
+        if not os.path.isdir(repo_dir):
+            continue
+        strays = untracked(repo_dir)
+        if not strays:
+            continue
+        shown = "\n".join(f"  {line}" for line in strays[:12])
+        if len(strays) > 12:
+            shown += f"\n  … and {len(strays) - 12} more"
+        return (
+            "This would stage every untracked file in the tree, not only your change:\n\n"
+            f"  {m.group(0).strip()}\n\n"
+            f"Untracked, non-ignored files it would sweep in:\n\n{shown}\n\n"
+            "Name the paths you changed (`git add <file> <file>`), or ignore/remove the "
+            "strays first. A blanket add once carried 40k lines of DI-container cache into "
+            "a commit that then had to be amended and force-pushed (2026-08-20). If sweeping "
+            "them in really is the point, prefix the command with DESTRUCTIVE_GIT_GATE_OFF=1."
+        )
+    return None
+
+
 def git_read_without_named_dir(cmd: str) -> str | None:
     """Warn when a git measurement does not say which directory it measures."""
     m = GIT_MEASURING_READ.search(cmd or "")
@@ -689,6 +761,7 @@ def main():
         data = json.loads(input_data)
         command = read_command(data)
     except (json.JSONDecodeError, TypeError):
+        data = {}
         command = input_data
 
     if not command:
@@ -710,6 +783,12 @@ def main():
         if reason:
             deny(reason)
             return
+    # State-aware gate: needs the repository the command runs in.
+    cwd = data.get("cwd", "") if isinstance(data, dict) else ""
+    reason = blanket_git_add(command, cwd if isinstance(cwd, str) else "")
+    if reason:
+        deny(reason)
+        return
 
     # Advisory: the command is usually right, and only its author knows whether
     # the inherited directory or the poll shape was intended.

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -234,6 +234,10 @@ Verify both directions before relying on it: `python3 scripts/test_reference_wor
 builds a throwaway layout and checks that a commit in `main/` denies while
 `git -C <branch> commit` and a commit in a branch worktree pass.
 
+## Recipe 8: Deny a blanket `git add` while untracked files are lying around
+
+Shipped in `scripts/validate_git_command.py` as `blanket_git_add()` (PreToolUse, Bash). `git add -A`, `git add --all` and `git add .` stage every untracked, non-ignored file in the tree; the rule "add the paths you changed by name" was written down and still violated — a `var/` DI-container cache (40k lines) rode into a commit and had to be amended and force-pushed out (2026-08-20). The gate reads the repository the command names (`git -C <dir>`) or the payload's `cwd`, asks `git status --porcelain --untracked-files=all`, and denies only when `??` entries exist, listing them. A clean tree, a tree with only tracked edits, a named path and `git add -u` pass. Escape hatch, shared with the destructive-git gate: `DESTRUCTIVE_GIT_GATE_OFF=1`. The deny message is the specification (see below): it names the files, the rule, the incident and the way out.
+
 ## Anti-Patterns
 
 | Anti-pattern | Why wrong | Fix |


### PR DESCRIPTION
Promoted from the harness-local destructive-git gate: `git add -A|--all|.` is denied while untracked, non-ignored files exist in the repository the command names (or the payload cwd), listing them; clean tree, tracked-only edits, named paths and `-u` pass; `DESTRUCTIVE_GIT_GATE_OFF=1` escape. Incident: a var/ DI-container cache (40k lines) swept into a commit on 2026-08-20 and amended out. Seven cases against a real temp repo (46/46 tests), Recipe 8 in claude-code-hooks.md. No version bump here — release PR follows.