### PR TITLE
fix(scripts): --help stops at the header instead of a hand-kept line number

### DIFF
--- a/skills/git-workflow/scripts/repo-contribution-preflight.sh
+++ b/skills/git-workflow/scripts/repo-contribution-preflight.sh
@@ -65,7 +65,7 @@ while [ $# -gt 0 ]; do
         --repo) REPO="${2:?--repo needs a directory}"; shift 2 ;;
         --section) SECTION="${2:?--section needs a name}"; shift 2 ;;
         --version) skill_version; exit 0 ;;
-        -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+        -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done

--- a/skills/git-workflow/scripts/signing-preflight.sh
+++ b/skills/git-workflow/scripts/signing-preflight.sh
@@ -75,7 +75,7 @@ while [ $# -gt 0 ]; do
         --quiet)        QUIET=1 ;;
         --repo)         shift; REPO_DIR="${1:-}" ;;
         --version) skill_version; exit 0 ;;
-        -h|--help)      sed -n '2,30p' "$0"; exit 0 ;;
+        -h|--help)      awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
         *)              echo "unknown argument: $1" >&2; exit 3 ;;
     esac
     shift

--- a/tests/test_scripts_report_version.sh
+++ b/tests/test_scripts_report_version.sh
@@ -105,6 +105,27 @@ else
     echo "  skip no .claude-plugin/plugin.json"
 fi
 
+# --help is the sibling surface of --version: both are the script describing
+# itself, and both broke the same way. Two scripts printed their header with a
+# FIXED line range, which drifts the moment anything is inserted above the
+# code. One had grown three lines past its header and printed "set -uo
+# pipefail" as documentation; the other had fallen one line short and silently
+# dropped the last line of its own usage. A range that has to be maintained by
+# hand will drift again, so both now stop at the first non-comment line -- and
+# this asserts the property rather than the line count, which would just be a
+# second number to maintain.
+echo "case 7: no --help output contains source code"
+for s in "$SCRIPTS"/*.sh; do
+    name="$(basename "$s")"
+    # Only the scripts that HANDLE --help; the others treat it as a positional
+    # argument and answering for them would assert on unrelated behaviour.
+    grep -q -- "-h|--help" "$s" || continue
+    out="$(timeout 30 bash "$s" --help 2>&1 || true)"
+    # shellcheck disable=SC2016  # $1 is regex, matching the literal case "$1"
+    leaked="$(printf '%s\n' "$out" | grep -cE '^(set -[a-z]|[a-z_]+\(\) *\{|while \[ |case "\$1")' || true)"
+    check "$name --help leaks no source" "0" "$leaked"
+done
+
 if [ "$fail" -eq 0 ]; then
     echo "all pass"
 else


### PR DESCRIPTION
Refs #218 — what reviewing that change turned up, landing separately because #218 merged first.

## Two scripts documented themselves with a line number, and both had drifted

`--help` in `repo-contribution-preflight.sh` and `signing-preflight.sh` printed the file header with a fixed line range. Neither range still matched its header:

| Script | Range | Header ends | Result |
|---|---|---|---|
| `repo-contribution-preflight.sh` | `2,28` | line 25 | printed **three lines too many**, including `set -uo pipefail` as documentation |
| `signing-preflight.sh` | `2,30` | line 31 | **dropped the last line** of its own usage |

The first one is mine: I widened that range in #210 when the header grew, and overshot. The second is the more interesting failure, because nobody notices it — documentation that is missing looks exactly like documentation that was never written.

Both now use the self-terminating form the other scripts already use: print comment lines until the first line that is not one. A hand-kept range drifts the moment anything is inserted above the code, which is precisely what #218's `skill_version()` did to it.

## The test asserts the property, not a number

Case 7: **no `--help` output contains source code**. Asserting the line count instead would just be a second number to keep in step with the first.

It fails against the previous script:

```
FAIL repo-contribution-preflight.sh --help leaks no source: expected '0', got '1'
```

Scoped to the four scripts that *handle* `--help`. The other two treat it as a positional argument, and asserting there would pin unrelated behaviour rather than this one.

## One more thing the review checked

#218 put the `--version` guard at the top of every script, several of which run under `set -e`, and shipped tests for the **new** path only. Nothing covered the path that was already there.

Checked now: all seven behave exactly as they do on `main` when invoked without `--version`, and the two guard-style scripts return the same exit codes as before — `merge-gate.sh` 0, `verify-git-workflow.sh` 1. An AND-OR list is exempt from `set -e`, so the guard is sound; it simply had no evidence behind it.

## Verification

All 12 files in `tests/` pass, including against the freshly released **1.28.0** — `test_scripts_report_version.sh` reads the number from `SKILL.md` at run time rather than pinning it, so the release bump moved through it without an edit. `shellcheck` clean at the pre-commit hook's severity (the hook runs stricter than `-S warning`; the one `SC2016` is suppressed at the line with a comment saying why — `$1` there is regex matching the literal string `case "$1"`). `verify-harness.sh --status`: Level 1 4/4, Level 2 3/3, Level 3 3/3.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
