### PR TITLE
fix(hook): fire each advisory once per session, not on every match

### DIFF
--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -294,7 +294,9 @@ class AdvisoryOncePerSession(unittest.TestCase):
         self, command: str, session: "str | None", runtime_dir: "str | None" = None
     ) -> str:
         env = dict(os.environ)
-        env["XDG_RUNTIME_DIR"] = runtime_dir if runtime_dir is not None else self.runtime.name
+        env["XDG_RUNTIME_DIR"] = (
+            runtime_dir if runtime_dir is not None else self.runtime.name
+        )
         payload: dict = {"command": command}
         if session is not None:
             payload["session_id"] = session
@@ -305,6 +307,7 @@ class AdvisoryOncePerSession(unittest.TestCase):
             text=True,
             env=env,
             timeout=30,
+            check=False,
         )
         return result.stdout
 

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import ClassVar
@@ -273,6 +274,65 @@ class ForgeBodyLanguageGate(unittest.TestCase):
         # Commit messages are out of scope for this gate; only forge bodies.
         out = run_hook(f"git commit -m 'feat: x\n\n{self.GERMAN}'")
         self.assertNotEqual("deny", decision(out))
+
+
+class AdvisoryOncePerSession(unittest.TestCase):
+    """The two advisories restate a general rule, not a fact about the command.
+
+    Repeating one on every matching call is noise paid in the user's attention:
+    each reaches the transcript via systemMessage. Fire once per session per
+    advisory — but a marker-storage problem must never suppress the warning.
+    """
+
+    ADVISORY_CMD = "git status"  # matches GIT_MEASURING_READ without a -C/cd
+
+    def setUp(self) -> None:
+        self.runtime = tempfile.TemporaryDirectory()
+        self.addCleanup(self.runtime.cleanup)
+
+    def run_hook_session(
+        self, command: str, session: "str | None", runtime_dir: "str | None" = None
+    ) -> str:
+        env = dict(os.environ)
+        env["XDG_RUNTIME_DIR"] = runtime_dir if runtime_dir is not None else self.runtime.name
+        payload: dict = {"command": command}
+        if session is not None:
+            payload["session_id"] = session
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        return result.stdout
+
+    def test_advisory_fires_once_per_session_per_advisory(self) -> None:
+        first = self.run_hook_session(self.ADVISORY_CMD, "sess-1")
+        self.assertIn("git-workflow:", first)
+        second = self.run_hook_session(self.ADVISORY_CMD, "sess-1")
+        self.assertEqual("", second.strip(), "same session, same advisory: stay quiet")
+
+    def test_a_different_session_fires_its_own_first_warning(self) -> None:
+        self.run_hook_session(self.ADVISORY_CMD, "sess-1")
+        other = self.run_hook_session(self.ADVISORY_CMD, "sess-2")
+        self.assertIn("git-workflow:", other)
+
+    def test_without_a_session_id_every_call_warns(self) -> None:
+        first = self.run_hook_session(self.ADVISORY_CMD, None)
+        second = self.run_hook_session(self.ADVISORY_CMD, None)
+        self.assertIn("git-workflow:", first)
+        self.assertIn("git-workflow:", second)
+
+    def test_an_unusable_runtime_dir_never_suppresses_the_warning(self) -> None:
+        # XDG_RUNTIME_DIR names an existing FILE: creating the marker directory
+        # cannot succeed. The advisory must fire anyway — storage failing is
+        # not the same as the warning having been seen.
+        blocker = Path(self.runtime.name) / "blocker"
+        blocker.write_text("not a directory\n")
+        out = self.run_hook_session(self.ADVISORY_CMD, "sess-3", str(blocker))
+        self.assertIn("git-workflow:", out)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -779,7 +779,13 @@ def _advisory_already_fired(data, name: str) -> bool:
     except OSError:
         return False
     try:
-        os.close(os.open(os.path.join(directory, f"{slug}.{name}"), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+        os.close(
+            os.open(
+                os.path.join(directory, f"{slug}.{name}"),
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        )
     except FileExistsError:
         return True
     except OSError:

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 
 # Enough of a body to count wrapped lines in; a cap so an accidentally huge
 # file cannot stall the hook.
@@ -748,6 +749,44 @@ def check_command(command: str) -> list[dict]:
     return warnings
 
 
+def _advisory_already_fired(data, name: str) -> bool:
+    """True if this advisory has already fired once in this session.
+
+    Both advisories restate a general rule rather than reporting a fact about
+    the particular command in hand. Repeating one on every matching call is
+    noise: the first has already told the author what to check, and the message
+    reaches the user's transcript via systemMessage, so the cost is paid in
+    their attention rather than ours. Fire once per session per advisory.
+
+    Every storage failure returns False: a marker problem must never suppress
+    a warning. The marker directory is therefore created in its own try block
+    — if XDG_RUNTIME_DIR names something unusable, makedirs raises before any
+    marker could exist, and that has to read as "not fired", not as
+    FileExistsError at the marker call.
+    """
+    session_id = data.get("session_id") if isinstance(data, dict) else None
+    if not session_id:
+        return False
+    slug = re.sub(r"[^A-Za-z0-9_-]", "", str(session_id))
+    if not slug:
+        return False
+    directory = os.path.join(
+        os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir(),
+        "git-workflow-advisories",
+    )
+    try:
+        os.makedirs(directory, exist_ok=True)
+    except OSError:
+        return False
+    try:
+        os.close(os.open(os.path.join(directory, f"{slug}.{name}"), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+    except FileExistsError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
 def main():
     try:
         input_data = sys.stdin.read()
@@ -795,6 +834,8 @@ def main():
     for advisory in (run_poll_problem, git_read_without_named_dir):
         note = advisory(command)
         if note:
+            if _advisory_already_fired(data, advisory.__name__):
+                return
             print(
                 json.dumps(
                     {"systemMessage": f"git-workflow: {note}", "suppressOutput": True}


### PR DESCRIPTION
**What**

`run_poll_problem` and `git_read_without_named_dir` restate a general rule rather than report anything about the command in hand. Today each one fires on *every* matching call for as long as a session runs — and since it reaches the user's transcript via `systemMessage`, the cost is paid in their attention, not ours.

This change deduplicates them with a session-scoped marker file under `XDG_RUNTIME_DIR/git-workflow-advisories/`, keyed on the hook payload's `session_id`:

- first matching call in a session → advisory fires, marker created
- later matching calls, same session + same advisory → silent
- different session id (or no session id at all) → behaves exactly as before

**Failure posture: a storage problem can never suppress a warning**

Every error path returns False ("not fired"). One subtlety worth flagging: `os.makedirs(directory, exist_ok=True)` raises `FileExistsError` when `XDG_RUNTIME_DIR` points at an existing *file*, which is the same exception type the O_EXCL marker creation raises to signal "already fired". The directory creation therefore sits in its own try block so that case reads as "storage unusable" (warn anyway), not "already seen" (stay quiet). There is a regression test pinning exactly this case.

**Tests**

4 new cases in `scripts/test_validate_git_command.py`:

- advisory fires once per session per advisory, then stays quiet
- a different session gets its own first warning
- payloads without a `session_id` behave as before (every call warns)
- an unusable `XDG_RUNTIME_DIR` never suppresses the warning

`python3 -m unittest discover -s scripts -p 'test_*.py'`: 50 tests, all green.

**Context**

Found from the user side: a whole session of read-only git commands paid this warning dozens of times. Patched locally against 1.26.0 in a plugin cache, where any update silently reverts it — upstreaming is the durable fix. Ported to current main (1.28.1).