### PR TITLE
docs: running a tool from a stale worktree, and two exit-code traps

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -476,7 +476,7 @@ git -C <repo> fetch origin && git -C <repo> log --oneline origin/main -3   # or:
 git worktree add ../fresh origin/main                                      # read from a fresh tree
 ```
 
-Two recurring failure modes:
+Three recurring failure modes:
 
 - **Reporting a stale value as fact.** Reading `"^0.13"` from an un-fetched
   worktree and stating "the constraint needs bumping" — when current `main` already
@@ -486,6 +486,23 @@ Two recurring failure modes:
   "read the source" for a decision, name the ref/worktree it must read, and
   re-verify its structural claims (config keys, signatures) against the current
   tree before building on them — half a report can come from an outdated path.
+- **Running a *tool* from the stale worktree, not just reading it.** A script you
+  merged an hour ago does not exist in a reference worktree that has not been
+  fast-forwarded, so invoking it by path fails with `exit 127` — which reads as a
+  broken command, a bad `PATH`, a typo, anything but "the tree is old". The
+  remedy is one line, and it belongs at the end of a merge rather than at the
+  start of the next debugging session:
+
+  ```bash
+  git -C <repo>/.bare fetch origin --prune
+  git -C <repo>/main merge --ff-only origin/main   # reference worktree usable again
+  ```
+
+  Note `--ff-only`: a reference worktree that cannot fast-forward has local
+  commits and is not a reference worktree any more, which is worth finding out
+  loudly. In a bare-repo layout `origin/*` does not update on its own, so the
+  fetch is not optional — and after a merge the *branch* worktree is usually gone,
+  which is exactly when scripts start being invoked from `main/` instead.
 
 Confirm the constructor/signature at the **resolved** dependency version (the one
 installed in `vendor`/`.Build`), not the library's `main` branch — they drift

--- a/skills/git-workflow/references/code-quality-tools.md
+++ b/skills/git-workflow/references/code-quality-tools.md
@@ -97,6 +97,45 @@ Note: SC2155 (`Declare and assign separately to avoid masking return values`) on
 exit code is propagated and `set -e` works normally. The empty-output case is distinct and not
 covered by any shellcheck rule.
 
+### Gotcha: Capturing an exit code, in a script that runs under `set -e`
+
+A shell test runner — one that asserts "this input must exit 1, that one must exit 0" — walks into
+two traps that both fail in the same misleading direction: **every case collapses at once**, so the
+runner looks wholly broken rather than subtly wrong.
+
+**`env` cannot call a shell function.** `env VAR=1 my_func` execs a *program*; the function is
+invisible to it, so the run dies with `127` and every case fails identically. Set the variable in a
+subshell instead of reaching for `env`:
+
+```bash
+guard() { python3 ./scripts/guard.py "$@"; }
+
+# Wrong: env execs a binary, never the function -> 127 on every case.
+env -u FLAG FLAG=1 guard "$fixture"
+```
+
+**`set -e` inside `$( )` aborts before the exit code is reported.** The subshell inherits `set -e`,
+so a case that is *supposed* to fail kills the substitution before the `echo $?` that was going to
+capture it — and the variable ends up empty:
+
+```bash
+actual=$(
+  set +e                                    # or the next non-zero line ends the subshell
+  unset FLAG_A FLAG_B                       # each case starts from a known environment
+  if [ -n "$assignment" ]; then
+    # shellcheck disable=SC2163  # exporting NAME=value, not the variable name
+    export "$assignment"
+  fi
+  guard "$fixture" >/dev/null 2>&1
+  echo $?
+)
+```
+
+Both were hit while writing a guard's regression suite: the first turned 16 passing cases into 16
+failures, the second produced a runner that printed its header and nothing else. Neither is caught
+by shellcheck — SC2163 fires on the deliberate `export "$assignment"`, which is the one line in the
+block that is correct as written.
+
 ### CI Integration
 
 ```yaml

--- a/skills/git-workflow/references/code-quality-tools.md
+++ b/skills/git-workflow/references/code-quality-tools.md
@@ -114,9 +114,19 @@ guard() { python3 ./scripts/guard.py "$@"; }
 env -u FLAG FLAG=1 guard "$fixture"
 ```
 
-**`set -e` inside `$( )` aborts before the exit code is reported.** The subshell inherits `set -e`,
-so a case that is *supposed* to fail kills the substitution before the `echo $?` that was going to
-capture it — and the variable ends up empty:
+**`set -e` inside `$( )` aborts before the exit code is reported — under `sh`, not under `bash`.**
+The substitution's subshell inherits `set -e`, so the case that is *supposed* to fail kills it
+before the `echo $?` that was going to capture the code. The shell decides whether this bites, and
+the split is what makes it expensive: the same file, unchanged, run three ways —
+
+```text
+sh   probe.sh   exit=1   "suite"                    # dies after the header
+dash probe.sh   exit=1   "suite"                    # same
+bash probe.sh   exit=0   "suite | ok | ok | ende"   # runs clean
+```
+
+So a runner written with `#!/usr/bin/env sh` passes while you develop it with `bash runner.sh` and
+dies in CI, where `sh` is dash or busybox. `set +e` inside the subshell fixes all three:
 
 ```bash
 actual=$(
@@ -135,6 +145,11 @@ Both were hit while writing a guard's regression suite: the first turned 16 pass
 failures, the second produced a runner that printed its header and nothing else. Neither is caught
 by shellcheck — SC2163 fires on the deliberate `export "$assignment"`, which is the one line in the
 block that is correct as written.
+
+Reproducing the second one takes a faithful structure, not a minimal one. `bash -c 'set -e;
+out=$(false; echo $?)'` prints `1` and suggests there is nothing here; the trap needs the real
+shape — a function returning the code, inside `$( )`, inside a script under `set -e`, run as `sh`.
+A probe that is too small is how a real trap gets written off as folklore.
 
 ### CI Integration
 


### PR DESCRIPTION
Two findings from a `/retro`, both about failures that present as something other than what they are.

## `advanced-git.md` — running a tool from a stale worktree

The "A stale worktree is a stale source" section covered *reading* a stale tree. It did not cover *running* from one.

A script merged an hour ago does not exist in a reference worktree that has not been fast-forwarded, so invoking it by path fails with `exit 127` — which reads as a broken command, a bad `PATH`, a typo, anything but "the tree is old". It happened twice in one session, the second time on a script that had been merged forty minutes earlier by the same session that then failed to run it.

The remedy belongs at the end of a merge rather than at the start of the next debugging session, and it is two lines. `--ff-only` is deliberate: a reference worktree that cannot fast-forward has local commits and has stopped being a reference worktree, which is worth finding out loudly. The note also says why the moment is easy to miss — after a merge the *branch* worktree is usually deleted, which is exactly when scripts start being invoked from `main/`.

## `code-quality-tools.md` — capturing an exit code under `set -e`

Two traps in shell test runners, placed next to the existing command-substitution gotcha because they share its shape. Both fail in the same misleading direction: **every case collapses at once**, so the runner looks wholly broken rather than subtly wrong.

- `env VAR=1 my_func` execs a *program* and never sees the shell function — 16 passing cases became 16 failures at `127`.
- `set -e` inside `$( )` aborts the subshell before the `echo $?` that was going to capture the code, so a runner whose cases are *supposed* to fail prints its header and nothing else.

Neither is caught by shellcheck. SC2163 does fire inside the corrected block — on `export "$assignment"`, which is the one line there that is correct as written, so the example carries the disable with the reason.

## verification

- `markdownlint-cli2` with the repo config: 0 issues.
- `scripts/verify-harness.sh`: `Level 3 COMPLETE | 0 error(s), 0 warning(s)`, no drift.
- `tests/test_advanced_git_recipes.sh`: 25 assertions, 0 failures.

Came from /retro: yes

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_017yWx1auDfcjcDQDjNg1866)_
