### PR TITLE
fix(pr-status): an approval on the head satisfies the bot-review demand

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -195,7 +195,13 @@ honours it **only** where the refusing branch stamped
 `next.reason: bot-review-unsatisfiable` — the quota wall, or two failed bot
 reviews on the head; the flag keys on that reason, never on the account-global
 quota state, so a satisfiable refusal (say, classic `require_last_push_approval`)
-can never receive a false "unsatisfiable" attestation. With a live review path
+can never receive a false "unsatisfiable" attestation. That keying is necessary
+and was not sufficient: until #214 the refusing branch itself stamped the reason
+while an `APPROVED` review sat on the very same head, and seven approved PRs in
+one sweep got the attestation anyway. The bot branches now also require that no
+approval is on the current head — checked against the approval list rather than
+`has_review_on_head`, which a failed Copilot review satisfies by being an
+ordinary `COMMENTED` row. With a live review path
 the attestation changes nothing, a non-author comment never counts, a human
 `CHANGES_REQUESTED` or a host-required approval keeps it inert, `--dry-run`
 previews the comment without posting it, and the next push invalidates the

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -648,7 +648,22 @@ evaluate() {
          # forever. The tool cannot observe "a human read the diff", so it no
          # longer pretends to: it keeps reporting the honest state and only
          # stops handing over a retry command a quota ceiling will reject.
+         # $no_current_approval gates this branch and the two below it for the
+         # same reason the generic gate at the bottom tests has_review_on_head:
+         # the demand is the never-merge-unreviewed POLICY, as the ruleset
+         # branch says in its own why-text, and an APPROVED review on this head
+         # satisfies it. Without the guard a PR that github-actions has already
+         # approved still reports request-review, and pr-merge.sh
+         # --self-reviewed then writes "the review this pull request demands is
+         # unsatisfiable" into permanent PR history — a claim that is false
+         # while the approval sits on the same SHA (#214).
+         #
+         # Not has_review_on_head: that is true for any non-author review
+         # including a COMMENTED one, and the Copilot error rows ARE COMMENTED,
+         # so testing it would let a failed bot review satisfy the policy. The
+         # approval list is the one predicate an error row cannot answer.
          elif ($needs_copilot and $s.copilot_review_errored
+               and $no_current_approval
                and ($s.has_copilot_review_on_head | not)
                and ($self_attested | not)
                and (($s.requested_reviewers|map(test("copilot";"i"))|any) | not)) then
@@ -682,9 +697,11 @@ evaluate() {
               cmd:"gh api repos/\($s.repo)/pulls/\($s.number)/requested_reviewers -X POST -f \"reviewers[]=copilot-pull-request-reviewer[bot]\""}
             end)
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
+               and $no_current_approval
                and ($s.requested_reviewers|map(test("copilot";"i"))|any)) then
            {action:"await-review", why:"Copilot review already requested for \($s.headOid[0:8]) and not delivered yet — waiting, not re-requesting"}
          elif ($needs_copilot and ($s.has_copilot_review_on_head|not)
+               and $no_current_approval
                and ($self_attested|not)) then
            # This branch outranks every CI branch below, so it is the one place
            # the CI state has to be carried along: without it NEXT reads

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -481,15 +481,23 @@ done
 # "nothing reviewed this head" must not be asserted there unconditionally: with a
 # valid approval ON the head, claiming otherwise tells the operator to disregard
 # a current review.
-echo "case 13: two errors + valid APPROVED ON the head — no false claims"
+echo "case 13: two errors + valid APPROVED ON the head — the approval satisfies the policy"
 make_stub_reviews \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_QUOTA" \
   "a-human|APPROVED|LGTM on the current head"
-check "has_review_on_head" "true"           "$(run_flag has_review_on_head)"
-# Pin the branch too: asserting only absences passes vacuously if this stops
-# being the branch that answers.
-check "next.action"        "request-review" "$(run_next)"
+check "has_review_on_head" "true"  "$(run_flag has_review_on_head)"
+# This case asserted request-review until #214. Correcting the WHY was only half
+# of it: the action was wrong too. The ruleset branch states its own demand as
+# the never-merge-unreviewed POLICY rather than a host gate (a Copilot review
+# does not count toward required approvals, and GitHub reports CLEAN here) — and
+# an APPROVED review on this head satisfies that policy. While it answered
+# request-review, pr-merge.sh --self-reviewed took the unsatisfiable leg and
+# wrote "the review this pull request demands is unsatisfiable" into permanent
+# PR history on seven PRs that were approved at the time.
+check "next.action"        "merge" "$(run_next)"
+# The false-attestation trigger specifically: --self-reviewed keys on this.
+check "next.reason absent" "null"  "$(run_flag 'next.reason')"
 for phrase in "no review on the current head" "sits on an older commit"; do
     if status | jq -e --arg p "$phrase" '.next.why | test($p)' >/dev/null; then
         echo "  FAIL why falsely claims: $phrase"
@@ -535,12 +543,13 @@ fi
 # Case 15 uses two distinct logins, so no key collides and it cannot catch a
 # lossy per-author projection. The SAME reviewer approving the head and then
 # commenting on it is what collapses the state.
+# merge since #214, for the same reason as case 13 — the approval is on the head.
 echo "case 16: same reviewer approves the head then comments — no false staleness"
 make_stub_reviews \
   "copilot-pull-request-reviewer|COMMENTED|$ERR_GENERIC" \
   "a-human|APPROVED|LGTM on the current head" \
   "a-human|COMMENTED|one more thought on the same head"
-check "next.action" "request-review" "$(run_next)"
+check "next.action" "merge" "$(run_next)"
 if status | jq -e '.next.why | test("sits on an older commit")' >/dev/null; then
     echo "  FAIL claims staleness for an approval that is on the head"
     fail=1
@@ -577,6 +586,35 @@ make_stub_reviews \
   "a-human|APPROVED|fixed" \
   "a-human|CHANGES_REQUESTED|found something else"
 check "reviews_on_head[a-human]" "APPROVED+CHANGES_REQUESTED" "$(run_flag '"reviews_on_head"."a-human"')"
+
+# --- #214: an approval on the head must not be reported as an unsatisfiable ---
+# --- review demand. Cases 13/16 cover the errored-row leg; this is the leg  ---
+# --- the reported PRs actually took.                                       ---
+# netresearch/t3x-nr-llm#860 and six siblings: Copilot was never asked on the
+# head at all (no error row, copilot_review_errored false), the wall was known
+# only from the month marker, and github-actions had APPROVED the head minutes
+# earlier. The marker leg answered request-review with
+# reason=bot-review-unsatisfiable, which is the exact input pr-merge.sh
+# --self-reviewed keys on to post its permanent "unsatisfiable" attestation.
+echo "case 20: quota MARKER + no copilot row + APPROVED on head — no false dead end"
+make_stub_reviews "a-human|APPROVED|LGTM on the current head"
+plant_marker
+check "copilot_quota_exhausted" "true"  "$(run_flag copilot_quota_exhausted)"
+check "copilot_review_errored"  "false" "$(run_flag copilot_review_errored)"
+check "has_review_on_head"      "true"  "$(run_flag has_review_on_head)"
+check "next.action"             "merge" "$(run_next)"
+check "next.reason absent"      "null"  "$(run_flag 'next.reason')"
+
+# The twin that must NOT move: same marker, same missing copilot row, but the
+# approval sits on an older commit. Nothing has read this head, so the dead end
+# is real and the attestation path stays open. Without this, case 20 could be
+# satisfied by deleting the marker leg outright.
+echo "case 20b: same, but the approval is STALE — the dead end is still reported"
+make_stub_reviews "a-human|APPROVED|approved before the last push|older"
+plant_marker
+check "has_review_on_head" "false"                     "$(run_flag has_review_on_head)"
+check "next.action"        "request-review"            "$(run_next)"
+check "next.reason"        "bot-review-unsatisfiable"  "$(run_flag 'next.reason')"
 
 
 # --- Signature gate (#187): BLOCKED + unsigned + all green must name the ---


### PR DESCRIPTION
Closes #214.

## What was wrong

The three copilot branches in `pr-status.sh` asked whether a **Copilot** review had landed on the head, and never whether anything else had. So a PR that `github-actions` had already `APPROVED` on the current head still came out as `request-review` with `reason: bot-review-unsatisfiable` — which is precisely the input `pr-merge.sh --self-reviewed` keys on to post its permanent *"the review this pull request demands is unsatisfiable"* attestation.

Seven PRs merged in one sweep on `netresearch/t3x-nr-llm` carry that comment while showing `reviewDecision: APPROVED` at merge time. On [#860](https://github.com/netresearch/t3x-nr-llm/pull/860) the approval landed on the merge head at 11:26:07Z and the attestation was posted at 11:31:55Z — five minutes after the review the comment says could not be obtained.

## The fix, and why it is the branch's own position

The bot branches now additionally require that **no approval sits on the current head**. That is what the ruleset branch already says it is enforcing, in its own `why` text: the rule *"does not block the merge, since a Copilot review does not count toward required approvals; the demand here is the never-merge-unreviewed policy, not a host gate"*. An approval on the head satisfies that policy. GitHub reports `CLEAN` in this state — a gate that genuinely blocks arrives as `BLOCKED` and is answered further up the ladder, ahead of these branches.

Gated on the **approval list**, not on `has_review_on_head`. The latter is true for any non-author review including a `COMMENTED` one, and a failed Copilot review *is* an ordinary `COMMENTED` row — testing it would let the error satisfy the policy it exists to enforce. This is not an argument I am asking you to take on trust: substituting `($s.has_review_on_head|not)` for the new predicate makes **case 15** fail (`staleness warning dropped by a COMMENTED reply`), which is how I checked it.

## Tests

Cases 13 and 16 asserted `request-review` for exactly this state. An earlier pass corrected the *wording* those branches emit and left the *action* — that is the half #214 is about, so both now assert `merge`, each with the reason recorded at the case.

New case 20 covers the leg the reported PRs actually took: the wall known only from the month marker, **no Copilot row on the head at all**, an approval present. New case 20b is its twin — same marker, same missing row, approval on an *older* commit — so the dead end is still reported where it is real, and case 20 cannot be satisfied by deleting the marker leg.

Both new cases fail without the script change:

```
case 20: quota MARKER + no copilot row + APPROVED on head — no false dead end
  FAIL next.action: expected 'merge', got 'request-review'
  FAIL next.reason absent: expected 'null', got 'bot-review-unsatisfiable'
```

Full suite with the fix: `118 ok, 0 FAIL` in `test_pr_status_errored_review.sh`; the four sibling `test_pr_*` files unchanged at `3/32/24/24 ok`. `verify-harness.sh --status`: Level 1 4/4, Level 2 3/3, Level 3 3/3. Pre-commit passed (shellcheck, markdownlint, whitespace, EOF, merge-conflict).

## Documentation

`references/pull-request-workflow.md` claimed a satisfiable refusal *"can never receive a false unsatisfiable attestation"*. The keying on the stamped reason is necessary and was not sufficient, since the refusing branch itself stamped it here — the passage now says so and names the added condition.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
