### PR TITLE
fix(pr-status): hold the watch, name the forge boundary, expire the quota marker

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, resolving PR review comments, merging PRs (including CI verification, auto-merge queues, and post-merge cleanup), managing PR review threads, merging PRs with signed commits, handling merge conflicts, verifying a merge didn't silently drop changes, syncing a long-diverged branch (e.g. master into integration), rebasing a long-lived branch onto a moved base or splitting one into several PRs, integrating Git with CI/CD, setting up git hooks (lefthook, captainhook, husky, pre-commit), or debugging hook-install failures in git worktrees. Not for creating releases (use github-release) or diagnosing BLOCKED/won't-merge PRs (use github-project)."
+description: "Use when establishing branching strategies, implementing Conventional Commits, creating or reviewing PRs, resolving PR review comments, merging PRs (including CI verification, auto-merge queues, and post-merge cleanup), managing PR review threads, merging PRs with signed commits, handling merge conflicts, verifying a merge didn't silently drop changes, syncing a long-diverged branch (e.g. master into integration), rebasing a long-lived branch onto a moved base or splitting one into several PRs, integrating Git with CI/CD, setting up git hooks (lefthook, captainhook, husky, pre-commit), or debugging hook-install failures in git worktrees. The pull-request tooling is GitHub-only — for a GitLab merge request use netresearch-gitlab. Not for creating releases (use github-release) or diagnosing BLOCKED/won't-merge PRs (use github-project)."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
@@ -15,6 +15,8 @@ allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ## Not Here
 
 Releases: `github-release`. BLOCKED-PR diagnosis: `github-project`.
+
+**GitHub only.** Everything below the branching and commit sections — `pr-status.sh`, `pr-merge.sh`, the merge gate, review threads — speaks GitHub GraphQL. A GitLab merge request belongs to `netresearch-gitlab`; the equivalent `glab` calls are in `references/pull-request-workflow.md` § *GitHub only*.
 
 ## Critical Rules (Non-Negotiable)
 

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -622,7 +622,11 @@ evaluate() {
          elif ($s.checks.failing_required|length) > 0 then
            {action:"fix-ci", why:"required check(s) failing: \($s.checks.failing_required|join(", "))",
             urls:$s.checks.failing_urls}
-         elif ($s.checks.fail > 0) then
+         # Only once every required check has concluded. While one is still
+         # running, a red non-required check is information: it cannot be what
+         # keeps the gate shut yet, and returning an action here ends a --watch
+         # that has nothing to act on. The wait branch below names it instead.
+         elif ($s.checks.fail > 0 and ($s.checks.pending_required|length) == 0) then
            {action:"triage-ci", why:"non-required check(s) failing: \($s.checks.failing|join(", ")) — not merge-blocking on their own, but UNSTABLE keeps the gate shut",
             urls:$s.checks.failing_urls}
          elif $s.unresolved_threads > 0 then
@@ -867,7 +871,11 @@ evaluate() {
                  + " Enqueueing now risks the merge queue dropping the entry when its"
                  + " required check never starts")}
          elif ($s.checks.pending_required|length) > 0 then
-           {action:"wait", why:"required check(s) still running: \($s.checks.pending_required|join(", "))"}
+           {action:"wait",
+            why:("required check(s) still running: \($s.checks.pending_required|join(", "))"
+                 + (if $s.checks.fail > 0
+                    then " — non-required red meanwhile: \($s.checks.failing|join(", ")); it decides nothing until the required ones conclude"
+                    else "" end))}
          elif ($s.mergeState == "CLEAN"
                and ($s.merge_methods|index("merge")|not)
                and ($s.merge_methods|index("rebase")|not)) then
@@ -1032,6 +1040,16 @@ while :; do
   s=$(snapshot)
   act=$(jq -r '.next.action' <<<"$s")
   fails=$(jq -r '.checks.failing|join(",")' <<<"$s")
+  # A red REQUIRED check is actionable the moment it appears. A red
+  # non-required one is not, while a required check is still running: it
+  # cannot be what keeps the gate shut yet, and returning on it ends the watch
+  # with nothing to do (#249). Hold until the required checks conclude — then
+  # the same red check is the reason the gate stays shut, and this fires.
+  fails_required=$(jq -r '.checks.failing_required|join(",")' <<<"$s")
+  pending_required=$(jq -r '.checks.pending_required|length' <<<"$s")
+  if [ -z "$fails_required" ] && [ "$pending_required" -gt 0 ]; then
+    fails=""
+  fi
 
   # The ignore test sits on this exit too, but ONLY when the standing action
   # the caller declined IS the CI action (fix-ci/triage-ci) — then its failing

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -78,8 +78,8 @@
 #   checks checks_settled threads unresolved_threads
 #   unanswered_comments unanswered_human unanswered_by unanswered_urls
 #   reviewDecision reviews_on_head has_review_on_head
-#   has_copilot_review_on_head copilot_review_errored copilot_error_count copilot_quota_hit
-#   copilot_quota_exhausted
+#   has_copilot_review_on_head copilot_latest_on_head_ok copilot_review_errored
+#   copilot_error_count copilot_quota_hit copilot_quota_exhausted
 #   self_review_on_head self_review_url
 #   requested_reviewers
 #   merge_methods auto_merge_allowed queue_active queue_entry
@@ -524,6 +524,14 @@ evaluate() {
                           | add // {}),
         has_review_on_head: (($head_reviews|length) > 0),
         has_copilot_review_on_head: (($copilot_on_head|length) > 0),
+        # Which of the two came last, not merely which exists. reviews(last:50)
+        # is chronological, so the final Copilot row on this head decides: a
+        # delivered review after an errored quota row means the wall lifted, and
+        # an errored row after a delivered one means it is back. Asking only
+        # "is there a review" would clear the marker in the second case too.
+        copilot_latest_on_head_ok:
+          (([$reviews_raw[] | select(.author.login | test("copilot"; "i"))] | last)
+           | if . == null then false else (is_errored_copilot_review | not) end),
         # True when Copilot answered on this head with an error body rather than
         # a review. Derived from the review body alone — see the comment above
         # $copilot_errored for why the check-run is not consulted.
@@ -907,7 +915,7 @@ evaluate() {
                  + " required check never starts")}
          elif ($s.checks.pending_required|length) > 0 then
            {action:"wait",
-            why:("required check(s) still running: \($s.checks.pending_required|join(", "))"
+            why:("required check(s) still pending: \($s.checks.pending_required|join(", "))"
                  + (if $s.checks.fail > 0
                     then " — non-required red meanwhile: \($s.checks.failing|join(", ")); it decides nothing until the required ones conclude"
                     else "" end))}
@@ -1053,13 +1061,13 @@ snapshot() {
   # copilot_quota_exhausted the marker would re-assert itself, and the PR named
   # inside it would be whichever one read the file rather than the one that
   # proved the wall — the single thing the content is there to answer.
-  if [ "$(jq -r '.copilot_quota_hit // false' <<<"$out")" = "true" ]; then
-    remember_quota_hit
-  # A Copilot review that actually landed outranks a remembered wall: the
-  # account had quota at least until this review, so keeping the marker would
-  # route the next PR to self-review against present evidence (#255).
-  elif [ "$(jq -r '.has_copilot_review_on_head // false' <<<"$out")" = "true" ]; then
+  # Order decides, so this is asked FIRST: an errored quota row and a delivered
+  # review can both sit on the same head, and then copilot_quota_hit alone would
+  # re-arm the marker although the wall has since lifted (#255).
+  if [ "$(jq -r '.copilot_latest_on_head_ok // false' <<<"$out")" = "true" ]; then
     forget_quota_hit
+  elif [ "$(jq -r '.copilot_quota_hit // false' <<<"$out")" = "true" ]; then
+    remember_quota_hit
   fi
   printf '%s\n' "$out"
 }

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -215,8 +215,28 @@ QUOTA_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/pr-status"
 # The month is in the NAME, not in the mtime: any later write would refresh an
 # mtime and make a marker outlive the reset it describes.
 QUOTA_MARKER="$QUOTA_DIR/copilot-quota-exhausted-$(date -u +%Y-%m)"
+# ... and the marker expires, because the wall does not last the month. Measured
+# on one machine: recorded 2026-08-18, a normal Copilot review delivered
+# 2026-08-29, the wall back ten minutes later. A marker believed until the month
+# rolls over turns one transient error into weeks of suppressed bot review, and
+# nothing re-probes. After the TTL the next run asks again and either re-arms it
+# or leaves it gone (#255). remember_quota_hit() never rewrites an existing
+# marker, so the mtime stays the moment the wall was first proven.
+QUOTA_TTL_HOURS="${PR_STATUS_QUOTA_TTL_HOURS:-6}"
 
-quota_marker_seen() { if [ -f "$QUOTA_MARKER" ]; then echo true; else echo false; fi; }
+quota_marker_seen() {
+  [ -f "$QUOTA_MARKER" ] || { echo false; return; }
+  if [ -n "$(find "$QUOTA_MARKER" -mmin "+$((QUOTA_TTL_HOURS * 60))" 2>/dev/null)" ]; then
+    rm -f "$QUOTA_MARKER" 2>/dev/null || :
+    echo false; return
+  fi
+  echo true
+}
+
+# A delivered Copilot review is the only positive evidence the wall is gone.
+# Acting on it beats waiting out the TTL: the very run that sees the review
+# would otherwise still route to self-review.
+forget_quota_hit() { rm -f "$QUOTA_MARKER" 2>/dev/null || :; }
 
 # Best-effort by design: the marker only saves a wasted re-request, so a
 # read-only or full cache directory must never turn a status query into a
@@ -608,13 +628,14 @@ evaluate() {
     # the file to undo it.
     | (if $s.copilot_quota_hit
        then "the error body on this pull request says the requesting user reached the quota limit"
-       else "an earlier run recorded the wall this month in \($marker_path) — delete that file if it was recorded in error"
+       else "an earlier run recorded the wall in \($marker_path) — delete that file if it was recorded in error"
        end) as $quota_evidence
-    | ("Copilot is OUT OF REVIEW QUOTA — \($quota_evidence). The quota is MONTHLY and"
-       + " account-wide: it will not recover this month, on this or any other PR, and"
-       + " re-requesting cannot change that. Review the diff yourself, note in the PR that"
-       + " the bot review was unavailable, and decide on that. Treat this notice as covering"
-       + " every PR until the monthly reset."
+    | ("Copilot is OUT OF REVIEW QUOTA — \($quota_evidence). The quota is account-wide, so"
+       + " re-requesting on another PR will not get around it right now. When it comes back"
+       + " is not something this tool can predict: it has been seen to return within the"
+       + " same month and go again minutes later, so the record above expires on its own and"
+       + " is dropped as soon as a Copilot review is observed. Review the diff yourself, note"
+       + " in the PR that the bot review was unavailable, and decide on that."
        + " To proceed on a documented self-review, post a PR comment (as the PR author)"
        + " containing the line `Self-review: <head-sha>` with at least the first 12"
        + " chars of \($s.headOid[0:12]) — pr-merge.sh --self-reviewed posts it and merges in"
@@ -1034,6 +1055,11 @@ snapshot() {
   # proved the wall — the single thing the content is there to answer.
   if [ "$(jq -r '.copilot_quota_hit // false' <<<"$out")" = "true" ]; then
     remember_quota_hit
+  # A Copilot review that actually landed outranks a remembered wall: the
+  # account had quota at least until this review, so keeping the marker would
+  # route the next PR to self-review against present evidence (#255).
+  elif [ "$(jq -r '.has_copilot_review_on_head // false' <<<"$out")" = "true" ]; then
+    forget_quota_hit
   fi
   printf '%s\n' "$out"
 }

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -190,6 +190,20 @@ if [ -z "$PR" ]; then
 fi
 OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
 
+# This script speaks GitHub GraphQL and nothing else. A GitLab project reads
+# host/group/project, which parses here without complaint and then dies deep in
+# the query as a bare "GraphQL query failed" — and --watch heartbeats into its
+# timeout on a query that can never succeed. Refuse it up front and name where
+# the answer lives instead (#250).
+case "$REPO" in
+  */*/*)
+    die "\"$REPO\" is not owner/repo. pr-status.sh is GitHub-only; for a GitLab merge request see references/pull-request-workflow.md § \"GitHub only\" and the netresearch-gitlab skill" ;;
+esac
+case "${OWNER}" in
+  *.*)
+    die "\"$OWNER\" looks like a host, not a GitHub owner. pr-status.sh is GitHub-only; for a GitLab merge request see references/pull-request-workflow.md § \"GitHub only\" and the netresearch-gitlab skill" ;;
+esac
+
 # --------------------------------------------------------- quota marker -----
 # The Copilot review quota is account-wide and monthly; the evidence for it is
 # not. It arrives as an error body on ONE pull request, and every other PR of

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -285,11 +285,22 @@ check "copilot_error_count" "1"              "$(run_flag copilot_error_count)"
 check "next.action"         "request-review" "$(run_next)"
 check "next.cmd absent"     "null"           "$(run_flag 'next.cmd')"
 check "next.reason"         "bot-review-unsatisfiable" "$(run_flag 'next.reason')"
-if status | jq -e '.next.why | test("MONTHLY")' >/dev/null; then
-    echo "  ok   why states the quota is monthly and will not recover"
+# Was test("MONTHLY"), pinning the claim that the quota "will not recover this
+# month" — withdrawn in #255, where a wall recorded on the 18th was followed by
+# a delivered review on the 29th. What still has to be said is that the wall is
+# account-wide, so another PR is no way around it; when it lifts is now stated
+# as unknown, and the marker expires instead of being believed to the reset.
+if status | jq -e '.next.why | test("account-wide")' >/dev/null; then
+    echo "  ok   why states the quota is account-wide"
 else
-    echo "  FAIL why lacks the monthly-quota advice"
+    echo "  FAIL why lacks the account-wide advice"
     fail=1
+fi
+if status | jq -e '.next.why | test("will not recover this month")' >/dev/null; then
+    echo "  FAIL why still predicts a recovery date"
+    fail=1
+else
+    echo "  ok   why no longer predicts when the quota returns"
 fi
 
 # The quota detector must be able to stay quiet: a generic outage row must not

--- a/tests/test_pr_status_quota_marker_expiry.sh
+++ b/tests/test_pr_status_quota_marker_expiry.sh
@@ -67,7 +67,16 @@ STUB
 import sys, json, os
 out = sys.argv[1]
 head = "deadbeefcafe"
+# COPILOT_SEQ lists the Copilot rows on this head in chronological order, the
+# order reviews(last:50) returns them in: "ok" a delivered review, "err" the
+# quota error. Both can sit on one head, and which came last is what decides.
+ERR = ("Copilot was unable to review this pull request because the user who "
+       "requested the review has reached their quota limit.")
 reviews = []
+for kind in [s for s in os.environ.get("COPILOT_SEQ", "").split(",") if s]:
+    reviews.append({"author": {"login": "copilot-pull-request-reviewer"},
+                    "state": "COMMENTED", "commit": {"oid": head},
+                    "body": ERR if kind == "err" else "looks fine"})
 if os.environ.get("COPILOT_REVIEW", "0") == "1":
     reviews.append({"author": {"login": "copilot-pull-request-reviewer"},
                     "state": "COMMENTED", "commit": {"oid": head}, "body": "looks fine"})
@@ -121,5 +130,20 @@ echo "case: the TTL is configurable"
 COPILOT_REVIEW=0 make_stub; arm_marker "2 hours ago"
 out=$(PR_STATUS_QUOTA_TTL_HOURS=1 status)
 check "marker removed at a 1h TTL" "no" "$(marker_exists)"
+
+# Both rows can sit on one head. Asking only "is there a review" clears the
+# marker in the second case too, where the wall is demonstrably back.
+echo "case: quota error, then a delivered review -> marker cleared"
+COPILOT_SEQ="err,ok" make_stub; arm_marker
+out=$(status)
+check "marker cleared" "no" "$(marker_exists)"
+
+# No wording assertion here: the delivered row satisfies the review gate, so
+# this snapshot goes to the merge branch, which carries no quota sentence. What
+# matters is that the marker is not cleared by a review the error outlived.
+echo "case: a delivered review, then the quota error -> marker stands"
+COPILOT_SEQ="ok,err" make_stub; rm -f "$MARKER"
+out=$(status)
+check "marker re-armed" "yes" "$(marker_exists)"
 
 exit "$fail"

--- a/tests/test_pr_status_quota_marker_expiry.sh
+++ b/tests/test_pr_status_quota_marker_expiry.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Regression test for #255: the recorded Copilot quota wall must expire, and a
+# delivered Copilot review must clear it.
+#
+# The marker was believed until the calendar month rolled over, and its wording
+# asserted the quota "will not recover this month". Measured on one machine:
+# recorded 2026-08-18, a normal Copilot review delivered 2026-08-29, the wall
+# back ten minutes later. So one transient error could route every PR to
+# self-review for weeks, with nothing re-probing.
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+check_contains() { # check_contains <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *) echo "  FAIL $1: no '$2' in output"; fail=1 ;;
+    esac
+}
+check_absent() { # check_absent <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: unexpected '$2' in output"; fail=1 ;;
+        *) echo "  ok   $1" ;;
+    esac
+}
+
+export XDG_CACHE_HOME="$STUB_DIR/cache"
+MARKER="$XDG_CACHE_HOME/pr-status/copilot-quota-exhausted-$(date -u +%Y-%m)"
+
+arm_marker() { # arm_marker [age-spec]
+    mkdir -p "$(dirname "$MARKER")"
+    printf 'copilot review quota exhausted; proven on o/r#1 at 2026-01-01T00:00:00Z\n' > "$MARKER"
+    [ $# -gt 0 ] && touch -d "$1" "$MARKER"
+    return 0
+}
+marker_exists() { [ -f "$MARKER" ] && echo yes || echo no; }
+
+# Stub `gh`: repo demands a Copilot review; COPILOT_REVIEW=1 adds a delivered one.
+make_stub() {
+    printf '%s\n' '[{"type":"copilot_code_review","parameters":{}}]' > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+    repos/*/branches/*/protection) exit 1 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+    chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json, os
+out = sys.argv[1]
+head = "deadbeefcafe"
+reviews = []
+if os.environ.get("COPILOT_REVIEW", "0") == "1":
+    reviews.append({"author": {"login": "copilot-pull-request-reviewer"},
+                    "state": "COMMENTED", "commit": {"oid": head}, "body": "looks fine"})
+json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "reviewDecision": None,
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": reviews},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS", "contexts": {"nodes": [
+                {"__typename": "CheckRun", "name": "CI", "conclusion": "SUCCESS",
+                 "status": "COMPLETED", "detailsUrl": "u",
+                 "startedAt": "2026-01-01T00:00:00Z"}]}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
+}
+
+status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1; }
+
+echo "case: fresh marker is believed"
+COPILOT_REVIEW=0 make_stub; arm_marker
+out=$(status)
+check_contains "quota wording shown" "OUT OF REVIEW QUOTA" "$out"
+check          "marker kept"          "yes" "$(marker_exists)"
+
+echo "case: the wording no longer predicts a recovery date"
+check_absent "no 'will not recover this month'" "will not recover this month" "$out"
+check_absent "no 'until the monthly reset'"     "until the monthly reset"     "$out"
+
+echo "case: an expired marker is dropped and no longer believed"
+COPILOT_REVIEW=0 make_stub; arm_marker "8 hours ago"
+out=$(status)
+check_absent "quota wording gone" "OUT OF REVIEW QUOTA" "$out"
+check        "marker removed"     "no" "$(marker_exists)"
+
+echo "case: a delivered Copilot review clears a fresh marker"
+COPILOT_REVIEW=1 make_stub; arm_marker
+out=$(status)
+check "marker cleared by the observed review" "no" "$(marker_exists)"
+
+echo "case: the TTL is configurable"
+COPILOT_REVIEW=0 make_stub; arm_marker "2 hours ago"
+out=$(PR_STATUS_QUOTA_TTL_HOURS=1 status)
+check "marker removed at a 1h TTL" "no" "$(marker_exists)"
+
+exit "$fail"

--- a/tests/test_pr_status_red_nonrequired_while_pending.sh
+++ b/tests/test_pr_status_red_nonrequired_while_pending.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Regression test for #249: a red NON-required check must not end a --watch
+# while a REQUIRED check is still running.
+#
+# The triage-ci branch sat above the pending-required branch, so any red check
+# short-circuited to an action even with required checks in flight. Nothing was
+# actionable at that point — the gate was still held by the running required
+# check — and every early return cost a manual re-arm.
+#
+# Now triage-ci waits for the required checks to conclude, and the wait branch
+# names the red non-required check instead of hiding it.
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+check_contains() { # check_contains <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *) echo "  FAIL $1: no '$2' in output"; fail=1 ;;
+    esac
+}
+check_absent() { # check_absent <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: unexpected '$2' in output"; fail=1 ;;
+        *) echo "  ok   $1" ;;
+    esac
+}
+
+export XDG_CACHE_HOME="$STUB_DIR/cache"
+
+# Stub `gh`: "gate" is the required context.
+#   GATE_STATUS=IN_PROGRESS|SUCCESS  — state of the required check
+#   RED_EXTRA=1                      — adds a red non-required check
+make_stub() {
+    printf '%s\n' '[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"gate"}]}}]' \
+        > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+    chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json, os
+out = sys.argv[1]
+head = "deadbeefcafe"
+gate_status = os.environ.get("GATE_STATUS", "IN_PROGRESS")
+checks = [{"__typename": "CheckRun", "name": "gate",
+           "conclusion": None if gate_status == "IN_PROGRESS" else gate_status,
+           "status": "IN_PROGRESS" if gate_status == "IN_PROGRESS" else "COMPLETED",
+           "detailsUrl": "u", "startedAt": "2026-01-01T00:00:00Z"}]
+if os.environ.get("RED_EXTRA", "0") == "1":
+    checks.append({"__typename": "CheckRun", "name": "codecov/project",
+                   "conclusion": "FAILURE", "status": "COMPLETED",
+                   "detailsUrl": "u", "startedAt": "2026-01-01T00:00:00Z"})
+json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE", "mergeStateStatus": "UNSTABLE", "reviewDecision": None,
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": [{"author": {"login": "rev"}, "state": "APPROVED",
+                               "commit": {"oid": head}, "body": ""}]},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "FAILURE", "contexts": {"nodes": checks}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
+}
+
+status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json; }
+watch() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json --watch "$@"; }
+
+echo "case: required still running, non-required red -> wait, not triage-ci"
+GATE_STATUS=IN_PROGRESS RED_EXTRA=1 make_stub
+out=$(status)
+check_absent   "no triage-ci"                  '"action": "triage-ci"' "$out"
+check_contains "waits on the required check"   "required check(s) still running: gate" "$out"
+check_contains "names the red non-required"    "non-required red meanwhile: codecov/project" "$out"
+
+echo "case: --watch holds instead of returning"
+rc=0; out=$(watch --interval 1 --max-wait 2) || rc=$?
+check        "exits 1 (timeout, still waiting)" "1" "$rc"
+check_absent "no ACTIONABLE return"             "ACTIONABLE" "$out"
+
+echo "case: required concluded, non-required still red -> triage-ci"
+GATE_STATUS=SUCCESS RED_EXTRA=1 make_stub
+out=$(status)
+check_contains "returns triage-ci"        '"action": "triage-ci"' "$out"
+check_contains "names the failing check"  "codecov/project" "$out"
+
+echo "case: a red REQUIRED check still returns at once"
+GATE_STATUS=FAILURE RED_EXTRA=0 make_stub
+rc=0; out=$(watch --interval 1 --max-wait 4) || rc=$?
+check          "exits 0"                     "0" "$rc"
+check_contains "returns on the required red" "ACTIONABLE" "$out"
+check_contains "names it as required"        "required check(s) failing: gate" "$out"
+
+exit "$fail"

--- a/tests/test_pr_status_red_nonrequired_while_pending.sh
+++ b/tests/test_pr_status_red_nonrequired_while_pending.sh
@@ -99,7 +99,7 @@ echo "case: required still running, non-required red -> wait, not triage-ci"
 GATE_STATUS=IN_PROGRESS RED_EXTRA=1 make_stub
 out=$(status)
 check_absent   "no triage-ci"                  '"action": "triage-ci"' "$out"
-check_contains "waits on the required check"   "required check(s) still running: gate" "$out"
+check_contains "waits on the required check"   "required check(s) still pending: gate" "$out"
 check_contains "names the red non-required"    "non-required red meanwhile: codecov/project" "$out"
 
 echo "case: --watch holds instead of returning"


### PR DESCRIPTION
Three findings in `pr-status.sh`, one commit each.

**#249 — `--watch` ended on a red non-required check while required ones were still running.** Two places decided that: the NEXT ladder returned `triage-ci` from a branch sitting above the pending-required branch, and the watch loop returned on any newly failing check without looking at required-ness. Both now wait until the required checks conclude; a red *required* check still returns at once, and the wait line names the red non-required one instead of hiding it.

**#250 — the GitHub-only boundary was undocumented at the entry point.** `-R git.netresearch.de/group/project` parsed fine and died 800 lines later as a bare `GraphQL query failed`; with `--watch` it heartbeated into its timeout. It now refuses up front on either tell — a three-segment path, or an owner that looks like a host. #259 has since routed `/pr-finish` off the GitHub path, so what was left is the frontmatter description (which decides whether the skill is invoked at all) and one line under *Not Here*.

**#255 — the quota marker predicted a reset it cannot know.** Recorded 2026-08-18, a normal Copilot review delivered 2026-08-29, the wall back ten minutes later — while the advice said "it will not recover this month". The marker now expires after `PR_STATUS_QUOTA_TTL_HOURS` (default 6) so the next run re-probes, an observed Copilot review clears it immediately, and the wording keeps what is known (account-wide) and drops what is not (when it returns).

## Tests

Two new regression tests, both seen to fail before they were seen to pass: reverting `pr-status.sh` fails 5 of 11 assertions in the first and 6 of 8 in the second.

`test_pr_status_errored_review.sh` pinned the withdrawn claim with `test("MONTHLY")`. It now asserts the account-wide half and that no recovery date is predicted; the comment there records which claim was dropped and why.

All 16 shell tests and 52 Python tests pass.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_
