### PR TITLE
fix(pr-finish): lead the preflight with pr-status.sh so it passes this repo's own gate

### DIFF
--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -20,14 +20,21 @@ resolution, and merge-queue handling. Then execute, in order:
 
    ```bash
    R=<owner/repo>; PR=<number>; BASE=<base-branch>
-   gh pr view   $PR --repo $R --json state,mergeable,mergeStateStatus,reviewDecision,headRefOid,baseRefName,title
+   # pr-status.sh FIRST — this repo's own PreToolUse gate (scripts/validate_git_command.py)
+   # denies a `gh pr view --json …mergeStateStatus…` that is not accompanied by it, and the
+   # gate reads the whole invocation, so one block carrying both is the shape it accepts.
+   "$SKILL/scripts/pr-status.sh" -R $R $PR   # $SKILL = the installed git-workflow skill dir; the deny message prints the absolute path
+   gh pr view   $PR --repo $R --json headRefOid,baseRefName,title
    gh pr checks $PR --repo $R
    gh api repos/$R/rules/branches/$BASE   # effective rules INCL. rulesets (e.g. copilot_code_review) — evaluated against the BASE branch; classic branch-protection API misses these
    gh pr view   $PR --repo $R --json reviewRequests --jq '.reviewRequests'
    gh api graphql -F owner="${R%/*}" -F repo="${R#*/}" -F pr="$PR" -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{databaseId author{login} path body}}}}}}}'
    ```
 
-   This yields, in one shot: merge state + why, every required check, **rulesets**
+   `pr-status.sh` already answers state, mergeability, checks, reviews, rulesets and
+   unresolved threads, and ends with a `NEXT:` line naming the action — the remaining
+   calls add what it does not break down. This yields, in one shot: merge state + why,
+   every required check, **rulesets**
    (if a `copilot_code_review` rule is blocking because no review has been triggered yet,
    you can request one via `gh api repos/$R/pulls/$PR/requested_reviewers -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` — but once requested you must wait for it to land before merging; see step 5, never merge over an in-flight review), pending review requests, and the thread IDs needed to reply to and resolve each thread. Reason once from this, not serially.
 

--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -20,10 +20,11 @@ resolution, and merge-queue handling. Then execute, in order:
 
    ```bash
    R=<owner/repo>; PR=<number>; BASE=<base-branch>
+   SKILL=<installed git-workflow skill dir>   # the gate's deny message prints its absolute path
    # pr-status.sh FIRST — this repo's own PreToolUse gate (scripts/validate_git_command.py)
    # denies a `gh pr view --json …mergeStateStatus…` that is not accompanied by it, and the
    # gate reads the whole invocation, so one block carrying both is the shape it accepts.
-   "$SKILL/scripts/pr-status.sh" -R $R $PR   # $SKILL = the installed git-workflow skill dir; the deny message prints the absolute path
+   "$SKILL/scripts/pr-status.sh" -R $R $PR
    gh pr view   $PR --repo $R --json headRefOid,baseRefName,title
    gh pr checks $PR --repo $R
    gh api repos/$R/rules/branches/$BASE   # effective rules INCL. rulesets (e.g. copilot_code_review) — evaluated against the BASE branch; classic branch-protection API misses these

--- a/tests/test_validate_git_command.py
+++ b/tests/test_validate_git_command.py
@@ -10,6 +10,7 @@ names the failure it stands for.
 
 import json
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -164,6 +165,31 @@ def pr_status_path_case(command: str) -> bool:
     return bool(match and os.path.isfile(match.group(1)))
 
 
+COMMANDS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "commands"
+)
+
+
+def shipped_command_blocks():
+    """Every ```bash block in commands/*.md, as (file, block) pairs.
+
+    The commands this repo ships are instructions an agent executes verbatim.
+    A block that the repo's own gate denies costs a round-trip every time the
+    command runs, and reads as the gate misfiring rather than the instruction
+    being wrong — which is exactly how it survived: `/pr-finish` step 0 told
+    the agent to run `gh pr view --json …mergeStateStatus…` without
+    pr-status.sh, and the deny landed twice in one session.
+    """
+    for md in sorted(pathlib.Path(COMMANDS_DIR).glob("*.md")):
+        text = md.read_text()
+        for block in re.findall(r"```bash\n(.*?)```", text, re.DOTALL):
+            body = "\n".join(
+                line.strip() for line in block.splitlines() if line.strip()
+            )
+            if body:
+                yield md.name, body
+
+
 def main() -> int:
     fails = 0
     for name, expected, command in CASES:
@@ -195,6 +221,15 @@ def main() -> int:
             f"  {'OK  ' if ok else 'FAIL'} {name:<44} "
             f"want=abs-path got={'abs-path' if ok else 'bare-name'}"
         )
+
+    denied = 0
+    for fname, block in shipped_command_blocks():
+        if run(block) == "DENY":
+            denied += 1
+            print(f"  FAIL shipped block denied in {fname}:\n{block}")
+    fails += denied
+    if not denied:
+        print("  OK   shipped command blocks pass the gate")
 
     print(f"  ---- failures: {fails}")
     return 1 if fails else 0


### PR DESCRIPTION
`/pr-finish` step 0 instructs the agent to run

```bash
gh pr view $PR --repo $R --json state,mergeable,mergeStateStatus,reviewDecision,headRefOid,baseRefName,title
```

and `scripts/validate_git_command.py` — the PreToolUse gate shipped from this same repo — denies exactly that shape, pointing at `pr-status.sh` instead. So the canonical PR-completion command spends a denied call before it does anything. It landed twice in one session (both `/pr-finish` invocations, on [netresearch/jujutsu-workflow-skill#26](https://github.com/netresearch/jujutsu-workflow-skill/pull/26) and [#27](https://github.com/netresearch/jujutsu-workflow-skill/pull/27)). The deny reads as the gate misfiring rather than as the instruction being wrong, which is how it survived this long.

## The fix

`merge_readiness_without_pr_status()` exempts an invocation that already carries `pr-status.sh`, and it evaluates the whole invocation — so one block holding both is the shape the gate wants. Step 0 now opens with `pr-status.sh`, which answers state, mergeability, checks, reviews, rulesets and unresolved threads in one call and ends with the `NEXT:` line naming the action. The `gh pr view` that follows asks only for what `pr-status.sh` does not break down: `headRefOid`, `baseRefName`, `title`.

## The gate that would have caught it

`tests/test_validate_git_command.py` now extracts every ```bash block from `commands/*.md` and fails if the hook denies one. Instructions this repo ships are executed verbatim; nothing checked that they survive this repo's own gate.

Verified in both directions rather than only green:

| tree | result |
| --- | --- |
| old step 0 restored (`git stash` on `commands/pr-finish.md`) | `---- failures: 1`, printing the denied block |
| with this change | `---- failures: 0` |

Local suite: all 18 test files pass; `scripts/verify-harness.sh --status` reports Level 3 (Enforced) complete.

## Note for the maintainer

`~/.claude/commands/pr-finish.md` as installed here is byte-identical to the copy in `CybotTM/dotclaude` (55 lines), not to this repo's (89 lines) — so the installed command is a diverged fork carrying the same defect, and improvements made here do not reach a session. Handled separately in dotclaude; flagging it because it means this fix alone does not change what an agent actually executes on this machine.

## Review

No bot review was available: Copilot is out of its monthly, account-wide quota (its submitted review says so), and CodeRabbit reported its own review limit reached. Reviewed the diff myself; one finding, fixed in 64bab96.

The preflight block had `"$SKILL/scripts/pr-status.sh"` with `$SKILL` explained only in a trailing comment, while every other value in the block is an angle-bracket placeholder assigned on the first line. An agent pasting it would have expanded `$SKILL` to nothing and called `/scripts/pr-status.sh` — the same class of defect this pull request exists to remove, one line further down. It is now assigned next to `R`, `PR` and `BASE`.

Re-checked after that commit: 18 test files pass, `verify-harness.sh --status` Level 3 complete, `spec-cleanup-guard.sh` clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Mf63edGvCVRQz6mwF8gxcC)_

