### PR TITLE
fix(hook): let a spent advisory yield, re-arm after six hours

### DIFF
--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from typing import ClassVar
@@ -285,6 +286,10 @@ class AdvisoryOncePerSession(unittest.TestCase):
     """
 
     ADVISORY_CMD = "git status"  # matches GIT_MEASURING_READ without a -C/cd
+    POLL_CMD = "while true; do gh run list --limit 5; sleep 30; done"
+    BOTH_CMD = (
+        "while true; do gh run list --limit 5; git log --oneline -1; sleep 30; done"
+    )
 
     def setUp(self) -> None:
         self.runtime = tempfile.TemporaryDirectory()
@@ -336,6 +341,34 @@ class AdvisoryOncePerSession(unittest.TestCase):
         blocker.write_text("not a directory\n")
         out = self.run_hook_session(self.ADVISORY_CMD, "sess-3", str(blocker))
         self.assertIn("git-workflow:", out)
+
+    def test_a_spent_advisory_does_not_swallow_the_other_ones_first_warning(
+        self,
+    ) -> None:
+        # One command can match both advisories. Once the poll advisory has
+        # fired, a combined command must still deliver the other advisory's
+        # first warning instead of returning early on the spent one.
+        first = self.run_hook_session(self.POLL_CMD, "sess-4")
+        self.assertIn("Waiting on workflow runs", first)
+        combined = self.run_hook_session(self.BOTH_CMD, "sess-4")
+        self.assertIn("inherits its working directory", combined)
+
+    def test_a_marker_older_than_the_rearm_window_fires_again_once(self) -> None:
+        # A session can run for days and its context gets compacted, so a
+        # warning delivered once at the start is gone by then. An old marker
+        # re-arms the advisory: fire again, restart the window, go quiet again.
+        self.run_hook_session(self.ADVISORY_CMD, "sess-5")
+        marker = (
+            Path(self.runtime.name)
+            / "git-workflow-advisories"
+            / "sess-5.git_read_without_named_dir"
+        )
+        old = time.time() - 7 * 60 * 60
+        os.utime(marker, (old, old))
+        again = self.run_hook_session(self.ADVISORY_CMD, "sess-5")
+        self.assertIn("git-workflow:", again)
+        quiet = self.run_hook_session(self.ADVISORY_CMD, "sess-5")
+        self.assertEqual("", quiet.strip(), "re-arm must also re-mark: quiet again")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 
 # Enough of a body to count wrapped lines in; a cap so an accidentally huge
 # file cannot stall the hook.
@@ -749,14 +750,22 @@ def check_command(command: str) -> list[dict]:
     return warnings
 
 
+# A session can run for days and its context gets compacted along the way, so
+# an advisory seen once at the start is long gone by the time the same slip
+# recurs. An old enough marker re-arms the advisory: one fresh warning, then
+# quiet again for another window.
+ADVISORY_REARM_SECONDS = 6 * 60 * 60
+
+
 def _advisory_already_fired(data, name: str) -> bool:
-    """True if this advisory has already fired once in this session.
+    """True if this advisory has already fired recently in this session.
 
     Both advisories restate a general rule rather than reporting a fact about
     the particular command in hand. Repeating one on every matching call is
     noise: the first has already told the author what to check, and the message
     reaches the user's transcript via systemMessage, so the cost is paid in
-    their attention rather than ours. Fire once per session per advisory.
+    their attention rather than ours. Fire once per session per advisory, and
+    once more per ADVISORY_REARM_SECONDS window in a long-running session.
 
     Every storage failure returns False: a marker problem must never suppress
     a warning. The marker directory is therefore created in its own try block
@@ -778,15 +787,18 @@ def _advisory_already_fired(data, name: str) -> bool:
         os.makedirs(directory, exist_ok=True)
     except OSError:
         return False
+    marker = os.path.join(directory, f"{slug}.{name}")
     try:
-        os.close(
-            os.open(
-                os.path.join(directory, f"{slug}.{name}"),
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o600,
-            )
-        )
+        os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
     except FileExistsError:
+        try:
+            # A marker mtime in the future (backwards clock step) makes the
+            # delta negative and reads as fresh: stay quiet rather than storm.
+            if time.time() - os.stat(marker).st_mtime > ADVISORY_REARM_SECONDS:
+                os.utime(marker, None)
+                return False
+        except OSError:
+            return False
         return True
     except OSError:
         return False
@@ -841,12 +853,18 @@ def main():
         note = advisory(command)
         if note:
             if _advisory_already_fired(data, advisory.__name__):
-                return
+                # This advisory is spent, but the other one may still owe the
+                # session its first warning — keep looking instead of exiting.
+                continue
             print(
                 json.dumps(
                     {"systemMessage": f"git-workflow: {note}", "suppressOutput": True}
                 )
             )
+            # One message per call: mixing this JSON line with check_command's
+            # plain-text reminder on the same stdout would be ambiguous to the
+            # harness. Only a SPENT advisory falls through (continue above), so
+            # a suppressed advisory no longer swallows unrelated warnings.
             return
 
     if "git" not in command.lower():


### PR DESCRIPTION
Two refinements on the once-per-session advisory dedup merged in #226.

**Yield instead of exit.** The already-fired branch used `return`, so a command matching both advisories — a run-poll loop containing a bare git read does — delivered nothing once the first advisory was spent, even while the second still owed the session its first warning. It now `continue`s to the next advisory.

**Side effect, seen and intended.** With `continue`, a command whose only matching advisory is spent also falls through to `check_command`, so its plain-text reminders (force-push, hard-reset) are no longer swallowed by the dedup. The early return when an advisory *fires* stays: one message per call, since mixing the systemMessage JSON with a plain-text reminder on the same stdout would be ambiguous to the harness — both choices are now stated in comments at the spot.

**Re-arm after six hours.** Sessions on the machines this hook serves run for days and their context gets compacted along the way; a warning delivered once at session start is long gone by the time the same slip recurs. Before #226 the named-dir advisory fired 463 times across 54 local sessions, 194 of them in a single session. A marker older than `ADVISORY_REARM_SECONDS` (six hours) now re-arms its advisory: one fresh warning, marker touched, quiet for another window — at most ~4 messages per day instead of 194, while the reminder survives compaction. Every stat/utime failure keeps reading as "warn", same failure posture as #226; a marker mtime in the future (backwards clock step) reads as fresh and stays quiet.

**Tests.** Two new cases, 52 total, all green. Both were watched failing before the fix, and an adversarial review round additionally mutation-verified them: `continue`→`return` reddens exactly the yield test, dropping the `os.utime` touch reddens exactly the re-arm test's third assertion. `ruff@0.16.0` check and format (the versions Skill Validation pins) are clean.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01C7S9rbgu5giqCwnzwafrHA)_
