### PR TITLE
chore(release): v1.31.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.31.0"
+  version: "1.31.1"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
## Summary

Patch release v1.31.1. Since [v1.31.0](https://github.com/netresearch/git-workflow-skill/releases/tag/v1.31.0) the range carries the pr-status superseded-check-run fix ([#263](https://github.com/netresearch/git-workflow-skill/pull/263) — newest check-run per name wins, a queued re-run outranks the finished row), the watch/quota/forge-boundary fixes from [#260](https://github.com/netresearch/git-workflow-skill/pull/260), four reference-doc additions ([#258](https://github.com/netresearch/git-workflow-skill/pull/258), [#259](https://github.com/netresearch/git-workflow-skill/pull/259), [#261](https://github.com/netresearch/git-workflow-skill/pull/261), [#262](https://github.com/netresearch/git-workflow-skill/pull/262)) and a harden-runner bump ([#264](https://github.com/netresearch/git-workflow-skill/pull/264)).

Version bump in the three parity-checked files, per the release flow.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01F91Rh11LCehJojefpo5aCF)_
