### PR TITLE
chore(release): 1.29.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args: [--allow-multiple-documents]
 
   - repo: https://github.com/netresearch/skill-repo-skill
-    rev: v1.22.0
+    rev: v1.36.0
     hooks:
       - id: validate-skill
       - id: check-version-parity

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.28.1"
+  version: "1.29.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Version bump on all three surfaces (root `plugin.json`, `.claude-plugin/plugin.json`, `skills/git-workflow/SKILL.md`) via skill-repo-skill's `bump-version.sh`. Ships #226, #236, #238, #239, #240 and #234 — advisory dedup with six-hour re-arm, the draft-watch fix with the widened ACTIONABLE vocabulary, the CodeQL advanced-setup switch, the queue-timeout doc correction, and the branch-sync trigger words.

Also moves the pre-commit pin for skill-repo-skill from v1.22.0 to v1.36.0: the old copy still enforced the withdrawn 500-word cap on SKILL.md and rejected this bump locally (the description grew in #234), while CI validates against main, which counts lines (72 here). The v1.36.0 validator passes this tree with zero errors.

Tag `v1.29.0` follows on the merge commit after this lands.