### PR TITLE
chore(release): 1.28.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.28.0"
+  version: "1.28.1"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Version bump for the v1.28.1 tag. Patch: the only behaviour change since v1.28.0 is one script fix, everything else is documentation.

## What v1.28.1 ships

**`fix(scripts)` — `--help` stops at the header instead of a hand-kept line number** (`a1dfff8`, #220). `repo-contribution-preflight.sh` and `signing-preflight.sh` both printed their usage by slicing a fixed line range, and both had already drifted: the first emitted `set -uo pipefail` as documentation, the second silently dropped the last line of its own usage. Both now print comment lines until the first line that is not one, which is the form the other scripts already used.

**`docs` — `references/ci-cd-integration.md`** (`7a34538`, `5840c12`, #223). `commits/<sha>/check-runs` returns one entry per *run*, not per check, so a second run on the same commit leaves the older conclusions in the list and a counter over them reports failures that no longer exist. `gh run rerun` does not behave that way — it updates the entry in place. The worked example now uses the two names that actually carry different conclusions, so it shows the stale `failure`, not just the duplication.

**`docs` — `references/merge-gate-watcher.md` and `references/pull-request-workflow.md`** (`8332c95`, `1f9ee65`, #224). Three ways a post-merge check reports absence that is an artefact of how it looked: a check run is named after the job rather than the workflow, `actions/runs` drops an empty `head_sha` filter silently and returns the unfiltered list, and a branch ref can answer with pre-merge content. The follow-up commit narrows one paragraph back to what was measured — the earlier wording asserted a caching mechanism that was never reproduced.

**`docs` — `SKILL.md` and `AGENTS.md`** (`d838e58`, #221, closes #216). `repo-contribution-preflight.sh` was missing from `SKILL.md` because the file sat at 499 words against a 500-word cap. It is listed now, with `--version`, and the file is at 486 — the room came from moving detail into the references that already carry it and from dropping a section that restated the frontmatter description.

The merge-gate fix from #215 is **not** in this release. It shipped in v1.28.0.

## Verification

Version parity checked against the tag before committing: `plugin.json`, `.claude-plugin/plugin.json` and `skills/git-workflow/SKILL.md` all read 1.28.1.

After merge: `git tag -s v1.28.1` on the merge commit, then push.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
