### PR TITLE
feat(pr-status): report issue comments nobody answered

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -31,10 +31,18 @@ bash "$GW/scripts/pr-status.sh" -R owner/repo 123 --watch
 Two API calls (a third, admin-only, when the PR is review-blocked — it reads
 classic branch protection, whose review gates like `require_last_push_approval`
 are invisible to the rules endpoint), and the output ends in a computed `NEXT:` — rebase, fix-ci,
-triage-ci, resolve-threads, request-review, wait, or merge (with the method
+triage-ci, resolve-threads, address-comments, request-review, wait, or merge (with the method
 this repo actually allows and a warning when a merge queue is active). The
 JSON form carries each unresolved thread's `threadId` *and* `commentId`, which
 is everything needed to reply and resolve without another query.
+
+`address-comments` covers the channel the other two miss. A reviewer who writes
+under the pull request instead of on a line of the diff produces an *issue
+comment*, which lives in neither `reviewThreads` nor the check rollup — so a
+report built from those alone says `threads: 0 unresolved` while the findings
+sit unread. Anything posted after the last word of the author counts as
+unanswered; comments from bots are shown but never drive the `NEXT:` line, so a
+Renovate note cannot push its own pull request off the auto-merge rung.
 
 Measured on a 40-PR rollout that did not have it: **183 of 370 shell calls
 were PR-status probing**, the rulesets endpoint was queried exactly once, and

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -76,6 +76,7 @@
 #   state mergeable mergeState draft number title repo author
 #   base head headOid
 #   checks checks_settled threads unresolved_threads
+#   unanswered_comments unanswered_human unanswered_by unanswered_urls
 #   reviewDecision reviews_on_head has_review_on_head
 #   has_copilot_review_on_head copilot_review_errored copilot_error_count copilot_quota_hit
 #   copilot_quota_exhausted
@@ -137,7 +138,7 @@ REPO=""; PR=""; JSON=0; WATCH=0; INTERVAL=20; MAXWAIT=3600; IGNORE=""
 # are deliberately not in here. tests/test_pr_status_draft_watch.sh pins the
 # two lists against every action literal this script can emit — a new action
 # must land in one of them.
-ACTIONABLE="fix-ci triage-ci resolve-threads request-review rebase resolve-conflicts merge blocked none fix-signatures ready investigate"
+ACTIONABLE="fix-ci triage-ci resolve-threads address-comments request-review rebase resolve-conflicts merge blocked none fix-signatures ready investigate"
 
 die() { printf 'pr-status: %s\n' "$1" >&2; exit 2; }
 
@@ -229,7 +230,7 @@ collect() {
         # The last page, not the first: a Self-review attestation (see the
         # header) is posted at the end of a conversation, and an old page
         # would go blind on exactly the PRs long enough to need one.
-        comments(last:100){ nodes{ author{login} body url } }
+        comments(last:100){ nodes{ author{login} body url createdAt } }
         reviews(last:50){ nodes{ author{login} state commit{oid} body } }
         reviewRequests(first:20){ nodes{ requestedReviewer{
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
@@ -354,6 +355,18 @@ evaluate() {
     | ([$reviews_raw[] | select(is_errored_copilot_review | not)]) as $head_reviews
     | ([$head_reviews[] | select(.author.login | test("copilot"; "i"))]) as $copilot_on_head
     | ([$p.reviewThreads.nodes[]? | select(.isResolved == false)]) as $unresolved
+    # Prose written under the pull request is an ISSUE comment, not a review
+    # thread and not a review. It appears in neither reviewThreads nor the
+    # check rollup, so a report built from those alone says "0 unresolved"
+    # while findings from a maintainer sit unread. Anything posted after the
+    # last word of the author is unanswered by construction; if the author
+    # never commented, every comment by someone else is.
+    | (([$p.comments.nodes[]? | select(.author.login == $author) | .createdAt] | max) // "") as $author_last_comment
+    | ([$p.comments.nodes[]? | select(.author.login != $author)
+                            | select(.createdAt > $author_last_comment)]) as $unanswered_comments
+    # Bots are reported but never drive the ladder: a Renovate or Dependabot
+    # note must not push its own PR off the auto-merge rung it exists to reach.
+    | ([$unanswered_comments[] | select((.author.login | test("\\[bot\\]$|^(dependabot|renovate|copilot)"; "i")) | not)]) as $unanswered_human
     # A cancelled context that reported again under the same name is STALE:
     # the later row is the answer and the cancelled one is a leftover. One that
     # never reported again is genuinely unmet and still shuts the gate — but it
@@ -493,6 +506,10 @@ evaluate() {
         author: $author,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
+        unanswered_comments: ($unanswered_comments|length),
+        unanswered_human: ($unanswered_human|length),
+        unanswered_by: ([$unanswered_comments[]|.author.login]|unique),
+        unanswered_urls: ([$unanswered_comments[]|.url]),
         threads: [$unresolved[]|{threadId: .id,
                                  commentId: .comments.nodes[0].databaseId,
                                  author: .comments.nodes[0].author.login,
@@ -603,6 +620,13 @@ evaluate() {
          elif $s.unresolved_threads > 0 then
            {action:"resolve-threads", why:"\($s.unresolved_threads) unresolved review thread(s)",
             threads:$s.threads}
+         # Below resolve-threads, which names a precise line and a thread id,
+         # and above draft: a comment left unanswered is real work no matter
+         # how the PR is parked. Human comments only — see $unanswered_human.
+         elif $s.unanswered_human > 0 then
+           {action:"address-comments",
+            why:"\($s.unanswered_human) comment(s) posted after your last word by \($s.unanswered_by|join(", ")) — issue comments live outside reviewThreads, so \"0 unresolved\" above does not cover them",
+            urls:$s.unanswered_urls}
          # Draft sits BELOW the branches that report real work — a conflict, a
          # stale base, a red check, an open thread all stay worth doing while
          # the PR is deliberately parked as draft (the back-to-draft-on-resume
@@ -921,6 +945,9 @@ render() {
      else empty end),
     "  reviews     : \(if .has_review_on_head then (.reviews_on_head|to_entries|map("\(.key)=\(.value)")|join(", ")) else "NONE on current head" end)  decision=\(if .reviewDecision=="" then "-" else .reviewDecision end)",
     "  threads     : \(.unresolved_threads) unresolved",
+    (if .unanswered_comments > 0 then
+       "  comments    : \(.unanswered_comments) unanswered (\(.unanswered_by|join(", ")))\(if .unanswered_human == 0 then " — bots only, not gating" else "" end)"
+     else empty end),
     "  merge       : methods=[\(.merge_methods|join(","))] auto=\(.auto_merge_allowed) queue=\(.queue_active)",
     (if .queue_entry then
        "  in queue    : position \(.queue_entry.position), \(.queue_entry.state)\(if (.queue_entry.eta != null) then ", ~\(((.queue_entry.eta) / 60) | floor) min" else "" end)"

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -230,7 +230,7 @@ collect() {
         # The last page, not the first: a Self-review attestation (see the
         # header) is posted at the end of a conversation, and an old page
         # would go blind on exactly the PRs long enough to need one.
-        comments(last:100){ nodes{ author{login} body url createdAt } }
+        comments(last:100){ nodes{ author{login __typename} body url createdAt } }
         reviews(last:50){ nodes{ author{login} state commit{oid} body } }
         reviewRequests(first:20){ nodes{ requestedReviewer{
           ... on User{login} ... on Bot{login} ... on Team{slug} } } }
@@ -366,7 +366,15 @@ evaluate() {
                             | select(.createdAt > $author_last_comment)]) as $unanswered_comments
     # Bots are reported but never drive the ladder: a Renovate or Dependabot
     # note must not push its own PR off the auto-merge rung it exists to reach.
-    | ([$unanswered_comments[] | select((.author.login | test("\\[bot\\]$|^(dependabot|renovate|copilot)"; "i")) | not)]) as $unanswered_human
+    # __typename is the authority, not the login. GraphQL returns Bot for an
+    # App and strips the [bot] suffix REST appends, so a login test alone reads
+    # "github-actions" and "sonarqubecloud" as people — measured on this very
+    # pull request, whose CI comments took it off the merge rung on the first
+    # attempt. The login patterns stay as a fallback for callers that supply a
+    # REST-shaped author, and for App-backed User accounts.
+    | ([$unanswered_comments[]
+        | select(((.author.__typename // "") == "Bot") | not)
+        | select((.author.login | test("\\[bot\\]$|^(dependabot|renovate|copilot)"; "i")) | not)]) as $unanswered_human
     # A cancelled context that reported again under the same name is STALE:
     # the later row is the answer and the cancelled one is a leftover. One that
     # never reported again is genuinely unmet and still shuts the gate — but it

--- a/tests/test_pr_status_unanswered_comments.sh
+++ b/tests/test_pr_status_unanswered_comments.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Regression test: prose written under a pull request must not be invisible.
+#
+# A reviewer who comments under the PR rather than on a line of the diff
+# produces an ISSUE comment. It appears in neither reviewThreads nor the check
+# rollup, so a report built from those alone says "threads: 0 unresolved" while
+# the findings sit unread. Observed on phpDocumentor/guides#1352 (2026-08-28):
+# three comments waiting, two of them substantive, reported as nothing open.
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+contains() { # contains <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *) echo "  FAIL $1: '$2' not found in output"; fail=1 ;;
+    esac
+}
+lacks() { # lacks <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: '$2' should not appear"; fail=1 ;;
+        *) echo "  ok   $1" ;;
+    esac
+}
+
+# COMMENTS_JSON is [{"author":…,"body":…,"createdAt":…}]. createdAt is what
+# separates answered from unanswered, so it is never defaulted here: a comment
+# without one would silently compare as older than everything and the whole
+# test would pass against a script that does nothing.
+make_stub() {
+    printf '%s\n' '[]' > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+    chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json, os
+out = sys.argv[1]
+head = "deadbeefcafe"
+comments = [{"author": {"login": c["author"]}, "body": c.get("body", "x"),
+             "url": "https://example.test/c", "createdAt": c["createdAt"]}
+            for c in json.loads(os.environ["COMMENTS_JSON"])]
+json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "reviewDecision": None,
+        "author": {"login": "author"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "comments": {"nodes": comments},
+        "reviews": {"nodes": [{"author": {"login": "reviewer"}, "state": "APPROVED",
+                               "commit": {"oid": head}, "body": "lgtm"}]},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS", "contexts": {"nodes": [
+                {"__typename": "CheckRun", "name": "CI", "conclusion": "SUCCESS",
+                 "status": "COMPLETED", "detailsUrl": "u",
+                 "startedAt": "2026-01-01T00:00:00Z"}]}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
+}
+
+run() { PATH="$STUB_DIR:$PATH" "$SCRIPT" -R o/r 1 2>&1; }
+action() { PATH="$STUB_DIR:$PATH" "$SCRIPT" -R o/r 1 --json 2>/dev/null | jq -r .next.action; }
+
+echo "Case 1: a maintainer comment newer than the last word of the author"
+COMMENTS_JSON='[{"author":"author","createdAt":"2026-08-01T10:00:00Z"},
+                {"author":"linawolf","createdAt":"2026-08-02T10:00:00Z"}]' make_stub
+out="$(run)"
+check   "NEXT is address-comments" "address-comments" "$(action)"
+contains "report names the commenter" "1 unanswered (linawolf)" "$out"
+
+echo "Case 2: the author answered afterwards"
+COMMENTS_JSON='[{"author":"linawolf","createdAt":"2026-08-02T10:00:00Z"},
+                {"author":"author","createdAt":"2026-08-03T10:00:00Z"}]' make_stub
+out="$(run)"
+check "answered comments do not drive NEXT" "merge" "$(action)"
+lacks "no comments line once answered" "unanswered" "$out"
+
+echo "Case 3: a bot comment is reported but never gates"
+COMMENTS_JSON='[{"author":"renovate[bot]","createdAt":"2026-08-02T10:00:00Z"}]' make_stub
+out="$(run)"
+check    "a bot must not push its own PR off the merge rung" "merge" "$(action)"
+contains "bot comment is still visible"  "bots only, not gating" "$out"
+
+echo "Case 4: the author never commented at all"
+COMMENTS_JSON='[{"author":"jaapio","createdAt":"2026-08-02T10:00:00Z"}]' make_stub
+check "silence by the author does not mean answered" "address-comments" "$(action)"
+
+echo "Case 5: an open review thread stays the more specific answer"
+COMMENTS_JSON='[{"author":"linawolf","createdAt":"2026-08-02T10:00:00Z"}]' make_stub
+python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json
+p = sys.argv[1]
+d = json.load(open(p))
+d["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"] = [
+    {"id": "T1", "isResolved": False, "isOutdated": False,
+     "comments": {"nodes": [{"databaseId": 9, "author": {"login": "linawolf"},
+                             "path": "src/x.php"}]}}]
+json.dump(d, open(p, "w"))
+PY
+check "threads outrank loose comments" "resolve-threads" "$(action)"
+
+[ "$fail" = "0" ] && echo "All cases passed." || echo "FAILURES"
+exit "$fail"

--- a/tests/test_pr_status_unanswered_comments.sh
+++ b/tests/test_pr_status_unanswered_comments.sh
@@ -57,7 +57,9 @@ STUB
 import sys, json, os
 out = sys.argv[1]
 head = "deadbeefcafe"
-comments = [{"author": {"login": c["author"]}, "body": c.get("body", "x"),
+comments = [{"author": {"login": c["author"],
+                        "__typename": c.get("type", "User")},
+             "body": c.get("body", "x"),
              "url": "https://example.test/c", "createdAt": c["createdAt"]}
             for c in json.loads(os.environ["COMMENTS_JSON"])]
 json.dump({"data": {"repository": {
@@ -107,6 +109,16 @@ COMMENTS_JSON='[{"author":"renovate[bot]","createdAt":"2026-08-02T10:00:00Z"}]' 
 out="$(run)"
 check    "a bot must not push its own PR off the merge rung" "merge" "$(action)"
 contains "bot comment is still visible"  "bots only, not gating" "$out"
+
+echo "Case 3b: an App whose login carries no [bot] suffix"
+# GraphQL returns Bot for an App and strips the [bot] suffix that REST appends,
+# so logins like github-actions and sonarqubecloud read as people to a login
+# test. Measured on netresearch/git-workflow-skill#252, where exactly this took
+# the PR off the merge rung.
+COMMENTS_JSON='[{"author":"sonarqubecloud","type":"Bot","createdAt":"2026-08-02T10:00:00Z"}]' make_stub
+out="$(run)"
+check    "__typename Bot outranks a human-looking login" "merge" "$(action)"
+contains "the App comment is still visible" "bots only, not gating" "$out"
 
 echo "Case 4: the author never commented at all"
 COMMENTS_JSON='[{"author":"jaapio","createdAt":"2026-08-02T10:00:00Z"}]' make_stub


### PR DESCRIPTION
`pr-status.sh` reports two feedback channels — the check rollup and `reviewThreads` — and treats their silence as silence overall. There is a third. A reviewer who writes prose *under* the pull request rather than on a line of the diff produces an **issue comment**, which appears in neither, so the tool prints `threads: 0 unresolved` while the findings sit unread and the `NEXT:` line advances to `request-review` or `merge`.

I hit this on [phpDocumentor/guides#1352](https://github.com/phpDocumentor/guides/pull/1352) on 2026-08-28: three comments waiting, two of them substantive findings from a maintainer (an untested option combination, and a regression-test value that missed `PHP_INT_MAX` by seven orders of magnitude). I reported the PR as having nothing open, on the strength of this tool, until a human asked whether I had read them.

## What changed

The GraphQL query already fetched the comments — they were used only to find the author's own `Self-review:` attestation. This adds `createdAt` to that field, counts what arrived after the last word of the author, reports it, and adds an `address-comments` rung to the ladder.

Placement is deliberate: **below** `resolve-threads`, which names a file and a thread id and is the more specific answer, and **above** draft and every review and merge branch, because unread feedback is real work however the PR is parked.

Bot comments are counted and shown but never drive the ladder (`$unanswered_human`), so a Renovate or Dependabot note cannot push its own PR off the auto-merge rung it exists to reach. The signal for that is the GraphQL `__typename`, not the login: GraphQL returns `Bot` for an App and strips the `[bot]` suffix REST appends, so a login test alone reads `github-actions` and `sonarqubecloud` as people. The first commit here got that wrong and **this pull request demonstrated it on itself** — its own CI comments produced `NEXT: address-comments` for two machine notices. Fixed in the second commit, with a case pinning it.

## What it looks like

```
  threads     : 0 unresolved
  comments    : 1 unanswered (linawolf)

NEXT: address-comments — 1 comment(s) posted after your last word by linawolf — issue comments live outside reviewThreads, so "0 unresolved" above does not cover them
```

## Verification

`tests/test_pr_status_unanswered_comments.sh` drives the real script against a stubbed `gh`, six cases: a maintainer comment newer than the author's last word, the author having answered afterwards, a bot-only comment, an App whose login carries no `[bot]` suffix, an author who never commented at all, and an open review thread that must stay the more specific answer. Without this change the test fails, and the failure is the defect itself — `NEXT=merge` for a PR carrying an unread maintainer comment.

The repo's own suite caught two things I had missed on the first pass and both are fixed here: the four new `--json` keys were absent from the `--json contract` header (`test_pr_status_json_contract.sh`), and `address-comments` was emitted without being classified as actionable (`test_pr_status_draft_watch.sh`), which would have made `--watch` sleep through it.

Full suite (13 files), `scripts/verify-harness.sh` and `shellcheck` are green. Also ran the patched script against eight live PRs on phpDocumentor/guides: the new line appears on exactly the three whose newest comment is from someone other than the author, and on none of the other five.

No version bump — that belongs to the release flow.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Mf63edGvCVRQz6mwF8gxcC)_
