### PR TITLE
docs(pr-workflow): reading a bot thread, and what resolving one claims

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -810,6 +810,35 @@ gh api graphql -f query='
 
 If that returns any rows, the PR is not merge-ready.
 
+#### Reading a bot body: strip the `<details>` blocks, never split on them
+
+`body[:80]` above tells threads apart; it does not let you read one. CodeRabbit
+opens every comment with a 54-character severity header (`_🎯 Functional
+Correctness_ | _🟡 Minor_ | _⚡ Quick win_`), so 80 characters buy the header
+plus about twenty of the title.
+
+Splitting on the tag is the tempting fix and it fails silently, because the
+blocks appear on **both sides** of the finding: "Supported by static analysis"
+and web-search evidence before it, "Committable suggestion" and "Prompt for AI
+Agents" after it. Over 18 CodeRabbit comments in one session, 7 had a block
+before the finding — so `split("<details>")[0]` returns the bare severity header
+about a third of the time, with nothing to say which third. `split("</details>")[-1]`
+is worse: it returns the trailing `<!-- fingerprinting -->` comments.
+
+Remove the blocks non-greedily across newlines instead, then the HTML comments:
+
+```python
+import re
+
+body = re.sub(r"<details>.*?</details>", "", raw, flags=re.S)  # re.S load-bearing
+body = re.sub(r"<!--.*?-->", "", body, flags=re.S)
+body = re.sub(r"\n{3,}", "\n\n", body).strip()
+```
+
+This holds for any reviewer that folds evidence into `<details>`. Read the
+finding, not the wrapper, before deciding whether a thread is actionable — and
+before replying to it.
+
 ### Wait for the async re-review before trusting `unresolved == 0`
 
 `unresolved == 0` is **not** merge-ready if you sampled it right after a push.

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -615,6 +615,28 @@ gh api graphql -f query='
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_xxx"}) { thread { isResolved } } }'
 ```
 
+### Resolving is a claim about the whole ask, not about the file you edited
+
+A finding often names more than one target — two config files, "the table *and*
+the examples", every caller of a symbol. Fixing the one you opened, replying with
+its SHA and resolving reads exactly like completion, and the thread then carries
+a green mark that stops anyone looking. Nothing in the API checks the claim.
+
+So before `resolveReviewThread`, re-read the comment and enumerate the targets it
+names — by noun, not by impression — and confirm each. A reviewer that writes
+"update the bootstrap table and all affected enforcement and maturity examples"
+has named three things; a commit touching the first two satisfies neither the ask
+nor the thread.
+
+Two habits make this cheap: quote the ask's own list back in the reply and mark
+each item, and grep for the defect's shape across the repository rather than
+across the file you happened to open — the second file is usually the one the
+reviewer could see and you could not.
+
+Where you deliberately do *not* act on part of an ask, say which part and why in
+the reply. "Resolved" with a silent omission is the failure this section exists
+for; an explicit decline is a legitimate outcome the reviewer can argue with.
+
 ### Refusing the lazy pattern
 
 These replies are banned:


### PR DESCRIPTION
Two findings from a retrospective over a session that carried nine skill-repo PRs through review and merge. Both are about the same act — reading and answering a bot review thread — and both were paid for in that session.

## 1. Resolving a thread is a claim about the whole ask

`### Verifying thread state from GitHub, not memory` covers whether a thread is resolved, and warns against trusting your own memory of it. Neither it nor the reply pattern covers whether the *ask* was met, and the failure is invisible from outside: fix the one file you opened, reply with its SHA, resolve — the green mark then stops anyone looking, and nothing in the API checks the claim.

Observed on [netresearch/agent-harness-skill#66](https://github.com/netresearch/agent-harness-skill/pull/66). A reviewer asked for "the bootstrap table and all affected enforcement **and maturity** examples". The commit fixed `enforcement-mechanisms.md`, replied and resolved. `maturity-levels.md` kept two CI examples pointing at `${CLAUDE_SKILL_DIR}/scripts/verify-harness.sh` — a path that expands to `/scripts/verify-harness.sh` inside a GitHub Actions job, where that variable does not exist. The thread read as closed for a full round before the next review caught it.

The new section adds the enumerate-the-nouns step before `resolveReviewThread`, two habits that make it cheap, and the case for saying so explicitly when part of an ask is deliberately declined.

## 2. Read a bot finding by stripping `<details>`, never by splitting on it

The triage snippet in the same file projects `first_comment: .comments.nodes[0].body[:80]`. CodeRabbit opens every comment with a 54-character severity header, so 80 characters buy the header plus roughly twenty of the title — enough to tell threads apart, which is what the snippet is for, and not enough to read one.

Splitting on the tag is the obvious repair and it fails silently, because the blocks sit on **both** sides of the finding: "Supported by static analysis" and web-search evidence before it, "Committable suggestion" and "Prompt for AI Agents" after it. Measured over the 18 CodeRabbit comments in that session, 7 carried a block before the finding — so `split("<details>")[0]` returns the bare severity header about a third of the time, with nothing marking which third. `split("</details>")[-1]` returns the trailing `<!-- fingerprinting -->` comments.

The documented form is the non-greedy `re.S` removal, which was the third thing tried in that session and the only one that works on both shapes.

## Scope

One file, two sections appended, nothing rewritten. The GraphQL query, the `isResolved == false` filter, the reply pattern and the "any rows → not merge-ready" conclusion are untouched — the `body[:80]` projection stays as it is, since telling threads apart is a legitimate use of it.

## Verification

```
validate-skill.sh vs main 8452263: 20 warnings, 0 errors on both — the only delta is the pre-existing
  "pull-request-workflow.md is N lines with no Contents section" line count, 3032 -> 3082
pre-commit run --files skills/git-workflow/references/pull-request-workflow.md: all hooks pass
```

Both quantitative claims in the new text were measured against the real bodies from that session, not estimated: the 54-character header, the 7-of-18 split, and the three extraction attempts.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Txqmch9od8QmcXqPyVJ7bD)_
