### PR TITLE
fix(preflight): an extension decides what is a contribution document

### DIFF
--- a/skills/git-workflow/scripts/repo-contribution-preflight.sh
+++ b/skills/git-workflow/scripts/repo-contribution-preflight.sh
@@ -57,6 +57,16 @@ if want docs; then
     # as often as from the root.
     while IFS= read -r f; do
         [ -f "$f" ] || continue
+        # The name globs are deliberately broad, so the extension decides. Without
+        # this, -iname SECURITY* claims .github/workflows/security.yml as a
+        # community-health document -- found by running the section against this
+        # repository, which has exactly that workflow. An extensionless
+        # CONTRIBUTING or SECURITY is a real document and stays.
+        case "${f##*/}" in
+            *.md|*.markdown|*.rst|*.txt|*.adoc) ;;
+            *.*) continue ;;
+            *) ;;
+        esac
         found=1
         printf '  %-34s %s lines\n' "${f#./}" "$(grep -c "" "$f")"
         # A short CONTRIBUTING is usually a signpost: surface what it points at.

--- a/tests/test_repo_contribution_preflight.sh
+++ b/tests/test_repo_contribution_preflight.sh
@@ -196,6 +196,29 @@ else
     fail=1
 fi
 
+# The name globs are broad by design, so nothing but the extension stops a CI
+# workflow from being claimed as a community-health document. Found by running
+# the section against the skill repository itself, which has security.yml --
+# no fixture here had a workflow, so the suite was blind to it.
+echo "case 12: .github/workflows/security.yml is a workflow, not a SECURITY doc"
+R=$(newrepo)
+mkdir -p "$R/.github/workflows"
+printf 'name: security\non: push\n' > "$R/.github/workflows/security.yml"
+docs12="$(section_of "$R" "Contribution docs")"
+if printf '%s\n' "$docs12" | grep -qE 'workflows/security\.yml'; then
+    echo "  FAIL a CI workflow was listed as a contribution document"
+    fail=1
+else
+    echo "  ok   workflow not claimed as a contribution document"
+fi
+
+# The other direction, so the filter cannot be tightened into dropping real
+# files: GitHub honours an extensionless CONTRIBUTING, and so must this.
+echo "case 13: an extensionless CONTRIBUTING is still a document"
+R=$(newrepo)
+printf 'Target develop. Sign your commits.\n' > "$R/CONTRIBUTING"
+says "extensionless CONTRIBUTING found" "$R" 'CONTRIBUTING +[0-9]+ lines'
+
 echo "case 11: --help still prints the whole header, including the README note"
 help_out="$(bash "$SCRIPT" --help 2>&1)"
 if printf '%s\n' "$help_out" | grep -qE 'README is checked, not skipped'; then


### PR DESCRIPTION
Follow-up to #210, fixing a false positive I introduced there.

## The defect

The community-health globs are broad on purpose — `SECURITY*` has to match `SECURITY.md`, `SECURITY.rst` and a bare `SECURITY` — and nothing else constrained them. Run against **this repository**, the docs section answered:

```
=== Contribution docs ===
  .github/workflows/security.yml     52 lines
  AGENTS.md                          71 lines
```

A CI workflow is not a community-health document. The consequence is worse than a stray line: this section exists so a contributor can see what a repository expects, and an entry that looks like a `SECURITY` policy but is a workflow sends them to read the wrong file — or, if it is the only match, makes a repository with no security policy look like it has one.

## The fix

The extension decides. `.md`, `.markdown`, `.rst`, `.txt` and `.adoc` are documents; anything else carrying an extension is not. A file with **no** extension stays a document, because GitHub honours a bare `CONTRIBUTING` or `SECURITY` and dropping those would trade one false answer for another.

## How it was found, which is the part worth keeping

Not by the test suite — by running `--section docs` against the skill repository itself, immediately after #210 merged. No fixture had a workflow file, so the suite was structurally blind to the entire class while reporting `all pass`. The tests were written against the cases I had thought of, and this was not one of them.

- **Case 12** puts a `.github/workflows/security.yml` in a fixture and asserts it is not listed. It fails against the previous version:

  ```
  FAIL a CI workflow was listed as a contribution document
  ```

- **Case 13** pins the opposite direction — an extensionless `CONTRIBUTING` must still be found — so the filter cannot later be tightened into dropping the form it exists to preserve. This one passes against both versions, by design: it guards the fix rather than proving it.

## Verification

All 11 files in `tests/` pass (18 assertions in the preflight suite now). `verify-harness.sh --status`: Level 1 4/4, Level 2 3/3, Level 3 3/3. `shellcheck` clean. The docs section against this repository now reports `AGENTS.md` alone, which is correct — the repository has no `CONTRIBUTING`, `SECURITY` or `SUPPORT` document of its own.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
