### PR TITLE
docs(git-hooks): a hook rev nobody bumps keeps enforcing the rule it shipped with

### DIFF
--- a/skills/git-workflow/references/git-hooks-setup.md
+++ b/skills/git-workflow/references/git-hooks-setup.md
@@ -37,6 +37,42 @@ including pre-releases**. It happily pins a beta (observed: isort
 mirrors a locked dev dependency (black, isort), keep the hook `rev` aligned
 with the lockfile version instead of blindly taking the newest tag.
 
+### Nobody bumps a `rev` unless you arrange it
+
+`autoupdate` is a manual command, so a repository that never runs it keeps its
+hooks forever. Renovate can do it, but **its pre-commit manager is disabled by
+default** — enable it explicitly:
+
+```json
+{ "extends": ["config:recommended"], "pre-commit": { "enabled": true } }
+```
+
+Without that line no hook is ever offered an update, and nothing reports it:
+an absent pull request looks exactly like being up to date. Measured across one
+fleet of 37 repositories, the six without the manager sat on a validator tag 15
+minor versions behind while the other 31 tracked current — the correlation was
+complete.
+
+**A stale `rev` keeps enforcing the rule that version had.** Those six failed
+commits with `SKILL.md is 501 words (max 500)` months after the word cap had
+been replaced by a line-based one. When a pinned checker rejects your change,
+read the pin before you edit the file to satisfy it: an error message names the
+rule the *pinned* version enforces, which is not necessarily the rule that
+applies. Shortening prose to pass a retired cap is work spent against nothing.
+
+**Do not reach for a moving ref to escape this.** `rev: main`, or a `v1` branch
+that tracks main, is worse rather than better:
+
+```
+[WARNING] The 'rev' field ... appears to be a mutable reference (moving tag /
+branch).  Mutable references are never updated after first install and are not
+supported.
+```
+
+pre-commit clones a mutable ref once and never refreshes it, so the running
+version freezes per machine, invisibly and differently for each developer. An
+immutable tag in the file plus a bot that moves it is the supported shape.
+
 ## Recommended Hooks by Stage
 
 ### pre-commit (fast, <5s)


### PR DESCRIPTION
`references/git-hooks-setup.md` covered `pre-commit autoupdate` and its prerelease trap, but not the case where **nothing bumps the `rev` at all**. Three additions, each from a session that lost work to them.

## Renovate's pre-commit manager is off by default

Without an explicit `"pre-commit": {"enabled": true}` no hook is ever offered an update — and nothing reports that, because an absent pull request looks exactly like being up to date.

Measured across a fleet of 37 repositories: the six lacking the manager sat on a validator tag **15 minor versions** behind, while the other 31 tracked current. The correlation was complete.

## A stale `rev` keeps enforcing the rule that version had

Those six failed commits with `SKILL.md is 501 words (max 500)` months after the word cap had been replaced by a line-based one. Twice in one session I shortened documentation prose to satisfy it before checking whether the rule still existed — work spent against nothing.

The generalisable part: **an error message names the rule the pinned version enforces, which is not necessarily the rule that applies.** When a pinned checker rejects a change, read the pin before editing the file to satisfy it.

## `rev: main` is not the escape

Measured, not assumed:

```
[WARNING] The 'rev' field ... appears to be a mutable reference (moving tag / branch).
Mutable references are never updated after first install and are not supported.
```

pre-commit clones a mutable ref once and never refreshes it, so the running version freezes per machine — invisibly, and differently for each developer. A `v1` branch that tracks `main` has the same property. An immutable tag plus a bot that moves it is the supported shape.

## Verification

```
validate-skill.sh: 0 errors, SKILL.md body 72 lines
pre-commit run --files <changed>: passes
```

Documentation only; no script or behaviour touched.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
