### PR TITLE
docs(references): stash no-ops on committed changes, and reviewing claims

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -215,6 +215,61 @@ old=$(cd src && git stash -q; ./script.sh; true)
 If a probe genuinely needs a clean tree, commit first (see the sibling rules on
 selective revert and selective commit) — do not stash your way there.
 
+### A control run must prove the change is gone, not assume the removal worked
+
+The sibling rule above keeps stash out of a probe. This one is about the
+opposite direction: using stash *deliberately* to remove your change so you can
+measure the baseline. `git stash push -- <paths>` captures *uncommitted* work
+for those paths — staged entries as well as unstaged edits, clearing the index
+entry in the process — and nothing else. Once your change is committed there is
+nothing left for it to take: it stashes nothing, exits 0, and prints a message
+you skim past. The "control" then runs the very code it was supposed to
+exclude.
+
+That produces the most dangerous shape a measurement can have — a result that
+confirms what you hoped, for a reason that has nothing to do with the code.
+Both runs report identical numbers, you write "behaviour is unchanged", and the
+evidence is a tautology. The only tell is that the matching `git stash pop`
+fails with `No stash entries found`, at the end, after the conclusion is
+already formed.
+
+```bash
+# ❌ Silently a no-op when the change is committed — both runs are identical
+#    because both runs are the SAME code
+git stash push -- config/app.php
+./vendor/bin/phpunit                 # "baseline"
+git stash pop
+
+# ✅ For a committed change, take the file back to the base revision.
+#    `git checkout <rev> -- <path>` overwrites index AND worktree for that path,
+#    and the restore below returns it to HEAD — not to edits you had in flight.
+#    So start from a clean tree, or do this in a throwaway worktree.
+set -euo pipefail   # a failed checkout or status must abort, not be stepped over
+
+st=$(git status --porcelain)
+[ -z "$st" ] || { echo 'dirty tree, refusing'; exit 1; }
+
+git checkout <base-sha> -- config/app.php
+
+# grep exits 0 = found, 1 = absent, 2 = could not read. Only 1 proves absence,
+# so branch on the code: `grep -q … && fail` treats a read error as "absent"
+# and waves the baseline through, and a bare `grep -n` succeeds when the
+# construct is still THERE, which is the same hole facing the other way.
+set +e; grep -q 'theConstructYouRemoved' config/app.php; rc=$?; set -e
+[ "$rc" -eq 1 ] || { echo "still present or unreadable (grep exit $rc)"; exit 1; }
+
+./vendor/bin/phpunit                              # real baseline
+
+git checkout HEAD -- config/app.php               # restore
+st=$(git status --porcelain)
+[ -z "$st" ] || { echo 'tree not restored'; exit 1; }
+```
+
+Whatever mechanism you use, assert the removal before you measure and assert the
+restoration afterwards, and make both assertions fail loudly — a check that
+exits 0 whether or not the condition holds is decoration. Neither costs a
+second, and without them a green A/B says nothing at all.
+
 ### Basic Stash Operations
 
 ```bash

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -317,6 +317,22 @@ web UI: consistent authentication, structured `--json` output, and clearer
 errors. Drop to raw `gh api` only for endpoints the porcelain commands don't
 cover yet.
 
+### Two `gh` shapes that read as bugs and are not
+
+`gh pr view --json merged` fails with `Unknown JSON field: "merged"` and then
+prints the whole valid-field list starting at `additions`, which buries the
+answer. There is no `merged` boolean: ask for `state` (`MERGED`), `mergedAt`,
+or `mergeCommit`.
+
+`gh repo fork <owner/repo> --remote=false` is refused outright —
+`the --remote flag is unsupported when a repository argument is provided`. The
+flag only applies when forking the repo you are standing in. To fork something
+else without touching local remotes, pass only `--clone=false`.
+
+Neither is worth a second attempt with the same shape, and they fail for
+different reasons: the first names a JSON field that does not exist, the second
+combines a flag with an argument it is not valid alongside.
+
 ### The quotas are session-shared pools — act, don't re-preflight
 
 Every `gh` call in a session draws from a shared pool — REST 5,000/h and
@@ -398,6 +414,37 @@ have to actually perform.
 Build the before/after table *before* writing the summary sentence. Filling in
 the rows is what catches the case you assumed was untouched; writing the
 sentence first only records the assumption.
+
+### On a small, gated diff, point review rounds at the claims, not the code
+
+A two-file change that every gate has already passed has very little room left
+for a code defect, and a great deal of room for a wrong sentence about it. The
+prose is the part nothing checks: no linter reads the commit message, no test
+runs the PR body, and a maintainer decides from exactly those.
+
+The asymmetry is easy to measure once you look for it. Across four review
+rounds on a two-file config fix, the tree never changed — same hash through
+four commit revisions — while every round found something: a mechanism claimed
+backwards, a blast radius copied from an issue and never traced, a verification
+matrix that claimed more coverage than was run, a `grep` quoted in a form that
+returns different results than stated, a cited line number pointing at a file
+the installed version no longer ships.
+
+So when the diff is small and the gates are green, brief the reviewer on the
+text: every number, every cited file and line, every version range, every
+"affects X", every "I ran Y". Ask for the claim to be checked against the
+source, not for an opinion on the code. Two things make this cheap and worth
+repeating:
+
+- Give the reviewer the SHA and require it back. That does not stop a finding
+  from describing a revision you have already replaced — it makes the mismatch
+  visible, which is the part you can act on.
+- Verify each finding yourself before acting on it. A reviewer's premise can be
+  wrong too, and a confidently wrong correction is worse than the error it
+  replaces.
+
+Stop when a round returns only wording, not substance. Rounds that converge on
+phrasing have found the floor.
 
 ### A PR body describes the branch it had, not the branch it has
 


### PR DESCRIPTION
Three lessons from a session on 2026-08-28 that fixed a broken Rector job across the TYPO3 extension estate and contributed the upstream fix. Docs only — no script, hook or eval touched.

## `git stash` is a silent no-op on a committed change

`advanced-git.md` gains a section next to the existing "A probe command is read-only". That one keeps stash *out* of a probe; this one is the opposite direction — using stash deliberately to remove your own change so you can measure a baseline.

`git stash push -- <paths>` only touches the working tree. Once the change is committed it stashes nothing, exits 0, and the "control" run executes the very code it was supposed to exclude. Both runs then report identical numbers, which reads as proof that behaviour is unchanged and is in fact a tautology. The only tell is the matching `git stash pop` failing with `No stash entries found`, at the end, after the conclusion has already been written down.

The section gives the `git checkout <base-sha> -- <paths>` shape for committed changes, and asks for two assertions that cost nothing: grep that the construct is actually gone before measuring, and `git status --porcelain` that the tree is back afterwards.

## On a small, gated diff, review the claims rather than the code

`pull-request-workflow.md` gains a section next to "'Unchanged' is a claim, and needs the same proof".

A two-file change that every gate has passed has little room left for a code defect and a lot of room for a wrong sentence about it. Nothing checks the prose: no linter reads a commit message, no test runs a PR body, and a maintainer decides from exactly those.

The asymmetry was measurable in that session. Across four review rounds on a two-file config fix the tree hash never changed — same hash through four commit revisions — while every round found a wrong claim: a mechanism described backwards, a blast radius copied from an upstream issue and never traced, a verification matrix claiming more coverage than had been run, a `grep` quoted in a form that returns different results than stated, and a line citation pointing into a file the installed version no longer ships.

So the section says to brief reviewers on the text, name the SHA and require it back, verify each finding before acting on it (a reviewer's premise can be wrong too), and stop when a round returns only wording.

## Two `gh` shapes that read as bugs and are not

Same file, under the existing gh CLI section. `gh pr view --json merged` has no such field — the error then prints the entire valid-field list starting at `additions`, which buries the answer; ask for `state`, `mergedAt` or `mergeCommit`. And `gh repo fork <owner/repo> --remote=false` is refused outright, because `--remote` only applies when forking the repo you are standing in; pass only `--clone=false`.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
