### PR TITLE
fix(pr-status): keep only the newest check-run per name

### DIFF
--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -338,9 +338,15 @@ evaluate() {
     # the old one answered triage-ci on a CLEAN pull request, and pr-merge.sh
     # refused a merge the gate had already opened (t3x-nr-image-optimize#173:
     # fuzz red at 15:03, green at 18:30, one SHA). Keep the newest row per
-    # name. Status contexts carry no startedAt and are unique per context, so
-    # the fallback only ever compares a row with itself.
-    | ($checks | group_by(.name) | map(max_by(.started // ""))) as $checks
+    # name — and a row that has not finished outranks every finished one
+    # regardless of timestamp: a re-run sits in the queue with startedAt
+    # null, and ranking it by "" would hand the name back to the finished
+    # row it is about to replace. Status contexts carry no startedAt and are
+    # unique per context, so the fallback only ever compares a row with
+    # itself.
+    | ($checks | group_by(.name)
+               | map(max_by([(if .state == "QUEUED" or .state == "PENDING" then 1 else 0 end),
+                             (.started // "")]))) as $checks
     # Effective required contexts come from the rules endpoint; classic
     # protection alone misses rulesets entirely.
     | ([$r[]? | select(.type=="required_status_checks")

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -331,6 +331,16 @@ evaluate() {
                                         elif .state == "PENDING" then "PENDING"
                                         else "FAIL" end), url: .targetUrl}
           end]) as $checks
+    # One head can carry several check-runs of the SAME name: a close/reopen,
+    # a workflow_dispatch or a `gh run rerun` of a superseded run starts a new
+    # run whose rows join the old ones in the rollup instead of replacing
+    # them. The GitHub merge state reads only the newest row per name; counting
+    # the old one answered triage-ci on a CLEAN pull request, and pr-merge.sh
+    # refused a merge the gate had already opened (t3x-nr-image-optimize#173:
+    # fuzz red at 15:03, green at 18:30, one SHA). Keep the newest row per
+    # name. Status contexts carry no startedAt and are unique per context, so
+    # the fallback only ever compares a row with itself.
+    | ($checks | group_by(.name) | map(max_by(.started // ""))) as $checks
     # Effective required contexts come from the rules endpoint; classic
     # protection alone misses rulesets entirely.
     | ([$r[]? | select(.type=="required_status_checks")

--- a/tests/test_pr_status_superseded_check_run.sh
+++ b/tests/test_pr_status_superseded_check_run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Regression test: a superseded check-run must not keep the gate shut.
+#
+# One head can carry several check-runs of the same name. A close/reopen, a
+# workflow_dispatch or a `gh run rerun` of a superseded run starts a NEW run
+# whose rows join the old ones in statusCheckRollup instead of replacing
+# them. GitHub's own merge state reads only the newest row per name and
+# reports CLEAN; pr-status.sh counted both, answered triage-ci for the old
+# red row, and pr-merge.sh refused a merge the gate had already opened
+# (t3x-nr-image-optimize#173: `fuzz / Fuzz Tests` red at 15:03 and green at
+# 18:30 on one SHA).
+#
+# Runs pr-status.sh against a stubbed `gh`, so it needs no network and no repo.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/git-workflow/scripts/pr-status.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+fail=0
+check_contains() { # check_contains <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *) echo "  FAIL $1: no '$2' in output"; fail=1 ;;
+    esac
+}
+check_absent() { # check_absent <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  FAIL $1: unexpected '$2' in output"; fail=1 ;;
+        *) echo "  ok   $1" ;;
+    esac
+}
+
+export XDG_CACHE_HOME="$STUB_DIR/cache"
+
+# Stub `gh`: no rulesets, so every check is non-required.
+#   NEWEST=SUCCESS|FAILURE — conclusion of the row with the later startedAt
+make_stub() {
+    printf '%s\n' '[]' > "$STUB_DIR/rules.json"
+    cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    repos/*/rules/branches/*) cat "$STUB_DIR/rules.json"; exit 0 ;;
+  esac
+done
+cat "$STUB_DIR/graphql.json"
+STUB
+    chmod +x "$STUB_DIR/gh"
+    python3 - "$STUB_DIR/graphql.json" <<'PY'
+import sys, json, os
+out = sys.argv[1]
+head = "deadbeefcafe"
+newest = os.environ.get("NEWEST", "SUCCESS")
+older = "FAILURE" if newest == "SUCCESS" else "SUCCESS"
+# The old row comes FIRST in the rollup, as GitHub returns it — the fix must
+# pick by startedAt, not by position.
+checks = [
+    {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
+     "conclusion": older, "status": "COMPLETED",
+     "detailsUrl": "run/1", "startedAt": "2026-08-30T15:03:00Z"},
+    {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
+     "conclusion": newest, "status": "COMPLETED",
+     "detailsUrl": "run/2", "startedAt": "2026-08-30T18:30:00Z"},
+    {"__typename": "CheckRun", "name": "ci / Unit Tests",
+     "conclusion": "SUCCESS", "status": "COMPLETED",
+     "detailsUrl": "run/2", "startedAt": "2026-08-30T18:30:00Z"},
+]
+json.dump({"data": {"repository": {
+    "nameWithOwner": "o/r",
+    "mergeCommitAllowed": True, "rebaseMergeAllowed": False, "squashMergeAllowed": False,
+    "pullRequest": {
+        "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN" if newest == "SUCCESS" else "UNSTABLE",
+        "reviewDecision": "APPROVED",
+        "author": {"login": "someone"},
+        "baseRefName": "main", "headRefName": "f", "headRefOid": head,
+        "isCrossRepository": False,
+        "reviews": {"nodes": [{"author": {"login": "rev"}, "state": "APPROVED",
+                               "commit": {"oid": head}, "body": ""}]},
+        "reviewRequests": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+        "comments": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
+            "state": "SUCCESS" if newest == "SUCCESS" else "FAILURE",
+            "contexts": {"nodes": checks}}}}]},
+        "allCommits": {"nodes": [{"commit": {"oid": head,
+                                             "signature": {"isValid": True}}}]},
+    }}}}, open(out, "w"))
+PY
+}
+
+status() { PATH="$STUB_DIR:$PATH" bash "$SCRIPT" -R o/r 1 --json; }
+
+echo "case: old row red, newest row green -> the superseded row is dropped"
+NEWEST=SUCCESS make_stub
+out=$(status)
+check_absent   "no triage-ci"                 '"action": "triage-ci"' "$out"
+check_absent   "old run not listed"           'run/1' "$out"
+check_contains "counts one row for the name"  '"total": 2' "$out"
+check_contains "gate is open"                 '"action": "merge"' "$out"
+
+echo "case: old row green, newest row red -> still red (newest wins, not greenest)"
+NEWEST=FAILURE make_stub
+out=$(status)
+check_contains "returns triage-ci"            '"action": "triage-ci"' "$out"
+check_contains "names the failing check"      'fuzz / Fuzz Tests' "$out"
+check_contains "points at the newest run"     'run/2' "$out"
+
+exit "$fail"

--- a/tests/test_pr_status_superseded_check_run.sh
+++ b/tests/test_pr_status_superseded_check_run.sh
@@ -35,7 +35,8 @@ check_absent() { # check_absent <name> <needle> <haystack>
 export XDG_CACHE_HOME="$STUB_DIR/cache"
 
 # Stub `gh`: no rulesets, so every check is non-required.
-#   NEWEST=SUCCESS|FAILURE — conclusion of the row with the later startedAt
+#   NEWEST=SUCCESS|FAILURE|QUEUED — state of the newer row. QUEUED models a
+#   re-run that has not started yet: status QUEUED, startedAt null.
 make_stub() {
     printf '%s\n' '[]' > "$STUB_DIR/rules.json"
     cat > "$STUB_DIR/gh" <<STUB
@@ -56,13 +57,19 @@ newest = os.environ.get("NEWEST", "SUCCESS")
 older = "FAILURE" if newest == "SUCCESS" else "SUCCESS"
 # The old row comes FIRST in the rollup, as GitHub returns it — the fix must
 # pick by startedAt, not by position.
+if newest == "QUEUED":
+    newer_row = {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
+                 "conclusion": None, "status": "QUEUED",
+                 "detailsUrl": "run/2", "startedAt": None}
+else:
+    newer_row = {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
+                 "conclusion": newest, "status": "COMPLETED",
+                 "detailsUrl": "run/2", "startedAt": "2026-08-30T18:30:00Z"}
 checks = [
     {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
      "conclusion": older, "status": "COMPLETED",
      "detailsUrl": "run/1", "startedAt": "2026-08-30T15:03:00Z"},
-    {"__typename": "CheckRun", "name": "fuzz / Fuzz Tests",
-     "conclusion": newest, "status": "COMPLETED",
-     "detailsUrl": "run/2", "startedAt": "2026-08-30T18:30:00Z"},
+    newer_row,
     {"__typename": "CheckRun", "name": "ci / Unit Tests",
      "conclusion": "SUCCESS", "status": "COMPLETED",
      "detailsUrl": "run/2", "startedAt": "2026-08-30T18:30:00Z"},
@@ -84,7 +91,7 @@ json.dump({"data": {"repository": {
         "reviewThreads": {"nodes": []},
         "comments": {"nodes": []},
         "commits": {"nodes": [{"commit": {"oid": head, "statusCheckRollup": {
-            "state": "SUCCESS" if newest == "SUCCESS" else "FAILURE",
+            "state": {"SUCCESS": "SUCCESS", "QUEUED": "PENDING"}.get(newest, "FAILURE"),
             "contexts": {"nodes": checks}}}}]},
         "allCommits": {"nodes": [{"commit": {"oid": head,
                                              "signature": {"isValid": True}}}]},
@@ -108,5 +115,13 @@ out=$(status)
 check_contains "returns triage-ci"            '"action": "triage-ci"' "$out"
 check_contains "names the failing check"      'fuzz / Fuzz Tests' "$out"
 check_contains "points at the newest run"     'run/2' "$out"
+
+echo "case: old row red, re-run still QUEUED (startedAt null) -> the queued row wins, gate waits"
+NEWEST=QUEUED make_stub
+out=$(status)
+check_absent   "no triage-ci for the old row"   '"action": "triage-ci"' "$out"
+check_absent   "old run not listed"             'run/1' "$out"
+check_contains "waits on the queued re-run"     '"action": "wait"' "$out"
+check_contains "reports it as queued"           '"queued": 1' "$out"
 
 exit "$fail"


### PR DESCRIPTION
## Summary

One head can carry several check-runs of the same name — a close/reopen, a `workflow_dispatch` or a `gh run rerun` of a superseded run starts a new run whose rows *join* the old ones in `statusCheckRollup` instead of replacing them. GitHub's merge state reads only the newest row per name and reports `CLEAN`; `pr-status.sh` counted both, answered `triage-ci` for the old red row, and `pr-merge.sh` refused a merge the gate had already opened.

Measured on [t3x-nr-image-optimize#173](https://github.com/netresearch/t3x-nr-image-optimize/pull/173) at `a33c78c3`: the `fuzz / Fuzz Tests` row from [run 33318483616](https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/33318483616) (red, 15:03) sat next to the row from [run 33328255980](https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/33328255980) (green, 18:30) on one SHA — `mergeStateStatus: CLEAN`, script output `42 pass, 1 fail`.

The fix collapses `$checks` to the newest row per name by `startedAt`, right after the rollup is read. Status contexts carry no `startedAt` and are unique per context, so the fallback only compares a row with itself. The existing CANCEL/stale logic is untouched: a cancelled row that reported again is now folded one step earlier, a cancelled row that never reported again is still counted as unmet.

## Test plan

- [x] `tests/test_pr_status_superseded_check_run.sh` — new; against the unfixed script it fails 4 of 7 assertions (old row listed, `triage-ci`, wrong total, no `merge`), with the fix all 7 pass. Second case proves "newest wins", not "greenest wins": old row green, new row red → still `triage-ci`, pointing at the new run.
- [x] Whole suite: 17 test files green.
- [x] Live: the fixed script on #173 reports `42 pass, 0 fail` and moves past `triage-ci`.
- [x] `bash -n`, shellcheck (pre-commit) clean.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01F91Rh11LCehJojefpo5aCF)_
