### PR TITLE
docs: count-based gates, and the REST subset when GraphQL is drained

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -275,6 +275,44 @@ gh api "repos/$R/code-scanning/alerts?tool_name=<tool>&pr=$PR&state=open" \
 If the paths and lines are yours, the finding is yours — whatever the local run
 says.
 
+## A presence check is not a correctness check: assert the count, not the existence
+
+A pipeline gate written as "the thing is there" passes for every wrong number of
+the thing. One repository ended its publish job with
+
+```bash
+grep -q '<select name="repository"' public/index.html \
+  || { echo "dropdown injection failed" >&2; exit 1; }
+```
+
+which is satisfied by one copy and equally by the 190 that had silently
+accumulated, because the injecting script was not idempotent and each run
+appended another. The gate existed precisely to catch a broken injection and was
+structurally blind to the failure that happened. It shipped 496 KB index pages
+for months.
+
+Where a build injects, generates or de-duplicates something, the assertion is a
+count and an equality, across every artifact rather than the one that happens to
+be convenient:
+
+```bash
+for f in $(find public -name index.html); do
+  n=$(grep -o '<select name="repository"' "$f" | wc -l)
+  [ "$n" -eq 1 ] || { echo "$f carries $n, expected exactly 1" >&2; exit 1; }
+done
+```
+
+Two habits follow:
+
+- **`grep -q` answers "at least one".** Reach for `grep -c` plus a comparison
+  whenever "none" and "many" are both wrong.
+- **Prove the guard fails.** Disable the fix, run the gate, watch it exit
+  non-zero with the message you expect, restore. A gate never seen red is a
+  claim; the run that reddens it is the evidence. The same session's idempotency
+  fix passed its own count check while still growing the file by one byte per
+  run — the count was right and the artifact was not, which only a
+  byte-comparison of two consecutive runs surfaced.
+
 ## Git Mirror Repositories
 
 Use `git clone --mirror` + `git push --mirror` to keep a target repository in sync with an

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -296,15 +296,27 @@ count and an equality, across every artifact rather than the one that happens to
 be convenient:
 
 ```bash
-find public -name index.html -print0 | while IFS= read -r -d '' f; do
+seen=0
+while IFS= read -r -d '' f; do
+  seen=$((seen + 1))
   n=$(grep -o '<select name="repository"' "$f" | wc -l)
   [ "$n" -eq 1 ] || { echo "$f carries $n, expected exactly 1" >&2; exit 1; }
-done
+done < <(find public -name index.html -print0)
+[ "$seen" -gt 0 ] || { echo "no index.html found — nothing was checked" >&2; exit 1; }
 ```
 
-`-print0` with a NUL-delimited read, not `for f in $(find …)`: the unquoted
-substitution word-splits, so a path containing a space silently becomes two
-paths and the gate checks neither of them.
+Three shapes in that loop, each of which has silently broken a gate:
+
+- **`-print0` with a NUL-delimited read**, not `for f in $(find …)`. The
+  unquoted substitution word-splits, so a path containing a space becomes two
+  paths and the gate checks neither.
+- **Process substitution, not a pipe.** `find … | while …` puts the loop in a
+  subshell, where `exit 1` ends the subshell and leaves the caller running — the
+  gate then reports its failure to nobody, unless `set -e` and `pipefail` happen
+  to be on in whatever copied it.
+- **Fail closed on an empty list.** Finding no artifacts is not a pass. A gate
+  that validated zero files is exactly as green as one that validated all of
+  them, which is how a renamed output directory goes unnoticed.
 
 Two habits follow:
 

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -296,16 +296,23 @@ count and an equality, across every artifact rather than the one that happens to
 be convenient:
 
 ```bash
-for f in $(find public -name index.html); do
+find public -name index.html -print0 | while IFS= read -r -d '' f; do
   n=$(grep -o '<select name="repository"' "$f" | wc -l)
   [ "$n" -eq 1 ] || { echo "$f carries $n, expected exactly 1" >&2; exit 1; }
 done
 ```
 
+`-print0` with a NUL-delimited read, not `for f in $(find …)`: the unquoted
+substitution word-splits, so a path containing a space silently becomes two
+paths and the gate checks neither of them.
+
 Two habits follow:
 
-- **`grep -q` answers "at least one".** Reach for `grep -c` plus a comparison
-  whenever "none" and "many" are both wrong.
+- **`grep -q` answers "at least one".** Count instead — but count *matches*:
+  `grep -c` counts matching **lines**, so generated or minified output that puts
+  several occurrences on one line reads as 1 and the gate passes on exactly the
+  artifact most likely to be wrong. `grep -o … | wc -l` is the one that answers
+  the question asked.
 - **Prove the guard fails.** Disable the fix, run the gate, watch it exit
   non-zero with the message you expect, restore. A gate never seen red is a
   claim; the run that reddens it is the evidence. The same session's idempotency

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -345,10 +345,16 @@ Recovery is waiting: `gh api rate_limit --jq '.resources.graphql.reset'` is an e
 whole finish flow appears blocked. Most of it is not. `rate_limit` can even
 report `5000/5000` for both resources while GraphQL refuses — the counter is not
 where a secondary limit shows up, so probe it directly instead of believing the
-number:
+number, and classify the failure rather than assuming the worst: a 401, a DNS
+error and a throttle all make `gh api` exit non-zero, and only one of them is
+worth waiting an hour for.
 
 ```bash
-gh api graphql -f query='{viewer{login}}' >/dev/null 2>&1 && echo up || echo throttled
+err=$(gh api graphql -f query='{viewer{login}}' 2>&1 >/dev/null) && echo up \
+  || case "$err" in
+       *RATE_LIMIT*|*"rate limit"*|*"secondary rate"*) echo throttled ;;
+       *) echo "graphql down, not throttled: $err" ;;
+     esac
 ```
 
 Answerable from REST, which is usually still healthy:
@@ -356,28 +362,45 @@ Answerable from REST, which is usually still healthy:
 | Question | REST call |
 |---|---|
 | head SHA, base, draft state | `gh api repos/$R/pulls/$PR` |
-| every check on the head | `gh api "repos/$R/commits/$SHA/check-runs?per_page=100" --paginate` |
-| reviews submitted | `gh api repos/$R/pulls/$PR/reviews --paginate` |
+| check runs on the head | `gh api "repos/$R/commits/$SHA/check-runs?per_page=100" --paginate` |
+| legacy commit statuses | `gh api "repos/$R/commits/$SHA/status?per_page=100" --paginate` |
+| reviews submitted | `gh api "repos/$R/pulls/$PR/reviews?per_page=100" --paginate` |
 | reviewers still requested | `gh api repos/$R/pulls/$PR/requested_reviewers` |
-| effective rulesets on the base | `gh api repos/$R/rules/branches/$ENC_BASE` (see below) |
+| effective rulesets on the base | `gh api "repos/$R/rules/branches/$ENC_BASE?per_page=100" --paginate` |
+| merge (direct only) | `gh api repos/$R/pulls/$PR/merge -X PUT -f sha="$SHA" -f merge_method=merge` |
 
-Two details the table hides. `reviews` is paginated and defaults to 30, so a PR
-with a long review history answers with a prefix that looks complete — the same
-truncation trap as unpaginated check-runs. And the rulesets endpoint takes the
-branch as a path segment, so a base like `release/2.1` must be URI-encoded first
-(`pr-status.sh` encodes it for exactly this reason):
+Four details the table hides.
+
+**Checks are two endpoints, not one.** `check-runs` does not carry legacy commit
+statuses, so a repository whose required contexts are classic statuses looks
+green with none of them read. Query both.
+
+**Every one of these paginates.** Default page size is 30 — `reviews`,
+`check-runs` and the rulesets array all truncate silently, which is the same
+trap this file warns about elsewhere.
+
+**The rulesets path takes the branch as a path segment**, so a base like
+`release/2.1` must be URI-encoded first (`pr-status.sh` encodes it for exactly
+this reason):
 
 ```bash
 ENC_BASE=$(printf %s "$BASE" | jq -sRr @uri)
 ```
-| merge | `gh api repos/$R/pulls/$PR/merge -X PUT -f merge_method=merge` |
 
-Two things have **no** REST equivalent and genuinely have to wait: converting a
-draft to ready (`markPullRequestReadyForReview`), and review-thread resolution
-(`resolveReviewThread`). A ruleset that requires a bot review is therefore a
-hard stop while the budget is out, because the review cannot be requested on a
-draft and the draft cannot be lifted. Say so and wait for the reset rather than
-merging past the rule.
+**Pin the head when merging through REST.** Without `-f sha="$SHA"` the endpoint
+merges whatever the head is at the moment it runs, so a push that lands between
+the gate check and the call is merged unreviewed. This row is also
+direct-merge-only: the endpoint has no merge-queue mode, so a queue repository
+needs its own flow rather than this fallback.
+
+The one thing with **no** REST equivalent is converting a draft to ready
+(`markPullRequestReadyForReview`); review-thread resolution
+(`resolveReviewThread`) is GraphQL-only too. Requesting a review is not on that
+list — `POST /pulls/$PR/requested_reviewers` works on a draft, and Copilot does
+review drafts, so a bot-review ruleset is not automatically a hard stop while
+the budget is out. Confirm the request off the **timeline**, not off
+`requested_reviewers`: the response body does not echo a bot reviewer, and a
+reviewer that has started drops off that list without having submitted.
 
 ### "Has it merged yet?" costs nothing — ask git, not the API
 

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -339,6 +339,36 @@ Three rules follow, and they cost nothing:
 
 Recovery is waiting: `gh api rate_limit --jq '.resources.graphql.reset'` is an epoch timestamp — sleep to it in **one** background command rather than retrying into the limit.
 
+### What still works while GraphQL is drained
+
+`pr-status.sh` is GraphQL end to end, so it exits `GraphQL query failed` and the
+whole finish flow appears blocked. Most of it is not. `rate_limit` can even
+report `5000/5000` for both resources while GraphQL refuses — the counter is not
+where a secondary limit shows up, so probe it directly instead of believing the
+number:
+
+```bash
+gh api graphql -f query='{viewer{login}}' >/dev/null 2>&1 && echo up || echo throttled
+```
+
+Answerable from REST, which is usually still healthy:
+
+| Question | REST call |
+|---|---|
+| head SHA, base, draft state | `gh api repos/$R/pulls/$PR` |
+| every check on the head | `gh api "repos/$R/commits/$SHA/check-runs?per_page=100" --paginate` |
+| reviews submitted | `gh api repos/$R/pulls/$PR/reviews` |
+| reviewers still requested | `gh api repos/$R/pulls/$PR/requested_reviewers` |
+| effective rulesets on the base | `gh api repos/$R/rules/branches/$BASE` |
+| merge | `gh api repos/$R/pulls/$PR/merge -X PUT -f merge_method=merge` |
+
+Two things have **no** REST equivalent and genuinely have to wait: converting a
+draft to ready (`markPullRequestReadyForReview`), and review-thread resolution
+(`resolveReviewThread`). A ruleset that requires a bot review is therefore a
+hard stop while the budget is out, because the review cannot be requested on a
+draft and the draft cannot be lifted. Say so and wait for the reset rather than
+merging past the rule.
+
 ### "Has it merged yet?" costs nothing — ask git, not the API
 
 The three rules above make a watcher cheaper. This one makes the commonest watcher free. Once a PR is queued the only question left is whether its head landed on the base, and git answers that with no API budget at all:

--- a/skills/git-workflow/references/merge-gate-watcher.md
+++ b/skills/git-workflow/references/merge-gate-watcher.md
@@ -357,9 +357,19 @@ Answerable from REST, which is usually still healthy:
 |---|---|
 | head SHA, base, draft state | `gh api repos/$R/pulls/$PR` |
 | every check on the head | `gh api "repos/$R/commits/$SHA/check-runs?per_page=100" --paginate` |
-| reviews submitted | `gh api repos/$R/pulls/$PR/reviews` |
+| reviews submitted | `gh api repos/$R/pulls/$PR/reviews --paginate` |
 | reviewers still requested | `gh api repos/$R/pulls/$PR/requested_reviewers` |
-| effective rulesets on the base | `gh api repos/$R/rules/branches/$BASE` |
+| effective rulesets on the base | `gh api repos/$R/rules/branches/$ENC_BASE` (see below) |
+
+Two details the table hides. `reviews` is paginated and defaults to 30, so a PR
+with a long review history answers with a prefix that looks complete — the same
+truncation trap as unpaginated check-runs. And the rulesets endpoint takes the
+branch as a path segment, so a base like `release/2.1` must be URI-encoded first
+(`pr-status.sh` encodes it for exactly this reason):
+
+```bash
+ENC_BASE=$(printf %s "$BASE" | jq -sRr @uri)
+```
 | merge | `gh api repos/$R/pulls/$PR/merge -X PUT -f merge_method=merge` |
 
 Two things have **no** REST equivalent and genuinely have to wait: converting a


### PR DESCRIPTION
Two gaps a maintenance session ran into.

**A presence check is not a correctness check** (`ci-cd-integration.md`)

A publish job ended with `grep -q '<select …>' index.html || exit 1`. That is satisfied by one copy and equally by the **190** that had accumulated, because the injecting script was not idempotent and each pipeline run appended another. The gate existed to catch a broken injection and was structurally blind to the failure that actually happened; 496 KB index pages shipped for months behind a green job.

The section says to assert a **count and an equality across every artifact**, not existence on the one that is convenient, and to prove the guard red by disabling the fix. It carries the twist from the same session too: the idempotency fix passed its own count check while the file still grew one byte per run — the count was right and the artifact was not, and only comparing two consecutive runs byte for byte surfaced it.

**What still works while GraphQL is drained** (`merge-gate-watcher.md`)

The file already explains that the two budgets are separate. It did not say what remains possible once GraphQL is out. `pr-status.sh` is GraphQL end to end and exits `GraphQL query failed`, so the finish flow looks blocked — while checks, reviews, requested reviewers, rulesets and the merge itself are all reachable over REST. Added as a table.

Two facts worth having in writing: `gh api rate_limit` can report `5000/5000` for both resources while GraphQL refuses, so probe it (`gh api graphql -f query='{viewer{login}}'`) rather than trusting the counter. And lifting a draft and resolving review threads have **no** REST equivalent — so a ruleset requiring a bot review is a genuine wait, not something to route around.

**Bounded**: documentation only. No script, no gate, no hook behaviour changes.

Draft — from my own session, wants a second reader.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0147ZQG3cRLaUUgpYQPozexo)_