### PR TITLE
docs(pull-request-workflow): two preconditions a stack has to meet

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1759,6 +1759,49 @@ The second way PR-green diverges from main-green needs no `push:`-gated job: a P
 - Rebasing before merge does **not** close the window — the config PR can land after your rebase. Only a merge queue or a "require branches to be up to date" rule makes it structurally impossible; where neither is on, expect this occasionally on active repos.
 - Consequence: watching the post-merge run on `main` is part of the merge, because this failure class is visible nowhere else. When it fires, diff `main`'s history for config-touching merges since your branch's last CI run and fix forward against the new config — it is mechanical, not an investigation into which check was wrong.
 
+### A stack needs push access to the repository the PRs target
+
+A pull request's base must be a branch **in the repository the PR is opened
+against**. Stacking PR2 on PR1's branch therefore requires that branch to exist
+there — which it does when you push branches to the target repo, and does not
+when you contribute from a fork. Upstream has no `feature/x`; it lives in your
+fork, and `gh pr create --base feature/x` answers:
+
+```
+Base ref must be a branch (createPullRequest)
+```
+
+Check before you plan around a stack, not after you have built it:
+
+```bash
+gh api "repos/$UPSTREAM" --jq '.permissions.push'   # false → no stack there
+```
+
+With `push: false` the options are a single PR, or a second PR that waits for
+the first to merge and then targets the default branch. Opening the follow-up in
+your own fork keeps it reviewable and off the upstream's list, but it is not a
+stack: the maintainers cannot see it in the queue.
+
+This bites hardest when a review suggests splitting one PR into two, since the
+split is proposed in the same breath as the stack that would deliver it. On a
+fork, "I'll split this into a base PR and a follow-up" is a promise about the
+merge order, not about what can be opened today — say which one you mean.
+
+### Before splitting a PR, run each half without the other
+
+A split is only real if both halves stand on their own. The half that carries a
+test and the half that makes CI accept it are the common trap: they read like
+"the change" and "the infrastructure for the change", and they are one commit's
+worth of coupling. Check it the cheap way — build each half and run the gates on
+it — before proposing the split, because a proposal is what the reviewer will
+plan around.
+
+The tell that they cannot be separated is usually already in front of you: if
+you diagnosed a CI failure that one half causes and the other half fixes, the
+question is settled and the split is a promise you cannot keep. Reviewing your
+own diagnosis before proposing is faster than reversing a split after the branch,
+the PR and the description have been rebuilt around it.
+
 ### Stacked PRs: retarget before you merge, `--delete-branch` only at the end
 
 A stacked chain (PR2 based on PR1's branch, PR3 on PR2's, …) merges

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1765,11 +1765,17 @@ A pull request's base must be a branch **in the repository the PR is opened
 against**. Stacking PR2 on PR1's branch therefore requires that branch to exist
 there — which it does when you push branches to the target repo, and does not
 when you contribute from a fork. Upstream has no `feature/x`; it lives in your
-fork, and `gh pr create --base feature/x` answers:
+fork, and `gh pr create --base feature/x` answers with four clauses, of which
+only the last is the cause:
 
 ```
-Base ref must be a branch (createPullRequest)
+pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be
+blank, No commits between upstream:feature/x and myfork:follow-up, Base ref must
+be a branch (createPullRequest)
 ```
+
+`No commits between` is the misleading one — the branches differ, and diffing
+them to find out why wastes the time this note exists to save.
 
 Check before you plan around a stack, not after you have built it:
 


### PR DESCRIPTION
## Problem

The stacked-PR material covers what happens once a stack exists: merge order, retargeting, `--delete-branch` closing the child, approvals lost when the base merges. Two things that decide whether the stack can exist at all were not written down, and both were paid for in one afternoon.

**A base must be a branch in the target repository.** Contributing from a fork, the feature branch lives in the fork, so upstream has nothing to point at:

```
$ gh pr create --base feature/x --head myorg:follow-up
Base ref must be a branch (createPullRequest)
```

The check is one call — `gh api "repos/$UPSTREAM" --jq '.permissions.push'` — and it belongs before the branch is built, not after the PR is refused.

**A split is only real if both halves stand on their own.** A test and the CI change that lets it pass read like two things and are one. Worse, the coupling is usually already proven at the moment the split is proposed: if you diagnosed a CI failure where one half causes it and the other fixes it, you have your answer and the split is a promise you cannot keep.

## Change

Two sections ahead of the existing stacked-PR material, since both are preconditions for it:

- *A stack needs push access to the repository the PRs target* — the constraint, the error it produces, the one-line check, and what the options actually are on a fork (single PR, or a follow-up that waits and targets the default branch). Also names the trap of proposing a split and a stack in the same breath, where only the merge order is deliverable.
- *Before splitting a PR, run each half without the other* — build each half, run the gates on it, and check your own diagnosis first.

## Observed

phpDocumentor/guides#1345, 2026-08-25. A review round grew the PR past its subject, so the extra work was split onto its own branch and committed — then the upstream PR could not be opened (`push: false` on the base repo), and the halves turned out to be inseparable anyway: any test loading the class hits the CI failure the other half fixes, in every suite. Branch, PR and description were rebuilt around the split and then rebuilt again to undo it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014H1xwaAmrQRWUA3vx8bJcD)_
