### PR TITLE
chore(release): 1.28.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "git-workflow",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Git workflow best practices with commit validation hooks",
-  "repository": "https://github.com/netresearch/git-workflow-skill",
-  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de"
   },
+  "repository": "https://github.com/netresearch/git-workflow-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "skills": [
     "./skills/git-workflow"
   ],

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.27.0"
+  version: "1.28.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Bumps the three version surfaces (`plugin.json`, `.claude-plugin/plugin.json`, `skills/git-workflow/SKILL.md`) via `bump-version.sh`. Six commits since v1.27.0.

**A minor**, not a patch: two features landed.

**What ships**

- **Every script answers `--version` and names the path that answered** (#218, closes the second half of #209). The path is the point, not the number: in the measurement behind #209 two installations both reported `1.26.0` truthfully while shipping different scripts, and a missing flag on the older copy read as a missing feature for a dozen merges. The version is read from the `SKILL.md` *beside* the script, so a cached copy reports what it was packaged with rather than what some other checkout says. A copy shipped without its `SKILL.md` answers `unknown` instead of failing — refusing there would make the flag useless in exactly the broken installation it exists to identify.
- **Upstream PR etiquette and a repo contribution preflight script**, with two follow-up fixes: an extension decides what counts as a contribution document, and the preflight reads the README instead of reporting an unchecked absence.
- **`pr-status.sh`: an approval on the head satisfies the bot-review demand.** The three Copilot branches asked whether *Copilot* had reviewed and never whether anyone had, so a pull request carrying a valid approval on its head still got `reason=bot-review-unsatisfiable` — and `--self-reviewed` then wrote *"the review this pull request demands is unsatisfiable"* into permanent history. Thirteen pull requests across two sessions carry that sentence untruthfully; six of mine have since been edited to append a correction naming the approval that existed.
- **A dismissed stacked approval has a cheaper recovery than `update-branch`** — documented in the pull-request workflow reference.

**Verified rather than assumed:** with the bump applied, `pr-status.sh --version` in this worktree reports `1.28.0` and the resolved path beneath it, so the new flag reads the number this release actually sets.

After merge: signed tag `v1.28.0` on the merge commit.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
