### PR TITLE
docs(pr-finish): route a GitLab merge request off the GitHub path

### DIFF
--- a/commands/pr-finish.md
+++ b/commands/pr-finish.md
@@ -12,6 +12,17 @@ PR-completion request, so it runs through the **git-workflow** skill every time.
 (under `skills/git-workflow/`) is authoritative for the merge gate, GraphQL thread
 resolution, and merge-queue handling. Then execute, in order:
 
+**Check the forge before step 0.** Every command below is GitHub — `gh`, GraphQL
+review threads, `mergeStateStatus`, rulesets, merge queue. None of it answers for
+a **GitLab merge request**: `pr-status.sh` accepts `-R git.netresearch.de/group/project`
+and then fails with a bare `pr-status: GraphQL query failed`, and `--watch` produces
+nothing until it is killed. For a GitLab MR, read the gate from
+`references/pull-request-workflow.md` § *GitHub only* — `detailed_merge_status`,
+`blocking_discussions_resolved` and `/discussions` in one `glab api` block — and, at
+Netresearch, the `netresearch-gitlab` skill's `references/glab_cheatsheet.md`. Steps
+1–6 below still apply as *intent* (rebase, fix CI, answer every thread, update the
+description, merge only when the gate is open, clean up); only the commands change.
+
 0. **Preflight — fetch the whole merge-gate picture in ONE mechanical block,
    before reasoning about merge-readiness.** Never discover a gate (BLOCKED,
    required reviews, rulesets, unresolved threads, failing checks) one


### PR DESCRIPTION
## Summary

`/pr-finish` is entirely GitHub-shaped — `gh`, GraphQL review threads, `mergeStateStatus`, rulesets, merge queue — and says so nowhere. Invoked on a GitLab merge request it hands over a preflight block that cannot run, and `pr-status.sh` accepts `-R git.netresearch.de/group/project` before failing with a bare `pr-status: GraphQL query failed`.

The skill already knows the answer: `references/pull-request-workflow.md` § *GitHub only* carries the GitLab equivalent (`detailed_merge_status`, `blocking_discussions_resolved`, `/discussions` in one `glab api` block). The command never pointed at it, so in a session finishing a GitLab MR the whole gate was re-derived by hand.

This adds one paragraph before step 0: check the forge, and if it is GitLab, read the gate from the reference (and, at Netresearch, `netresearch-gitlab`'s `glab_cheatsheet.md`). It states explicitly that steps 1–6 still hold as *intent* — rebase, fix CI, answer every thread, update the description, merge only when the gate is open, clean up — and that only the commands change.

## Scope

`commands/pr-finish.md` only, +11 lines, nothing removed. No step rewritten, no GitLab procedure duplicated into the command — it routes to the reference that owns it. `markdownlint-cli2` clean.

Note, unrelated and not touched here: `Build/Scripts/validate-skill.sh` reports a pre-existing `SKILL.md is 501 words (max 500)` error on `main` as well. It also counts *words*, while `skill-repo-skill`'s current check counts body *lines* (error above 500, warning above 300) — the copy in this repo looks stale.