### PR TITLE
chore(release): v1.27.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Git workflow best practices with commit validation hooks",
   "repository": "https://github.com/netresearch/git-workflow-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.0"
+  version: "1.27.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Minor: new PreToolUse gate blanket_git_add in validate_git_command.py (#211). Three version surfaces bumped; check-version-parity passes.