### PR TITLE
docs(git-workflow): check-runs lists one entry per run, not per check

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -75,13 +75,24 @@ check-runs beside the first. The old ones keep their old conclusion, so a
 counter over that endpoint reports failures that no longer exist:
 
 ```
-security / SAST (Opengrep): success   22:12:34
-security / SAST (Opengrep): success   22:12:31   <- previous run, same SHA
+All security checks:           success   22:13:53
+All security checks:           failure   22:10:01   <- previous run, same SHA
+fuzz / Preflight (event gate): success   22:11:32
+fuzz / Preflight (event gate): failure   22:09:34   <- previous run, same SHA
 ```
 
 Measured on a pull request whose fuzz preflight was red until an upstream
-workflow was fixed: the reopen produced a green run, and the endpoint kept
-listing the red one, so "2 failing" was reported while nothing was failing.
+workflow was fixed, then closed and reopened. On that one commit:
+
+| Query | Failures reported |
+| --- | --- |
+| every check-run with `conclusion == "failure"` | 2 |
+| newest run per name only | 0 |
+| `gh pr checks` | 0 |
+
+Note which names duplicate: the two that had actually failed. Checks that were
+green in both runs duplicate too, but silently — so a spot check on a green
+name shows two identical entries and looks harmless.
 
 `gh run rerun` does **not** do this — it updates the existing check-run in
 place. Verified on two pull requests where a rerun turned a red check green:

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -67,6 +67,38 @@ Because the exit code cannot distinguish "watched and passed" from "never
 found the run", assert the run exists before watching it, or re-read the
 check's state afterwards rather than trusting the watcher's return.
 
+### `commits/<sha>/check-runs` returns one entry per run, not per check
+
+A second workflow run on the **same commit** — a closed-and-reopened pull
+request, a `workflow_dispatch`, an `on: schedule` firing — adds another set of
+check-runs beside the first. The old ones keep their old conclusion, so a
+counter over that endpoint reports failures that no longer exist:
+
+```
+security / SAST (Opengrep): success   22:12:34
+security / SAST (Opengrep): success   22:12:31   <- previous run, same SHA
+```
+
+Measured on a pull request whose fuzz preflight was red until an upstream
+workflow was fixed: the reopen produced a green run, and the endpoint kept
+listing the red one, so "2 failing" was reported while nothing was failing.
+
+`gh run rerun` does **not** do this — it updates the existing check-run in
+place. Verified on two pull requests where a rerun turned a red check green:
+one entry each, conclusion `success`.
+
+So when the question is "is this pull request green now":
+
+```bash
+# Right: gh pr checks reports the latest attempt per check
+gh pr checks "$PR" --repo "$R" --json name,bucket
+
+# If you must use the API, keep only the newest run per name
+gh api "repos/$R/commits/$SHA/check-runs?per_page=100" --paginate \
+  --jq '[.check_runs[]] | group_by(.name)
+        | map(max_by(.started_at)) | map(select(.conclusion == "failure")) | length'
+```
+
 ### Ask which step failed before reading any log
 
 The jobs API names it in one call, and the name is usually enough to reproduce


### PR DESCRIPTION
`ci-cd-integration.md` recommends `commits/<sha>/check-runs` for finding run ids, which is what it is good at. This adds what it is **not** good at.

A second workflow run on the same commit — a reopened pull request, a `workflow_dispatch`, a schedule firing — adds another set of check-runs beside the first, and the old ones keep their old conclusion:

```
security / SAST (Opengrep): success   22:12:34
security / SAST (Opengrep): success   22:12:31   <- previous run, same SHA
```

Measured on a pull request whose fuzz preflight was red until an upstream reusable workflow was fixed: reopening produced a green run, the endpoint kept listing the red one, and a monitor built on it reported "2 failing" while nothing was failing.

## The distinction that matters

`gh run rerun` does **not** do this — it updates the existing check-run in place. Verified on two pull requests where a rerun turned a red check green: one entry each, conclusion `success`. So the rule is *new run vs. rerun*, not "the API duplicates entries", which is how I first heard it and would have written it down wrong.

The added jq keeps only the newest run per name; checked against the affected pull request, it reports 0 failing where the naive count reports 2.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_