### PR TITLE
docs(watcher): name-miss, empty SHA and a stale ref all read as "not there"

### DIFF
--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -214,6 +214,60 @@ gh api repos/$R/commits/$SHA/status      --jq '{state, total:(.statuses|length)}
 
 **Pre-existing red ≠ your regression.** If a post-merge gate (e.g. SonarCloud "Quality Gate failed" on N Security Hotspots) is red, check the *prior* base commit before owning it: `gh api repos/$R/commits/<prev-sha>/check-runs --jq '.check_runs[]?|select(.name=="<gate>")|.conclusion'`. Identical red on the parent + a diff that touched no relevant code = a pre-existing backlog to report, not a regression to fix.
 
+### A check run is named after the JOB, not the workflow
+
+Looking for a workflow by its own name in `commits/$SHA/check-runs` finds nothing, and the natural conclusion — "that run does not exist for this commit" — is wrong. The entry is there under the **job** name.
+
+Measured on `netresearch/typo3-demo`: workflow run 32536686040 is `Deploy (Update)` (`event=workflow_run`, `check_suite_id=88200944968`); its check run 96938832284 is named `deploy`. Same check suite, and the check run's `html_url` points back at `/actions/runs/32536686040/job/96938832284`. Reproduced 4/4 there and 2/2 on `netresearch/ofelia`, where `Verify Release` appears as `Verify / Verify Release`.
+
+So match on the check suite or on the job names you expect, not on the workflow name — and never infer absence from a name miss.
+
+### When you want run-level state, filter server-side with `head_sha=`
+
+The workflow run's own `status`/`conclusion` (as opposed to its jobs') lives on the runs endpoint. Do **not** reach back for a windowed list and filter it yourself — `actions/runs` takes the SHA as a query parameter and filters on the server:
+
+```bash
+[ -n "$SHA" ] || { echo "no SHA — refusing to watch"; exit 1; }
+gh api "repos/$R/actions/runs?head_sha=$SHA&per_page=50" \
+  --jq '.workflow_runs[] | "\(.name)=\(.status)/\(.conclusion // "-")"'
+```
+
+The guard on the first line is not decoration. An **empty** `$SHA` drops the filter silently and the API answers with the unfiltered list — 4506 runs on one repository measured this way, against 0 for a syntactically valid unknown SHA and 0 for outright garbage. A watcher whose SHA lookup failed then extracts some unrelated run's state and reports it as the watched commit's; the extraction is not empty, so the value guard below cannot catch it.
+
+`repos/$R/actions/runs?per_page=20` piped into a client-side `select(.head_sha==$s)` has the same window defect as `gh run list`, with one difference that makes it worse in a loop: **it works on the first tick.** The commit is recent, so it sits inside the window; twenty minutes later unrelated runs have pushed it out and every subsequent tick sees nothing. A watcher built that way reports progress, then goes quiet, and quiet is indistinguishable from "still running" — it will sit out its full budget without ever emitting. (Observed 2026-08-21; the first tick listed five runs, later ticks listed none.)
+
+### The emptiness guard must test the extracted value, not the response
+
+The natural guard is on the API call:
+
+```bash
+json="$(gh api "…" 2>/dev/null || echo '')"
+if [ -z "$json" ]; then sleep 45; continue; fi     # never fires
+```
+
+That checks the wrong thing. When the window scrolls past the commit the response is a perfectly valid `{"workflow_runs": []}` — non-empty, well-formed, and about a different set of runs. Guard on the value you actually extracted, and make a persistent extraction failure say so, because a watcher that has gone blind must not look like a watcher that is waiting:
+
+```bash
+state="$(printf '%s' "$json" | jq -r '…')"
+if [ -z "$state" ]; then
+  errors=$((errors + 1))
+  [ "$errors" = "5" ] && echo "query has returned nothing for 5 rounds — this watch is blind"
+  sleep 45; continue
+fi
+errors=0
+```
+
+### A file read right after a merge can still return the pre-merge content
+
+`contents/<path>?ref=<branch>` is served from a cache that lags the merge by seconds. A post-merge verification that reads the branch ref can therefore report the merged change as **absent** — an invented regression, produced by measuring too early rather than by anything being wrong. Address the merge commit instead, the same way the rest of this section does:
+
+```bash
+MC=$(gh api "repos/$R/pulls/$PR" --jq '.merge_commit_sha')
+gh api "repos/$R/contents/<path>?ref=$MC" --jq '.content' | base64 -d | grep -q '<marker>'
+```
+
+Observed 2026-08-21: a watcher fired "the trigger is NOT on main" the moment the PR merged; a direct read at the merge SHA a minute later showed it present, at the expected lines.
+
 ## Delete the branch/worktree only after the merge is CONFIRMED, never on watcher exit
 
 A merge-gate watcher loop can exit for reasons that are **not** "merged": the

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -259,7 +259,7 @@ errors=0
 
 ### A file read right after a merge can still return the pre-merge content
 
-`contents/<path>?ref=<branch>` is served from a cache that lags the merge by seconds. A post-merge verification that reads the branch ref can therefore report the merged change as **absent** — an invented regression, produced by measuring too early rather than by anything being wrong. Address the merge commit instead, the same way the rest of this section does:
+`contents/<path>?ref=<branch>` has been observed answering with pre-merge content immediately after a merge. A post-merge verification that reads the branch ref can therefore report the merged change as **absent** — an invented regression, produced by measuring too early rather than by anything being wrong. The mechanism is not established here (no attempt was made to reproduce it against a controlled merge); what is established is that the branch ref answered stale and the merge commit answered correctly. Address the merge commit, the same way the rest of this section does:
 
 ```bash
 MC=$(gh api "repos/$R/pulls/$PR" --jq '.merge_commit_sha')

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1123,6 +1123,20 @@ Draft → Ready for Review → Changes Requested → Approved → Merged
          ↑_____________________|
 ```
 
+**The Draft → Ready edge only exists if the workflow listens for it.** `ready_for_review` is not in the `pull_request` default type set (`opened`, `synchronize`, `reopened`). A workflow declaring a bare `pull_request:` therefore never runs on that transition. Where such a workflow carries the auto-approval — typically a `pr-quality` job gated on `github.event.pull_request.draft == false` — the job skips while the PR is a draft and **nothing re-runs it when the draft is lifted**. The PR then sits at `reviewDecision: REVIEW_REQUIRED` with nothing red and no pending job, which reads as "waiting for a human" and is really "waiting for an event that will never come".
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+```
+
+**Diagnose it by absence, not by the red.** There is no failing check to find. Compare the auto-approve job's runs against the PR's events: if it ran once at `opened` and skipped, and no run exists for the ready transition, this is the cause — not the Copilot review quota, which is usually also true at that moment and is not why the PR is stuck.
+
+**The PR that adds the trigger does not deadlock itself.** It is tempting to conclude that opening such a fix as a draft is a trap, since lifting the draft would need the trigger the PR is still adding. For `pull_request` it is not: GitHub reads the workflow file from the **PR's merge ref**, so the `on:` block — `types:` included — comes from the branch under review and is already in force on that PR. Verified on two PRs that *introduced* their own workflow (`netresearch/ofelia#442`, `netresearch/git-workflow-skill#156`): both show a run of the new workflow at their own head SHA with `event=pull_request`.
+
+The trap is real only for `pull_request_target`, which deliberately loads the workflow from the base branch — there the new trigger takes effect for the *next* PR, not this one. Check which of the two the workflow uses before deciding the draft convention has to be set aside.
+
 ### Commands
 
 ```bash


### PR DESCRIPTION
Three ways a post-merge check reports "not there" when the thing is there, and the state is really an artefact of how it was looked for. All three came out of one session's watchers on 2026-08-21.

## A check run is named after the job

Searching `commits/<sha>/check-runs` for a *workflow's* name finds nothing, and the natural conclusion — the run does not exist for this commit — is wrong.

`netresearch/typo3-demo` run `32536686040` is `Deploy (Update)` (`event=workflow_run`, `check_suite_id=88200944968`); its check run `96938832284` is named `deploy`, same check suite, and its `html_url` points back at that run's job. Reproduced 4/4 there and 2/2 on `netresearch/ofelia`, where `Verify Release` appears as `Verify / Verify Release`.

## `head_sha=` filters server-side — and vanishes when empty

`actions/runs` accepts the SHA as a query parameter; the file previously only warned against client-side filtering of a windowed list. The parameter has one sharp edge worth stating: **an empty variable drops the filter silently** and the API returns the unfiltered list — 4506 runs measured that way on one repository, against 0 for a syntactically valid unknown SHA and 0 for outright garbage. A watcher whose SHA lookup failed then reports a stranger's run as the watched commit's, and because the extraction is not empty, a value guard cannot catch it. Hence the `[ -n "$SHA" ]` line before the loop.

The window defect itself is already documented here for `gh run list`. What is new is its behaviour **inside a loop**: it works on the first tick, because the commit is still recent, and goes blind later — and quiet is indistinguishable from "still running".

## A file read right after a merge can return pre-merge content

A watcher fired "the trigger is NOT on main" the moment a PR merged; a read at the merge commit a minute later showed it present at the expected lines. Address the merge commit, not the branch ref.

## `ready_for_review`, and the conclusion that does *not* follow

`pull-request-workflow.md` gains the type-set trap: `ready_for_review` is not in the `pull_request` defaults, so a workflow carrying a `draft == false`-gated auto-approval never re-runs when the draft is lifted, and the PR sits at `REVIEW_REQUIRED` with nothing red.

The tempting follow-up — "so never open the fix for this as a draft" — is **false**, and the section says so. For `pull_request`, GitHub reads the workflow file from the PR's merge ref, so a PR that adds the trigger already has it in force. Verified on [netresearch/ofelia#442](https://github.com/netresearch/ofelia/pull/442) and [netresearch/git-workflow-skill#156](https://github.com/netresearch/git-workflow-skill/pull/156), both of which introduced their own workflow and ran it at their own head SHA. The trap belongs to `pull_request_target`, which loads from the base branch.

## What an adversarial pass removed before it shipped

An earlier draft of this change asserted that a `workflow_run`-triggered deploy has **no** entry under `commits/<sha>/check-runs`, and used that to justify needing the runs API. Measurement refuted it — the entry is there under the job name. The claim had been reasoned, not measured; it is now replaced by the first section above, which is the more useful finding.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
