### PR TITLE
feat(scripts): every script answers --version and names its own path

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -211,6 +211,20 @@ state it claims to observe — the same reason the old "review-yourself"
 it only when the diff was actually reviewed, and say what was looked at in
 the review-note comment beside it.
 
+### Before believing a script cannot do something: ask which copy is running
+
+Every script in `scripts/` answers `--version`, and prints the resolved path beneath it:
+
+```
+$ pr-merge.sh --version
+pr-merge.sh 1.27.0
+path: /home/you/.agents/skills/git-workflow/scripts/pr-merge.sh
+```
+
+The version is read from the `SKILL.md` next to the script, never from a checkout elsewhere, so a cached copy reports the number it was packaged with. The path is there because the number alone is not enough: two installations on one machine declared the same version while shipping different scripts, and `--self-reviewed` existed in only one of them (#209). The flag was reported as missing — which reads exactly like a feature that was never built — and about a dozen PRs were merged by hand instead of through the attestation flow.
+
+So when a documented flag is rejected as unknown, that is a question about the installation before it is a question about the tool. `--version` needs no repository, no network and no `gh`: it is the one thing that must still answer when everything else is broken.
+
 ## A Rebase Conflict Can Mean the PR Is Superseded
 
 When `NEXT: rebase` turns into a conflict, look at **what the main side of the

--- a/skills/git-workflow/scripts/merge-gate.sh
+++ b/skills/git-workflow/scripts/merge-gate.sh
@@ -8,6 +8,39 @@
 # mergeStateStatus==CLEAN already encodes GitHub's required-approval gate. Gating
 # on reviewDecision!=APPROVED would false-positive-block every such repo.
 set -euo pipefail
+
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
+[ "${1:-}" = "--version" ] && { skill_version; exit 0; }
 CMD=$(jq -r '.tool_input.command // ""')
 
 # Parse the PR id from the three `gh pr merge` reference forms. Flags before

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -36,6 +36,37 @@
 # the queue. 1 is retryable later; 2 needs a human.
 set -uo pipefail
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
 REPO=""; PR=""; DRY=0; SELF_REVIEWED=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -47,6 +78,7 @@ while [ $# -gt 0 ]; do
     -R|--repo) need "$@"; REPO="$2"; shift 2 ;;
     --dry-run) DRY=1; shift ;;
     --self-reviewed) SELF_REVIEWED=1; shift ;;
+    --version) skill_version; exit 0 ;;
     -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  PR="$1"; shift ;;

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -97,6 +97,37 @@
 # object drift apart, in either direction.
 set -uo pipefail
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
 REPO=""; PR=""; JSON=0; WATCH=0; INTERVAL=20; MAXWAIT=3600; IGNORE=""
 
 # Every action the watch loop returns on. --ignore-action accepts exactly
@@ -130,6 +161,7 @@ while [ $# -gt 0 ]; do
     # Prints the whole leading comment block rather than a fixed line range:
     # a hard-coded range silently truncates --help the moment the header
     # grows, which is how a documented contract stops being visible.
+    --version) skill_version; exit 0 ;;
     -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  PR="$1"; shift ;;

--- a/skills/git-workflow/scripts/repo-contribution-preflight.sh
+++ b/skills/git-workflow/scripts/repo-contribution-preflight.sh
@@ -26,6 +26,37 @@
 
 set -uo pipefail
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
 REPO="."
 SECTION="all"
 
@@ -33,6 +64,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --repo) REPO="${2:?--repo needs a directory}"; shift 2 ;;
         --section) SECTION="${2:?--section needs a name}"; shift 2 ;;
+        --version) skill_version; exit 0 ;;
         -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac

--- a/skills/git-workflow/scripts/signing-preflight.sh
+++ b/skills/git-workflow/scripts/signing-preflight.sh
@@ -32,6 +32,37 @@
 
 set -uo pipefail
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
 CONFIG_ONLY=0
 QUIET=0
 REPO_DIR="."
@@ -43,6 +74,7 @@ while [ $# -gt 0 ]; do
         --check-commit) shift; CHECK_REV="${1:-}" ;;
         --quiet)        QUIET=1 ;;
         --repo)         shift; REPO_DIR="${1:-}" ;;
+        --version) skill_version; exit 0 ;;
         -h|--help)      sed -n '2,30p' "$0"; exit 0 ;;
         *)              echo "unknown argument: $1" >&2; exit 3 ;;
     esac

--- a/skills/git-workflow/scripts/spec-cleanup-guard.sh
+++ b/skills/git-workflow/scripts/spec-cleanup-guard.sh
@@ -26,6 +26,37 @@
 # baked-in defaults below apply.
 set -euo pipefail
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
 DEFAULT_PATHS=(
   "docs/superpowers/**"
   "claudedocs/**"
@@ -213,5 +244,6 @@ case "${1:-}" in
   --selftest) selftest ;;
   --dry-run) run 1 ;;
   "") run 0 ;;
+  --version) skill_version; exit 0 ;;
   *) die "unknown argument: $1 (try --help)";;
 esac

--- a/skills/git-workflow/scripts/verify-git-workflow.sh
+++ b/skills/git-workflow/scripts/verify-git-workflow.sh
@@ -4,6 +4,39 @@
 
 set -e
 
+# --version answers "which copy am I running" without diffing installations.
+# Two installations can declare the SAME number while shipping different
+# scripts (netresearch/git-workflow-skill#209 measured exactly that, and the
+# missing flag read as a missing feature for a dozen merges). So the resolved
+# path is printed beside the version: the number says what the copy claims to
+# be, the path says which file actually answered.
+#
+# The version is read from the SKILL.md NEXT TO the script, never from a
+# checkout elsewhere -- a cached copy must report the number it was packaged
+# with, or the answer is worse than none. \042 and \047 are the quote
+# characters by octal code, so this awk program contains no quote of its own
+# to terminate the single-quoted string it lives in.
+skill_version() {
+    local here skill v
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill="$here/../SKILL.md"
+    v="unknown"
+    if [ -f "$skill" ]; then
+        v="$(awk '/^[ \t]*version:/ {
+                 s = $0
+                 sub(/^[ \t]*version:[ \t]*/, "", s)
+                 gsub(/[\042\047]/, "", s)
+                 gsub(/[ \t\r]+$/, "", s)
+                 if (s != "") { print s; exit }
+             }' "$skill" 2>/dev/null)" || v=""
+        [ -n "$v" ] || v="unknown"
+    fi
+    printf '%s %s\n' "$(basename "${BASH_SOURCE[0]}")" "$v"
+    printf 'path: %s/%s\n' "$here" "$(basename "${BASH_SOURCE[0]}")"
+}
+
+[ "${1:-}" = "--version" ] && { skill_version; exit 0; }
+
 REPO_DIR="${1:-.}"
 ERRORS=0
 WARNINGS=0

--- a/tests/test_scripts_report_version.sh
+++ b/tests/test_scripts_report_version.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression test: every script answers --version, and answers for ITSELF.
+#
+# #209 measured two installations on one machine declaring the same version
+# while shipping different scripts, so `--self-reviewed` existed in one and not
+# the other. Nothing could be asked "which copy am I running" — a missing flag
+# read as a missing feature, and roughly a dozen PRs were merged by hand.
+#
+# A release fixes one instance of that. --version makes the next one visible.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS="$ROOT/skills/git-workflow/scripts"
+SKILL="$ROOT/skills/git-workflow/SKILL.md"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+# Read straight from the frontmatter, independently of the awk the scripts use
+# — a test that reuses the implementation cannot catch the implementation being
+# wrong. python3 is already a dependency of this repository (conflict-marker-gate.py).
+declared() {
+    python3 - "$1" <<'PY'
+import re, sys
+for line in open(sys.argv[1], encoding="utf-8"):
+    m = re.match(r'\s*version:\s*"?([^"\n]+?)"?\s*$', line)
+    if m:
+        print(m.group(1))
+        break
+PY
+}
+
+VERSION="$(declared "$SKILL")"
+echo "SKILL.md declares: $VERSION"
+if [ -z "$VERSION" ]; then
+    echo "  FAIL could not read a version from $SKILL"
+    exit 1
+fi
+
+echo "case 1: every script answers --version with that number"
+for s in "$SCRIPTS"/*.sh; do
+    name="$(basename "$s")"
+    out="$(bash "$s" --version 2>&1 || true)"
+    check "$name reports the version" "$name $VERSION" "$(printf '%s\n' "$out" | head -1)"
+done
+
+echo "case 2: every script names the file that answered"
+for s in "$SCRIPTS"/*.sh; do
+    name="$(basename "$s")"
+    out="$(bash "$s" --version 2>&1 || true)"
+    check "$name names its own path" "path: $SCRIPTS/$name" "$(printf '%s\n' "$out" | sed -n 2p)"
+done
+
+# The property the whole flag exists for. A second copy on the same machine must
+# report ITS OWN number — reading the version from a checkout elsewhere, or from
+# a git tag, would reproduce exactly the confusion #209 documented.
+echo "case 3: a second copy reports its own SKILL.md, not this one"
+COPY="$TMP/other/skills/git-workflow"
+mkdir -p "$COPY"
+cp -r "$SCRIPTS" "$COPY/scripts"
+printf -- '---\nname: git-workflow\nversion: "0.0.1-other"\n---\n\n# other\n' > "$COPY/SKILL.md"
+for name in pr-status.sh pr-merge.sh verify-git-workflow.sh; do
+    out="$(bash "$COPY/scripts/$name" --version 2>&1 || true)"
+    check "$name reports the copy version"  "$name 0.0.1-other"          "$(printf '%s\n' "$out" | head -1)"
+    check "$name reports the copy path"     "path: $COPY/scripts/$name"  "$(printf '%s\n' "$out" | sed -n 2p)"
+done
+
+# A copy whose SKILL.md was not shipped must still answer. Refusing here would
+# make the flag useless in exactly the broken installation it exists to identify.
+echo "case 4: no SKILL.md beside the script — answers 'unknown', does not fail"
+BARE="$TMP/bare/skills/git-workflow"
+mkdir -p "$BARE"
+cp -r "$SCRIPTS" "$BARE/scripts"
+out="$(bash "$BARE/scripts/pr-status.sh" --version 2>&1)"; rc=$?
+check "exit status is 0"        "0"                     "$rc"
+check "version reads unknown"   "pr-status.sh unknown"  "$(printf '%s\n' "$out" | head -1)"
+
+# --version must not need the network, a git repository, or a PR. It is the one
+# question that has to be answerable when everything else is broken.
+echo "case 5: answers outside a git repository, with no gh on PATH"
+NOGIT="$TMP/nogit"
+mkdir -p "$NOGIT"
+if ( cd "$NOGIT" && PATH="/usr/bin:/bin" bash "$SCRIPTS/pr-status.sh" --version >/dev/null 2>&1 ); then
+    echo "  ok   answers with a stripped PATH outside a repository"
+else
+    echo "  FAIL --version needs a repository or gh on PATH"
+    fail=1
+fi
+
+echo "case 6: the number matches .claude-plugin/plugin.json"
+PLUGIN="$ROOT/.claude-plugin/plugin.json"
+if [ -f "$PLUGIN" ]; then
+    check "plugin.json agrees" "$VERSION" "$(jq -r '.version' "$PLUGIN")"
+else
+    echo "  skip no .claude-plugin/plugin.json"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "all pass"
+else
+    echo "FAILURES"
+    exit 1
+fi


### PR DESCRIPTION
Refs #209 — the half of it that a release cannot close.

## What #209 measured, and what is still open

Two installations of this skill on one machine declared **the same version** while shipping different scripts, so `--self-reviewed` existed in one and not the other. Both numbers were truthful; `main` had simply moved without a bump.

The release fixed that instance. It did not make the next one visible, and #209 named the gap itself: *"a consumer cannot currently answer 'which copy am I running'."* The cost was measured, not assumed — a rejected flag reads exactly like a feature that was never built, and roughly a dozen PRs were merged by hand instead of through the attestation flow.

## What this adds

All seven scripts answer `--version`:

```
$ pr-merge.sh --version
pr-merge.sh 1.27.0
path: /home/you/.agents/skills/git-workflow/scripts/pr-merge.sh
```

The **path is not decoration**. The number alone is exactly what failed in #209, where both copies said `1.26.0` and meant different things. The path is what tells two installations apart.

The version is read from the `SKILL.md` **next to the script** — never from a checkout elsewhere, never from a git tag. A cached copy has to report the number it was packaged with, or the answer is worse than no answer.

It works where nothing else does: no repository, no network, no `gh` on `PATH`. And with no `SKILL.md` beside it, it reports `unknown` and exits 0 rather than failing — refusing there would make the flag useless in precisely the broken installation it exists to identify.

## Why seven copies of a function instead of a shared library

A sourced helper has one failure mode this feature cannot afford: if the library is missing from an installation, the version query itself breaks — at the exact moment it is needed. There is no `source` anywhere in this repository today, so a self-contained function also matches what is already there. Seven copies of a short function is the cheaper trade.

## Tests

`tests/test_scripts_report_version.sh`, 25 assertions.

**Case 3 is the property the flag exists for**: a second copy in another directory, with its own `SKILL.md` declaring `0.0.1-other`, must report *its own* number and *its own* path. An implementation that read the version from the repository root, or from `git describe`, would pass cases 1 and 2 and reproduce #209 exactly.

The suite reads the frontmatter with `python3` rather than reusing the `awk` the scripts use — a test that reuses the implementation cannot catch the implementation being wrong.

Case 4 pins the missing-`SKILL.md` behaviour, case 5 the stripped-`PATH`-outside-a-repository case, case 6 agreement with `.claude-plugin/plugin.json`.

**Every assertion fails against the previous scripts — 0 of 25 pass:**

```
FAIL merge-gate.sh reports the version: expected 'merge-gate.sh 1.27.0', got ''
FAIL pr-merge.sh reports the version: got 'pr-merge: unknown flag: --version'
FAIL pr-status.sh reports the version: got 'pr-status: unknown flag: --version'
```

All 12 files in `tests/` pass. `verify-harness.sh --status`: Level 1 4/4, Level 2 3/3, Level 3 3/3. `shellcheck` clean on all seven scripts and the new test.

## Not in this PR

`SKILL.md` is untouched and still at its 500-word cap, so the scripts remain unlisted there. That is #216 and needs a decision about what the entry point should carry, not a drive-by edit while fixing something adjacent. `--version` is documented in `references/pull-request-workflow.md` instead.

This also does not bump any version. There are now unreleased commits on `main` again, including the merge-gate fix from #215 — which is #209's other half, and a maintainer's call about when to cut a release.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
