### PR TITLE
docs(pull-request-workflow): return a PR to draft when work resumes

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1125,12 +1125,12 @@ Draft → Ready for Review → Changes Requested → Approved → Merged
 
 **Draft is a state the PR returns to, not one it only starts in.** Opening every PR with `--draft` is the well-known half. The half that gets missed: when work resumes on a PR that is already "ready for review" — a rebase, a round of review fixes, another commit of any kind — convert it back *before the first push*, with `gh pr ready --undo <n>` (`glab mr update <iid> --draft`). Mark it ready again as a separate step, once the checks are green and the user has asked for it.
 
-The reason is what "ready for review" tells everyone else. It is a standing request for a maintainer's time against a specific head, and mid-work heads do not deserve it: between the first fix commit and the last one, the PR advertises for review a state you already know is incomplete — sometimes one you know is broken, when the work is a response to a reviewer's finding. Reviewers who look during that window spend attention on a diff that is about to change, and a green CI run on an intermediate head reads as an endorsement of work that is not finished. The draft round-trip costs two commands and removes the whole class.
+The reason is what "ready for review" tells everyone else. It is a standing request for a maintainer's time against a specific head, and mid-work heads do not deserve it: between the first fix commit and the last one, the PR advertises for review a state you already know is incomplete — sometimes one you know is broken, when the work is a response to a reviewer's finding. Reviewers who look during that window spend attention on a diff that is about to change, and a green CI run on an intermediate head reads as an endorsement of work that is not finished. The round-trip is two commands.
 
-The tell that this was skipped is a PR whose recent commits are labelled as review fixes while `draft: false` held throughout. Check before you start, not after:
+The tell that this was skipped is a PR whose recent commits are labelled as review fixes while it stayed out of draft throughout. Check before you start, not after — note that `gh pr view --json` spells the field `isDraft`, while the REST payload and `gh api` call it `draft`:
 
 ```bash
-gh pr view "$PR" --json draft,headRefName,state --jq '{draft,headRefName,state}'
+gh pr view "$PR" --json isDraft,headRefName,state --jq '{isDraft,headRefName,state}'
 ```
 
 **The Draft → Ready edge only exists if the workflow listens for it.** `ready_for_review` is not in the `pull_request` default type set (`opened`, `synchronize`, `reopened`). A workflow declaring a bare `pull_request:` therefore never runs on that transition. Where such a workflow carries the auto-approval — typically a `pr-quality` job gated on `github.event.pull_request.draft == false` — the job skips while the PR is a draft and **nothing re-runs it when the draft is lifted**. The PR then sits at `reviewDecision: REVIEW_REQUIRED` with nothing red and no pending job, which reads as "waiting for a human" and is really "waiting for an event that will never come".

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1120,7 +1120,17 @@ Match the repo's commit conventions exactly: Conventional Commits type and scope
 
 ```
 Draft → Ready for Review → Changes Requested → Approved → Merged
-         ↑_____________________|
+  ↑______________|↑_____________________|
+```
+
+**Draft is a state the PR returns to, not one it only starts in.** Opening every PR with `--draft` is the well-known half. The half that gets missed: when work resumes on a PR that is already "ready for review" — a rebase, a round of review fixes, another commit of any kind — convert it back *before the first push*, with `gh pr ready --undo <n>` (`glab mr update <iid> --draft`). Mark it ready again as a separate step, once the checks are green and the user has asked for it.
+
+The reason is what "ready for review" tells everyone else. It is a standing request for a maintainer's time against a specific head, and mid-work heads do not deserve it: between the first fix commit and the last one, the PR advertises for review a state you already know is incomplete — sometimes one you know is broken, when the work is a response to a reviewer's finding. Reviewers who look during that window spend attention on a diff that is about to change, and a green CI run on an intermediate head reads as an endorsement of work that is not finished. The draft round-trip costs two commands and removes the whole class.
+
+The tell that this was skipped is a PR whose recent commits are labelled as review fixes while `draft: false` held throughout. Check before you start, not after:
+
+```bash
+gh pr view "$PR" --json draft,headRefName,state --jq '{draft,headRefName,state}'
 ```
 
 **The Draft → Ready edge only exists if the workflow listens for it.** `ready_for_review` is not in the `pull_request` default type set (`opened`, `synchronize`, `reopened`). A workflow declaring a bare `pull_request:` therefore never runs on that transition. Where such a workflow carries the auto-approval — typically a `pr-quality` job gated on `github.event.pull_request.draft == false` — the job skips while the PR is a draft and **nothing re-runs it when the draft is lifted**. The PR then sits at `reviewDecision: REVIEW_REQUIRED` with nothing red and no pending job, which reads as "waiting for a human" and is really "waiting for an event that will never come".
@@ -1150,7 +1160,7 @@ gh pr edit 123 --add-reviewer "@reviewer1,@reviewer2"
 # Mark ready for review
 gh pr ready 123
 
-# Convert to draft
+# Convert to draft — also the first step whenever work resumes on a ready PR
 gh pr ready 123 --undo
 
 # Approve PR


### PR DESCRIPTION
## Problem

The PR Lifecycle section already covers opening every PR with `--draft` and the mechanics of the Draft → Ready edge, but it treats draft as a birth condition. There is no rule for the case that actually recurs: work resuming on a PR that already reads "ready for review" — a rebase onto a moved base, a round of review fixes, another commit of any kind. `gh pr ready --undo` appears only as an unexplained line in the command list, which reads as a remedy for a PR opened non-draft by mistake rather than as a step in the normal loop.

## Why it matters

"Ready for review" is a standing request for a maintainer's time against a specific head, and mid-work heads do not deserve it. Between the first fix commit and the last, such a PR advertises for review a state you already know is incomplete — sometimes one you know is broken, when the work is a response to a reviewer's finding. Reviewers who look during that window spend attention on a diff that is about to change, and a green CI run on an intermediate head reads as an endorsement of work that is not finished.

## Change

Adds the return edge to the state diagram, the rule with its reason, the tell that it was skipped (recent commits labelled as review fixes while `draft: false` held throughout), and the `gh`/`glab` commands. The command-list entry now says when it applies.

## Observed

phpDocumentor/guides#1344, 2026-08-24. The PR sat at "ready for review" through a rebase and two rounds of fixes answering a reviewer's finding, one of which the finding had shown to be broken. It took two corrections before the state was set right, and the rule that should have covered it only spoke about `gh pr create`.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014H1xwaAmrQRWUA3vx8bJcD)_
