### PR TITLE
docs(pull-request-workflow): drop the unverifiable queue-timeout default

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1967,8 +1967,11 @@ Arm auto-merge / enqueue **only when all four hold**:
 4. **A quiet runner pool** — see below.
 
 **Do not enqueue into a busy runner pool.** A merge queue drops an entry whose
-required checks do not report within `check_response_timeout_minutes` (default
-5). That clock starts at enqueue and covers the wait for a *runner*, not just
+required checks do not report within `check_response_timeout_minutes`. The REST
+docs state no default for that parameter — read the configured value from the
+ruleset (the query below shows it; the two netresearch repos checked run 30
+and 60 minutes).
+That clock starts at enqueue and covers the wait for a *runner*, not just
 the run: with the pool saturated, the jobs sit in `queued` with no runner and
 the entry is discarded having executed nothing.
 

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -367,9 +367,11 @@ evaluate() {
     | ($queued  | map(select(.name as $n | $required | index($n)))) as $queued_required
     # Right after a push every check is queued and none is running, which is
     # normal for a few seconds and says nothing about runner capacity. Age the
-    # signal before acting on it, using the tolerance the merge queue itself
-    # applies (check_response_timeout_minutes, default 5) as the threshold:
-    # queued longer than the queue would wait is when it stops being fresh.
+    # signal before acting on it. The 5-minute threshold is this script owning
+    # a conservative freshness floor — NOT the merge queue tolerance: that is
+    # check_response_timeout_minutes, which the REST docs give no default for
+    # and which is configured per ruleset (30 and 60 on the two netresearch
+    # repos checked, #233).
     # No apostrophes in here — the whole jq program sits in a single-quoted
     # shell string, and one would end it.
     | (($queued_required | map(.started // empty) | min) // null) as $oldest_q


### PR DESCRIPTION
Closes #233. The REST docs describe `check_response_timeout_minutes` without stating any default (verified against the current rules endpoint documentation), and the two netresearch repos checked configure 30 (ofelia) and 60 (ldap-manager) — both re-queried live during review — so the "(default 5)" parenthetical asserted a number nothing backs. The paragraph now says the docs state no default and points at the ruleset query the same section already shows.

The review round found the same claim once more: the `pr-status.sh` comment justifying the 5-minute `await-capacity` threshold attributed it to "the tolerance the merge queue itself applies (check_response_timeout_minutes, default 5)". The threshold and behavior are unchanged; the comment now owns the 5 as this script's conservative freshness floor and names the ruleset as the place the real tolerance lives.