### PR TITLE
chore(release): v1.31.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.30.0"
+  version: "1.31.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Version bump to 1.31.0 across `.claude-plugin/plugin.json`, `plugin.json` and `skills/git-workflow/SKILL.md`.

MINOR: the ten commits since [v1.30.0](https://github.com/netresearch/git-workflow-skill/releases/tag/v1.30.0) include a `feat`.

| PR | Change |
| --- | --- |
| [#252](https://github.com/netresearch/git-workflow-skill/pull/252) | `feat(pr-status)`: report issue comments nobody answered; `fix(pr-status)`: read the author type rather than the shape of the login |
| [#253](https://github.com/netresearch/git-workflow-skill/pull/253) | `chore(deps)`: pre-commit hook netresearch/skill-repo-skill to v1.37.0 |
| [#254](https://github.com/netresearch/git-workflow-skill/pull/254) | `docs(references)`: stash no-ops on committed changes, and reviewing claims |
| [#256](https://github.com/netresearch/git-workflow-skill/pull/256) | `fix(pr-finish)`: the step-0 preflight instructed a `gh pr view --json …mergeStateStatus…` that this repo's own PreToolUse gate denies; it now leads with `pr-status.sh`. Adds the test that runs every shipped command block through the gate. |

The motivation for cutting this release now is #256: the released plugin still ships the block the gate rejects, so `/git-workflow:pr-finish` spends a denied call on every run until this lands.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Mf63edGvCVRQz6mwF8gxcC)_
