### PR TITLE
docs(stash): document recovering a popped/dropped stash via its SHA

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1037,7 +1037,9 @@ git gc
 # Aggressive gc
 git gc --aggressive
 
-# Prune unreachable objects
+# Prune unreachable objects — unlike plain `git gc`, this deletes them
+# immediately (no gc.pruneExpire grace period). Don't run it while recovering
+# a dropped stash — see "A popped/dropped stash is not immediately gone" below.
 git prune
 
 # Verify repository
@@ -1210,26 +1212,34 @@ git checkout HEAD~1 -- path/to/file
 git reflog
 git reset --hard HEAD@{1}
 
-# Recover stash
-git fsck --unreachable | grep commit | cut -d' ' -f3 | \
-  xargs git log --merges --no-walk --grep=WIP
+# Recover stash — field-position parsing (not `cut -d' ' -f3`) survives locale
+# translation (German fsck reorders the line to "unreachable commit <sha>"),
+# and matching both `^WIP on ` (anonymous) and `^On ` (named via `stash push -m`)
+# catches stashes `--grep=WIP` alone would silently miss.
+git fsck --unreachable | awk '{for(i=1;i<=NF;i++) if ($i=="commit"){print $(i+1); break}}' | \
+  xargs -r git log --no-walk --merges -E --grep='^WIP on |^On '
 ```
 
 ### A popped/dropped stash is not immediately gone
 
 `git stash pop` and `git stash drop` remove the stash's ref from `git stash
 list`, but the underlying commit object is not deleted — it becomes a
-dangling commit, reachable by SHA. It is not deleted by an incidental `git
-gc` either: `gc.pruneExpire` defaults to 2 weeks, so a freshly dangling
-commit survives ordinary garbage collection — only an explicit `git gc
---prune=now` (or waiting out the expiry window) actually removes it. Do not
-conclude stashed changes are lost just because they vanished from the
-working tree (e.g. an unrelated later step — a build hook, `composer
-update`'s asset-publish lifecycle, another tool — silently overwrote the
-same files) or because the stash is gone from `git stash list`.
+dangling commit, reachable by SHA. An ordinary `git gc` will not delete it
+right away — `gc.pruneExpire` defaults to 2 weeks, so a freshly dangling
+commit survives routine garbage collection. But don't assume any pruning
+step is safe: a bare `git prune` (no `--expire`, same as `git gc
+--prune=now`) removes unreachable objects immediately, no grace period —
+including the plain `git prune` this file's own Repository Maintenance
+recipe recommends. Do not conclude stashed changes are lost just because
+they vanished from the working tree (e.g. an unrelated later step — a build
+hook, `composer update`'s asset-publish lifecycle, another tool — silently
+overwrote the same files) or because the stash is gone from `git stash
+list` — but don't run maintenance commands against the repo either until
+you've actually recovered it.
 
-Git prints the commit SHA at pop/drop time — keep that line in view instead
-of letting it scroll away:
+Git prints the commit SHA at pop/drop time (not on a `pop` that hits a
+conflict — the stash then stays in `git stash list` instead) — keep that
+line in view instead of letting it scroll away:
 
 ```
 Dropped refs/stash@{0} (14386d701aad44499e677dbc4b3a3f613bb6405f)

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1215,6 +1215,33 @@ git fsck --unreachable | grep commit | cut -d' ' -f3 | \
   xargs git log --merges --no-walk --grep=WIP
 ```
 
+### A popped/dropped stash is not immediately gone
+
+`git stash pop` and `git stash drop` remove the stash's ref from `git stash
+list`, but the underlying commit object is not deleted — it becomes a
+dangling commit, still reachable by SHA, until the next `git gc`. Do not
+conclude stashed changes are lost just because they vanished from the
+working tree (e.g. an unrelated later step — a build hook, `composer
+update`'s asset-publish lifecycle, another tool — silently overwrote the
+same files) or because the stash is gone from `git stash list`.
+
+Git prints the commit SHA at pop/drop time — keep that line in view instead
+of letting it scroll away:
+
+```
+Dropped refs/stash@{0} (14386d701aad44499e677dbc4b3a3f613bb6405f)
+```
+
+Recover directly from that SHA:
+
+```bash
+git stash apply 14386d701aad44499e677dbc4b3a3f613bb6405f
+```
+
+If the SHA wasn't captured, find the dangling commit via `git fsck`
+(the "Recover stash" recipe above) or check `git reflog` for stash-related
+entries.
+
 ### Tags & Remote-State Topology
 
 A plain `git fetch` auto-follows *new* tags on fetched commits, but it will not

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1219,7 +1219,10 @@ git fsck --unreachable | grep commit | cut -d' ' -f3 | \
 
 `git stash pop` and `git stash drop` remove the stash's ref from `git stash
 list`, but the underlying commit object is not deleted — it becomes a
-dangling commit, still reachable by SHA, until the next `git gc`. Do not
+dangling commit, reachable by SHA. It is not deleted by an incidental `git
+gc` either: `gc.pruneExpire` defaults to 2 weeks, so a freshly dangling
+commit survives ordinary garbage collection — only an explicit `git gc
+--prune=now` (or waiting out the expiry window) actually removes it. Do not
 conclude stashed changes are lost just because they vanished from the
 working tree (e.g. an unrelated later step — a build hook, `composer
 update`'s asset-publish lifecycle, another tool — silently overwrote the
@@ -1238,9 +1241,12 @@ Recover directly from that SHA:
 git stash apply 14386d701aad44499e677dbc4b3a3f613bb6405f
 ```
 
-If the SHA wasn't captured, find the dangling commit via `git fsck`
-(the "Recover stash" recipe above) or check `git reflog` for stash-related
-entries.
+If the SHA wasn't captured, find the dangling commit via `git fsck` (the
+"Recover stash" recipe above) — `git reflog` will not help here: dropping or
+popping a stash removes the entry from `refs/stash`'s own reflog (and if it
+was the only stash, `refs/stash` disappears entirely, so `git reflog show
+refs/stash` fails with "ambiguous argument"), and plain `git reflog` (HEAD)
+never had a stash entry to begin with.
 
 ### Tags & Remote-State Topology
 


### PR DESCRIPTION
## Summary

Document that a popped/dropped git stash's commit object survives (as a dangling commit, reachable by SHA) until `git gc` runs, and how to recover it with `git stash apply <sha>`.

## Came from

`/retro` session on 2026-08-27.
Finding: recover a dropped/popped git stash via its commit SHA
Learning-Id: retro-20260827-recover-dropped-stash-sha

- **Symptom:** After a stash was popped and its changes confirmed restored, an unrelated build-tool hook later silently reverted the same files. The changes appeared lost.
- **Cause:** The agent didn't know a popped/dropped stash's commit object is still recoverable by SHA until garbage collection.
- **Required behavior:** Keep the SHA git prints on stash pop/drop in view; if files thought to be safe turn out reverted, try `git stash apply <sha>` (or `git fsck --unreachable`) before concluding the work is lost.
- **Verification:** Manual — recovered the exact incident's changes via `git stash apply 14386d701aad44499e677dbc4b3a3f613bb6405f` after the stash had already been dropped from `git stash list`.

## Change

Extended the existing "Recovery Operations" section in `skills/git-workflow/references/advanced-git.md` (right after the existing "Recover stash" `git fsck` recipe) with a new subsection, "A popped/dropped stash is not immediately gone," covering: the underlying fact (dangling commit survives until gc), the recovery command (`git stash apply <sha>`), and the practical trigger to watch for (files silently reverted by something other than git after a stash was already popped/restored).

## Test plan

- [ ] Reviewed the new section renders correctly (no broken markdown/code fences)
- [ ] No other file in the repo now contradicts this guidance
