### PR TITLE
fix(hooks): stop the named-directory advisory repeating on every command

### DIFF
--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -447,6 +447,23 @@ class NamedDirectoryAdvisoryScope(unittest.TestCase):
         self.assertFalse(self.fired("ssh root@nova.nr 'git status'"))
         self.assertFalse(self.fired("docker exec app sh -c 'git rev-parse HEAD'"))
 
+    def test_a_cd_in_a_subshell_counts_as_named(self) -> None:
+        # The measurement pattern accepts `(` and `$(` as separators before
+        # `git`, so these match and then have to find their `cd`. Recognising
+        # the git command but not the cd that precedes it inside the same
+        # subshell is the advisory firing on a command that names its directory.
+        self.assertFalse(self.fired("(cd /etc && git status)"))
+        self.assertFalse(self.fired("(cd /etc; git status)"))
+
+    def test_a_cd_in_a_command_substitution_counts_as_named(self) -> None:
+        self.assertFalse(self.fired("$(cd /etc && git log -1)"))
+        self.assertFalse(self.fired("x=$(cd /srv && git rev-parse HEAD)"))
+
+    def test_a_subshell_without_a_cd_still_warns(self) -> None:
+        # The widening must not swallow the case the advisory exists for.
+        self.assertTrue(self.fired("(git status)"))
+        self.assertTrue(self.fired("x=$(git rev-parse HEAD)"))
+
     def test_a_cd_in_an_earlier_payload_does_not_silence_a_local_slip(self) -> None:
         # The remote `cd` belongs to the ssh payload; the local `git status`
         # after it is exactly the slip this advisory exists for.

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import unittest
+import unittest.mock
 from pathlib import Path
 from typing import ClassVar
 
@@ -296,12 +297,23 @@ class AdvisoryOncePerSession(unittest.TestCase):
         self.addCleanup(self.runtime.cleanup)
 
     def run_hook_session(
-        self, command: str, session: "str | None", runtime_dir: "str | None" = None
+        self,
+        command: str,
+        session: "str | None",
+        runtime_dir: "str | None" = None,
+        fallback_dir: "str | None" = None,
     ) -> str:
         env = dict(os.environ)
         env["XDG_RUNTIME_DIR"] = (
             runtime_dir if runtime_dir is not None else self.runtime.name
         )
+        # The hook falls back to the temp directory when XDG_RUNTIME_DIR cannot
+        # hold markers, so the temp directory has to be isolated per test too.
+        # Left at the real /tmp, markers from one run silence the next one and
+        # the suite passes or fails depending on what an earlier run left there.
+        fallback = fallback_dir if fallback_dir is not None else self.runtime.name
+        for var in ("TMPDIR", "TEMP", "TMP"):
+            env[var] = fallback
         payload: dict = {"command": command}
         if session is not None:
             payload["session_id"] = session
@@ -333,10 +345,11 @@ class AdvisoryOncePerSession(unittest.TestCase):
         self.assertIn("git-workflow:", first)
         self.assertIn("git-workflow:", second)
 
-    def test_an_unusable_runtime_dir_never_suppresses_the_warning(self) -> None:
-        # XDG_RUNTIME_DIR names an existing FILE: creating the marker directory
-        # cannot succeed. The advisory must fire anyway — storage failing is
-        # not the same as the warning having been seen.
+    def test_an_unusable_runtime_dir_still_reaches_the_user_the_first_time(
+        self,
+    ) -> None:
+        # XDG_RUNTIME_DIR names an existing FILE, so no marker can be written
+        # there. The warning must still reach the author.
         blocker = Path(self.runtime.name) / "blocker"
         blocker.write_text("not a directory\n")
         out = self.run_hook_session(self.ADVISORY_CMD, "sess-3", str(blocker))
@@ -352,6 +365,36 @@ class AdvisoryOncePerSession(unittest.TestCase):
         self.assertIn("Waiting on workflow runs", first)
         combined = self.run_hook_session(self.BOTH_CMD, "sess-4")
         self.assertIn("inherits its working directory", combined)
+
+    def test_a_permanently_unusable_runtime_dir_still_dedupes(self) -> None:
+        # XDG_RUNTIME_DIR is exported by the login shell but the directory does
+        # not exist and cannot be created (no systemd user session -- the normal
+        # case under WSL, in containers, and on cron-launched sessions). Falling
+        # back to "not fired" then repeats on EVERY matching command for the
+        # life of the session: four identical warnings in a row on 2026-09-02,
+        # which is what the once-per-session rule exists to prevent. A location
+        # that cannot hold markers must be replaced by one that can, not turned
+        # into permission to storm.
+        unusable = Path(self.runtime.name) / "blocker" / "nested"
+        unusable.parent.write_text("not a directory\n")
+        first = self.run_hook_session(self.ADVISORY_CMD, "sess-6", str(unusable))
+        self.assertIn("git-workflow:", first)
+        second = self.run_hook_session(self.ADVISORY_CMD, "sess-6", str(unusable))
+        self.assertEqual("", second.strip(), "unusable runtime dir: still dedupe")
+
+    def test_the_fallback_is_the_temp_directory_the_process_would_use(self) -> None:
+        # Naming the location is what makes the previous test more than "it
+        # went quiet somehow": the marker has to be findable where the hook
+        # says it puts it.
+        unusable = Path(self.runtime.name) / "blocker2" / "nested"
+        unusable.parent.write_text("not a directory\n")
+        self.run_hook_session(self.ADVISORY_CMD, "sess-7", str(unusable))
+        marker = (
+            Path(self.runtime.name)
+            / "git-workflow-advisories"
+            / "sess-7.git_read_without_named_dir"
+        )
+        self.assertTrue(marker.exists(), f"expected the marker at {marker}")
 
     def test_a_marker_older_than_the_rearm_window_fires_again_once(self) -> None:
         # A session can run for days and its context gets compacted, so a
@@ -369,6 +412,95 @@ class AdvisoryOncePerSession(unittest.TestCase):
         self.assertIn("git-workflow:", again)
         quiet = self.run_hook_session(self.ADVISORY_CMD, "sess-5")
         self.assertEqual("", quiet.strip(), "re-arm must also re-mark: quiet again")
+
+
+class NamedDirectoryAdvisoryScope(unittest.TestCase):
+    """A `cd` opening a quoted payload names the directory just as well.
+
+    `ssh host 'cd /etc && git log -1'` and `bash -c 'cd /srv && git status'`
+    both say where the measurement happens. The advisory used to fire anyway,
+    because it only recognised a `cd` preceded by a statement separator and a
+    quote is not one -- so every remote inspection drew the same paragraph
+    (four in a row on 2026-09-02, on an ssh loop that did `cd /etc` first).
+    """
+
+    def fired(self, command: str) -> bool:
+        return "inherits its working directory" in run_hook(command)
+
+    def test_a_bare_measurement_still_warns(self) -> None:
+        self.assertTrue(self.fired("git status"))
+
+    def test_a_cd_opening_a_quoted_payload_counts_as_named(self) -> None:
+        self.assertFalse(self.fired("bash -c 'cd /srv/app && git status'"))
+
+    def test_ssh_with_options_and_a_remote_cd(self) -> None:
+        self.assertFalse(
+            self.fired(
+                "timeout 60 ssh -o BatchMode=yes root@nova.nr 'cd /etc && git log -1'"
+            )
+        )
+
+    def test_a_quoted_payload_without_a_cd_never_matched_anyway(self) -> None:
+        # Characterization: `git` sits right behind the quote, which is not a
+        # statement separator, so the measurement pattern never matched here.
+        # Recorded so a future widening of that pattern has to face this case.
+        self.assertFalse(self.fired("ssh root@nova.nr 'git status'"))
+        self.assertFalse(self.fired("docker exec app sh -c 'git rev-parse HEAD'"))
+
+    def test_a_cd_in_an_earlier_payload_does_not_silence_a_local_slip(self) -> None:
+        # The remote `cd` belongs to the ssh payload; the local `git status`
+        # after it is exactly the slip this advisory exists for.
+        self.assertTrue(self.fired("ssh host 'cd /etc && ls'; git status"))
+
+    def test_a_local_measurement_after_a_remote_one_still_warns(self) -> None:
+        self.assertTrue(self.fired("ssh host 'git status'; git log --oneline -1"))
+
+
+class NowhereToStoreAMarker(unittest.TestCase):
+    """When no location can hold a marker, the warning still reaches the author.
+
+    This cannot be provoked through the environment: `tempfile.gettempdir()`
+    validates its candidates and lands on /tmp whatever TMPDIR says, so the
+    branch is only reachable where /tmp itself is unwritable. Exercised
+    directly, because a defensive branch nothing ever runs is a claim, not a
+    guarantee.
+    """
+
+    def test_every_candidate_failing_reads_as_not_fired(self) -> None:
+        import validate_git_command as vgc
+
+        payload = {"session_id": "sess-nowhere"}
+        with unittest.mock.patch.object(
+            vgc.os, "makedirs", side_effect=OSError("read-only")
+        ):
+            first = vgc._advisory_already_fired(payload, "git_read_without_named_dir")
+            second = vgc._advisory_already_fired(payload, "git_read_without_named_dir")
+        self.assertFalse(first)
+        self.assertFalse(second, "storage failure must never read as 'already seen'")
+
+    def test_the_runtime_dir_is_preferred_when_it_works(self) -> None:
+        import validate_git_command as vgc
+
+        with (
+            tempfile.TemporaryDirectory() as runtime,
+            tempfile.TemporaryDirectory() as fallback,
+        ):
+            with (
+                unittest.mock.patch.dict(vgc.os.environ, {"XDG_RUNTIME_DIR": runtime}),
+                unittest.mock.patch.object(
+                    vgc.tempfile, "gettempdir", return_value=fallback
+                ),
+            ):
+                vgc._advisory_already_fired(
+                    {"session_id": "sess-pref"}, "git_read_without_named_dir"
+                )
+            marker = (
+                Path(runtime)
+                / "git-workflow-advisories"
+                / "sess-pref.git_read_without_named_dir"
+            )
+            self.assertTrue(marker.exists(), "a working XDG_RUNTIME_DIR wins")
+            self.assertFalse((Path(fallback) / "git-workflow-advisories").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -472,6 +472,23 @@ class NamedDirectoryAdvisoryScope(unittest.TestCase):
     def test_a_local_measurement_after_a_remote_one_still_warns(self) -> None:
         self.assertTrue(self.fired("ssh host 'git status'; git log --oneline -1"))
 
+    def test_a_closed_subshell_cd_does_not_reach_the_next_command(self) -> None:
+        # `cd` inside a subshell dies with the subshell. Accepting it for a
+        # measurement that runs after the closing paren is the advisory going
+        # quiet on precisely the slip it exists for.
+        self.assertTrue(self.fired("(cd /etc && ls); git status"))
+        self.assertTrue(self.fired("x=$(cd /etc && pwd); git status"))
+
+    def test_a_cd_deeper_inside_a_closed_payload_does_not_leak_out(self) -> None:
+        # Same for a remote payload: the earlier test only covered a `cd` at
+        # the start of the quoted run, which no separator preceded anyway.
+        self.assertTrue(self.fired('ssh host "echo ok; cd /etc && ls"; git status'))
+
+    def test_every_measurement_is_checked_not_just_the_first(self) -> None:
+        # The remote measurement is named by its own `cd`; the local one that
+        # follows is not, and it is the one worth warning about.
+        self.assertTrue(self.fired("ssh host 'cd /etc && git status'; git status"))
+
 
 class NowhereToStoreAMarker(unittest.TestCase):
     """When no location can hold a marker, the warning still reaches the author.
@@ -494,6 +511,50 @@ class NowhereToStoreAMarker(unittest.TestCase):
             second = vgc._advisory_already_fired(payload, "git_read_without_named_dir")
         self.assertFalse(first)
         self.assertFalse(second, "storage failure must never read as 'already seen'")
+
+    def test_a_root_that_takes_the_directory_but_refuses_the_marker_falls_through(
+        self,
+    ) -> None:
+        # makedirs succeeding does not mean the marker can be written: the
+        # advisory directory may exist and be unwritable. Committing to the
+        # first root that accepts makedirs leaves the dedupe off for good,
+        # which is the storm this whole mechanism exists to prevent.
+        import validate_git_command as vgc
+
+        with (
+            tempfile.TemporaryDirectory() as runtime,
+            tempfile.TemporaryDirectory() as fallback,
+        ):
+            hostile = Path(runtime) / "git-workflow-advisories"
+            hostile.mkdir()
+            hostile.chmod(0o500)  # listable, not writable
+            try:
+                with (
+                    unittest.mock.patch.dict(
+                        vgc.os.environ, {"XDG_RUNTIME_DIR": runtime}
+                    ),
+                    unittest.mock.patch.object(
+                        vgc.tempfile, "gettempdir", return_value=fallback
+                    ),
+                ):
+                    first = vgc._advisory_already_fired(
+                        {"session_id": "sess-fall"}, "git_read_without_named_dir"
+                    )
+                    second = vgc._advisory_already_fired(
+                        {"session_id": "sess-fall"}, "git_read_without_named_dir"
+                    )
+            finally:
+                # restore before the TemporaryDirectory tries to remove it
+                hostile.chmod(0o700)
+            self.assertFalse(first)
+            self.assertTrue(second, "the fallback root must still dedupe")
+            self.assertTrue(
+                (
+                    Path(fallback)
+                    / "git-workflow-advisories"
+                    / "sess-fall.git_read_without_named_dir"
+                ).exists()
+            )
 
     def test_the_runtime_dir_is_preferred_when_it_works(self) -> None:
         import validate_git_command as vgc

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -577,23 +577,51 @@ GIT_MEASURING_READ = re.compile(
 )
 CD_BEFORE = re.compile(_SEP + r"\s*cd\s+\S")
 # A quote is not a statement separator, so `ssh host 'cd /etc && git log -1'`
-# used to read as "no cd" and drew the advisory on every remote inspection.
-# The cd counts only inside the same quoted run as the measurement, so a cd
-# belonging to an earlier payload cannot silence a later local slip.
+# read as "no cd" and drew the advisory on every remote inspection.
 _QUOTES = "\"'"
+
+
+def _same_scope_prefix(cmd: str, end: int) -> str:
+    """`cmd[:end]` with everything outside the measurement's own scope blanked.
+
+    A `cd` only reaches a later command when it ran in the same shell. Two ways
+    it does not, and both were accepted before:
+
+    * `(cd /etc && ls); git status` — the subshell exited, taking its `cd` with
+      it, so the local `git status` is exactly the unnamed measurement the
+      advisory is for.
+    * `ssh host "echo ok; cd /etc && ls"; git status` — the `cd` ran on another
+      machine.
+
+    Closed quoted runs and closed `(...)` groups are therefore blanked out.
+    Whatever is still open at `end` is the scope the measurement sits in, so
+    the text before it is blanked instead — that makes the run's own start the
+    `^` the pattern needs, since a quote is not a separator.
+    """
+    out = list(cmd[:end])
+    quote, quote_start, opens = "", -1, []
+    for i, ch in enumerate(cmd[:end]):
+        if quote:
+            if ch == quote:
+                out[quote_start : i + 1] = " " * (i - quote_start + 1)
+                quote = ""
+            continue
+        if ch in _QUOTES:
+            quote, quote_start = ch, i
+        elif ch == "(":
+            opens.append(i)
+        elif ch == ")" and opens:
+            start = opens.pop()
+            out[start : i + 1] = " " * (i - start + 1)
+    innermost = max(quote_start if quote else -1, opens[-1] if opens else -1)
+    if innermost >= 0:
+        out[: innermost + 1] = " " * (innermost + 1)
+    return "".join(out)
 
 
 def _named_directory_before(cmd: str, end: int) -> bool:
     """True when a `cd` names the directory the measurement at `end` runs in."""
-    segment_start, quote = 0, ""
-    for i, ch in enumerate(cmd[:end]):
-        if quote:
-            if ch == quote:
-                quote, segment_start = "", i + 1
-        elif ch in _QUOTES:
-            quote, segment_start = ch, i + 1
-    prefix = cmd[segment_start:end] if quote else cmd[:end]
-    return bool(CD_BEFORE.search(prefix) or (quote and re.match(r"\s*cd\s+\S", prefix)))
+    return bool(CD_BEFORE.search(_same_scope_prefix(cmd, end)))
 
 
 # --- blanket `git add` (promoted from a harness-local hook, 2026-08-20) ------
@@ -670,8 +698,14 @@ def blanket_git_add(cmd: str, cwd: str = "", untracked=_untracked_files) -> str 
 def git_read_without_named_dir(cmd: str) -> str | None:
     """Warn when a git measurement does not say which directory it measures."""
     cmd = cmd or ""
-    m = GIT_MEASURING_READ.search(cmd)
-    if not m or _named_directory_before(cmd, m.start()):
+    # Every measurement, not just the first: `ssh host 'cd /etc && git status';
+    # git status` opens with a remote measurement that names its directory, and
+    # stopping there suppressed the local one that does not — the only line in
+    # that command the advisory is actually about.
+    if not any(
+        not _named_directory_before(cmd, m.start())
+        for m in GIT_MEASURING_READ.finditer(cmd)
+    ):
         return None
     return (
         "This git command inherits its working directory. `cd` survives between "
@@ -814,8 +848,13 @@ def _advisory_already_fired(data, name: str) -> bool:
     slug = re.sub(r"[^A-Za-z0-9_-]", "", str(session_id))
     if not slug:
         return False
-    roots = [os.environ.get("XDG_RUNTIME_DIR"), tempfile.gettempdir()]
-    for root in roots:
+    # A root is only usable once the MARKER itself can be written. makedirs
+    # succeeding proves nothing: the advisory directory can already exist and be
+    # unwritable, and committing to that root then leaves the dedupe off for the
+    # rest of the session — the storm this whole mechanism exists to prevent.
+    # So each root is tried all the way through, and only a write failure on the
+    # last one reads as "not fired".
+    for root in (os.environ.get("XDG_RUNTIME_DIR"), tempfile.gettempdir()):
         if not root:
             continue
         directory = os.path.join(root, "git-workflow-advisories")
@@ -823,23 +862,21 @@ def _advisory_already_fired(data, name: str) -> bool:
             os.makedirs(directory, exist_ok=True)
         except OSError:
             continue
-        break
-    else:
-        return False
-    marker = os.path.join(directory, f"{slug}.{name}")
-    try:
-        os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
-    except FileExistsError:
+        marker = os.path.join(directory, f"{slug}.{name}")
         try:
-            # A marker mtime in the future (backwards clock step) makes the
-            # delta negative and reads as fresh: stay quiet rather than storm.
-            if time.time() - os.stat(marker).st_mtime > ADVISORY_REARM_SECONDS:
-                os.utime(marker, None)
+            os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+        except FileExistsError:
+            try:
+                # A marker mtime in the future (backwards clock step) makes the
+                # delta negative and reads as fresh: stay quiet rather than storm.
+                if time.time() - os.stat(marker).st_mtime > ADVISORY_REARM_SECONDS:
+                    os.utime(marker, None)
+                    return False
+            except OSError:
                 return False
+            return True
         except OSError:
-            return False
-        return True
-    except OSError:
+            continue  # this root cannot hold markers — try the next
         return False
     return False
 

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -569,6 +569,24 @@ GIT_MEASURING_READ = re.compile(
     r"|symbolic-ref|for-each-ref|ls-files|cat-file)\b"
 )
 CD_BEFORE = re.compile(r"(?:^|[|&;\n])\s*cd\s+\S")
+# A quote is not a statement separator, so `ssh host 'cd /etc && git log -1'`
+# used to read as "no cd" and drew the advisory on every remote inspection.
+# The cd counts only inside the same quoted run as the measurement, so a cd
+# belonging to an earlier payload cannot silence a later local slip.
+_QUOTES = "\"'"
+
+
+def _named_directory_before(cmd: str, end: int) -> bool:
+    """True when a `cd` names the directory the measurement at `end` runs in."""
+    segment_start, quote = 0, ""
+    for i, ch in enumerate(cmd[:end]):
+        if quote:
+            if ch == quote:
+                quote, segment_start = "", i + 1
+        elif ch in _QUOTES:
+            quote, segment_start = ch, i + 1
+    prefix = cmd[segment_start:end] if quote else cmd[:end]
+    return bool(CD_BEFORE.search(prefix) or (quote and re.match(r"\s*cd\s+\S", prefix)))
 
 
 # --- blanket `git add` (promoted from a harness-local hook, 2026-08-20) ------
@@ -644,8 +662,9 @@ def blanket_git_add(cmd: str, cwd: str = "", untracked=_untracked_files) -> str 
 
 def git_read_without_named_dir(cmd: str) -> str | None:
     """Warn when a git measurement does not say which directory it measures."""
-    m = GIT_MEASURING_READ.search(cmd or "")
-    if not m or CD_BEFORE.search(cmd[: m.start()]):
+    cmd = cmd or ""
+    m = GIT_MEASURING_READ.search(cmd)
+    if not m or _named_directory_before(cmd, m.start()):
         return None
     return (
         "This git command inherits its working directory. `cd` survives between "
@@ -772,6 +791,15 @@ def _advisory_already_fired(data, name: str) -> bool:
     — if XDG_RUNTIME_DIR names something unusable, makedirs raises before any
     marker could exist, and that has to read as "not fired", not as
     FileExistsError at the marker call.
+
+    XDG_RUNTIME_DIR is only trusted once it has been shown to work. Login
+    shells export it whether or not the directory exists, and where there is no
+    systemd user session (WSL, containers, a cron-launched session) it names a
+    path under root-owned /run/user that cannot be created. Treating that as
+    "not fired" is permanent: the advisory then repeats on every matching
+    command for the life of the session, which is the storm the once-per-
+    session rule exists to prevent. So fall back to the temp directory, and
+    keep returning False only when nowhere at all can hold a marker.
     """
     session_id = data.get("session_id") if isinstance(data, dict) else None
     if not session_id:
@@ -779,13 +807,17 @@ def _advisory_already_fired(data, name: str) -> bool:
     slug = re.sub(r"[^A-Za-z0-9_-]", "", str(session_id))
     if not slug:
         return False
-    directory = os.path.join(
-        os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir(),
-        "git-workflow-advisories",
-    )
-    try:
-        os.makedirs(directory, exist_ok=True)
-    except OSError:
+    roots = [os.environ.get("XDG_RUNTIME_DIR"), tempfile.gettempdir()]
+    for root in roots:
+        if not root:
+            continue
+        directory = os.path.join(root, "git-workflow-advisories")
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError:
+            continue
+        break
+    else:
         return False
     marker = os.path.join(directory, f"{slug}.{name}")
     try:

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -563,12 +563,19 @@ def run_poll_problem(cmd: str) -> str | None:
 # repository (2026-08-12: an `ls-remote` answered from the wrong checkout and
 # produced a wrong "deviation" claim). Reads only; writes are covered by the
 # reference-worktree gate.
+#
+# One separator class for both halves. They must agree: whatever counts as a
+# statement boundary before `git` has to count as one before `cd`, or a command
+# that names its directory still draws the advisory. They did not agree —
+# `(` and `$(` opened a measurement but not a cd — so `(cd /etc && git status)`
+# and `x=$(cd /srv && git rev-parse HEAD)` were reported as unnamed.
+_SEP = r"(?:^|[|&;\n(]|\$\()"
 GIT_MEASURING_READ = re.compile(
-    r"(?:^|[|&;\n(]|\$\()\s*git\s+(?!-C\b)(?!--git-dir)(?:-c\s+\S+\s+)*"
+    _SEP + r"\s*git\s+(?!-C\b)(?!--git-dir)(?:-c\s+\S+\s+)*"
     r"(ls-remote|rev-parse|rev-list|log|status|diff|show|describe"
     r"|symbolic-ref|for-each-ref|ls-files|cat-file)\b"
 )
-CD_BEFORE = re.compile(r"(?:^|[|&;\n])\s*cd\s+\S")
+CD_BEFORE = re.compile(_SEP + r"\s*cd\s+\S")
 # A quote is not a statement separator, so `ssh host 'cd /etc && git log -1'`
 # used to read as "no cd" and drew the advisory on every remote inspection.
 # The cd counts only inside the same quoted run as the measurement, so a cd


### PR DESCRIPTION
Two independent defects made one advisory restate itself on every matching call. Observed on 2026-09-02 during a maintenance window: four identical paragraphs in a row while inspecting a remote host over ssh — exactly the storm the once-per-session rule exists to prevent.

**A quote is not a statement separator.** `ssh host 'cd /etc && git log -1'` read as "no cd", because `CD_BEFORE` only recognised a `cd` preceded by `^ | & ; \n`. The directory is named right there. The `cd` now counts when it sits in the same quoted run as the measurement, so a `cd` belonging to an earlier payload still cannot silence a later local slip.

**The dedupe marker was permanently unreachable.** It lived under `XDG_RUNTIME_DIR` and every storage failure read as "not fired". Login shells export that variable whether or not the directory exists; without a systemd user session it names a path under root-owned `/run/user` that cannot be created. So the dedupe was off always, not occasionally:

```
$ echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"; ls -ld /run/user/1001
XDG_RUNTIME_DIR=/run/user/1001
ls: cannot access '/run/user/1001': No such file or directory
```

It now falls back to the temp directory, and returns "not fired" only when nowhere can hold a marker.

**Before and after, same command, same session id, three runs each:**

```
=== old ===
Lauf 1: 1
Lauf 2: 1
Lauf 3: 1
=== new ===
Lauf 1: 0
Lauf 2: 0
Lauf 3: 0
```

(0 rather than "1 then 0" because this command names its directory — the first defect.)

**Tests.** Each of the three behaviours was seen to fail before the fix. The guard against over-widening the `cd` match — a `cd` in an earlier ssh payload must not silence a following local `git status` — was checked against a naive version that just adds quotes to the regex; it reddens there, so it is coverage and not decoration. The unreachable-storage branch cannot be provoked through the environment (`tempfile.gettempdir()` validates its candidates and lands on `/tmp` whatever `TMPDIR` says), so it is exercised directly rather than asserted about.

One test-isolation defect fixed along the way: markers left in the real `/tmp` by one run silenced the next, which turned the two runtime-dir cases into false greens on a second run. The suite now isolates the temp directory and passes twice in a row from a clean state.

Draft until someone else has looked at it — I both found and fixed this one.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0147ZQG3cRLaUUgpYQPozexo)_