### PR TITLE
fix(hooks): a heredoc body is text, so the named-directory gate stops denying it

### DIFF
--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -604,6 +604,11 @@ class NamedDirectoryWriteGate(unittest.TestCase):
         # A payload a local shell runs is a command, not text (second round).
         "bash -c 'git push origin main'",
         "sh -c 'git commit -m x'",
+        # An UNQUOTED heredoc expands, so a substitution inside its body is a
+        # command that really runs — unlike the prose around it.
+        "cat > f.md <<EOF\nnow: $(git commit -m x)\nEOF",
+        # A heredoc earlier in the call does not excuse a write after it.
+        "cat > f.md <<'EOF'\ndoc\nEOF\ngit commit -m x",
         # git reads an empty -C as no directory change at all (git 2.55.0).
         'git -C "" push origin main',
         "git --git-dir= push origin main",
@@ -703,6 +708,13 @@ class NamedDirectoryWriteGate(unittest.TestCase):
         # The directory is named; the message only mentions a command.
         "git -C /home/u/repo commit -m 'fix git push handling'",
         "gh pr create --draft",
+        # A heredoc body is text being written, not a command being run. The
+        # gate denied writing any document that mentioned a git write —
+        # documentation, release notes, its own test fixtures.
+        "cat > doc.md <<'EOF'\nrun: git commit -m x\nEOF",
+        "cat > doc.md <<EOF\nrun: git commit -m x\nEOF",
+        # In a QUOTED body a substitution does not expand, so nothing runs.
+        "cat > doc.md <<'EOF'\nnow: $(git commit -m x)\nEOF",
     ]
 
     def test_writes_without_a_named_directory_are_denied(self) -> None:
@@ -726,6 +738,20 @@ class NamedDirectoryWriteGate(unittest.TestCase):
             "deny", decision(run_hook("git -C /r commit -m 'fix git push handling'"))
         )
         self.assertEqual("deny", decision(run_hook("bash -c 'git push origin main'")))
+
+    def test_a_heredoc_body_is_text_unless_it_expands(self) -> None:
+        # The whole distinction in one place. Writing a file that mentions a
+        # git write is not a git write; a substitution inside an UNQUOTED body
+        # is, because that body expands before the command reads it.
+        self.assertNotEqual(
+            "deny", decision(run_hook("cat > d.md <<'EOF'\nrun: git commit -m x\nEOF"))
+        )
+        self.assertNotEqual(
+            "deny", decision(run_hook("cat > d.md <<EOF\nrun: git commit -m x\nEOF"))
+        )
+        self.assertEqual(
+            "deny", decision(run_hook("cat > d.md <<EOF\nnow: $(git commit -m x)\nEOF"))
+        )
 
     def test_the_message_names_the_subcommand_and_both_fixes(self) -> None:
         out = run_hook("git push origin main")

--- a/scripts/test_validate_git_command.py
+++ b/scripts/test_validate_git_command.py
@@ -607,6 +607,12 @@ class NamedDirectoryWriteGate(unittest.TestCase):
         # An UNQUOTED heredoc expands, so a substitution inside its body is a
         # command that really runs — unlike the prose around it.
         "cat > f.md <<EOF\nnow: $(git commit -m x)\nEOF",
+        # Nesting: a flat $(...) scan matched only the inner $(date) and blanked
+        # the outer write away with the prose, so this passed the gate.
+        'cat > f.md <<EOF\n$(git commit -m x "$(date)")\nEOF',
+        # Two backslashes are an escaped backslash, so the substitution does
+        # expand — the escape rule must not overshoot into this case.
+        "cat > f.md <<EOF\n\\\\$(git commit -m x)\nEOF",
         # A heredoc earlier in the call does not excuse a write after it.
         "cat > f.md <<'EOF'\ndoc\nEOF\ngit commit -m x",
         # git reads an empty -C as no directory change at all (git 2.55.0).
@@ -715,6 +721,14 @@ class NamedDirectoryWriteGate(unittest.TestCase):
         "cat > doc.md <<EOF\nrun: git commit -m x\nEOF",
         # In a QUOTED body a substitution does not expand, so nothing runs.
         "cat > doc.md <<'EOF'\nnow: $(git commit -m x)\nEOF",
+        # A delimiter may contain characters outside \w: bash accepts END-MARK,
+        # and the hyphen used to break the match so the body stayed visible.
+        "cat > doc.md <<'END-MARK'\ngit commit -m x\nEND-MARK",
+        # <<- strips leading TABS from the terminator; requiring column 0 left
+        # the body unmasked.
+        "cat > doc.md <<-'EOF'\n\tgit commit -m x\n\tEOF",
+        # A single backslash makes the substitution literal text to bash.
+        "cat > doc.md <<EOF\n\\$(git commit -m x)\nEOF",
     ]
 
     def test_writes_without_a_named_directory_are_denied(self) -> None:

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -906,9 +906,35 @@ def _git_invocations(cmd: str):
         yield subcommand, match.start(), names_directory
 
 
+# A heredoc body is data, not a command: `cat > doc.md <<'EOF' … git commit …
+# EOF` writes text ABOUT a commit, it does not make one. Scanning it denies
+# writing documentation, test fixtures and release notes — the same false
+# denial this gate's harness-local ancestor produced, from the same cause.
+#
+# An UNQUOTED body still expands, so a command substitution inside one really
+# does run. Those spans are kept; the prose around them is not. Replacement is
+# length-preserving because the callers below reason about offsets.
+_HEREDOC_BODY = re.compile(r"<<-?\s*(['\"]?)(\w+)\1(.*?^\2$)", re.DOTALL | re.MULTILINE)
+_SUBSTITUTION = re.compile(r"\$\([^()]*\)|`[^`]*`")
+
+
+def _mask_heredoc_bodies(cmd: str) -> str:
+    """Blank heredoc bodies, keeping what an unquoted one would still execute."""
+
+    def blank(match: "re.Match[str]") -> str:
+        body = match.group(3)
+        kept = [" "] * len(body)
+        if not match.group(1):
+            for sub in _SUBSTITUTION.finditer(body):
+                kept[sub.start() : sub.end()] = body[sub.start() : sub.end()]
+        return match.group(0)[: len(match.group(0)) - len(body)] + "".join(kept)
+
+    return _HEREDOC_BODY.sub(blank, cmd or "")
+
+
 def git_write_without_named_dir(cmd: str) -> str | None:
     """Deny a git write that neither uses `-C` nor follows a `cd` in its scope."""
-    cmd = cmd or ""
+    cmd = _mask_heredoc_bodies(cmd or "")
     unnamed = [
         subcommand
         for subcommand, start, names_directory in _git_invocations(cmd)

--- a/scripts/validate_git_command.py
+++ b/scripts/validate_git_command.py
@@ -914,22 +914,86 @@ def _git_invocations(cmd: str):
 # An UNQUOTED body still expands, so a command substitution inside one really
 # does run. Those spans are kept; the prose around them is not. Replacement is
 # length-preserving because the callers below reason about offsets.
-_HEREDOC_BODY = re.compile(r"<<-?\s*(['\"]?)(\w+)\1(.*?^\2$)", re.DOTALL | re.MULTILINE)
-_SUBSTITUTION = re.compile(r"\$\([^()]*\)|`[^`]*`")
+# A delimiter is a shell word, not `\w+`: `<<\'END-MARK\'` is valid, and its
+# hyphen broke the match, so the body stayed visible and the write was denied.
+# `<<-` additionally strips leading TABS from its terminator, so that form needs
+# its own terminator pattern — accepting indentation for the plain form would
+# mask more than bash does, which is the dangerous direction.
+_HEREDOC_START = re.compile(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_.-]*)\2")
+
+
+def _substitution_spans(body: str) -> list[tuple[int, int]]:
+    r"""Spans an unquoted heredoc would still execute, nesting- and escape-aware.
+
+    A flat `\$\([^()]*\)` cannot see `$(git commit -m "$(date)")`: it matches only
+    the inner `$(date)`, so the outer `git` was blanked away with the prose and
+    an unnamed write passed the gate. Escapes matter in the other direction —
+    `\\$(git commit …)` is literal text to bash, and keeping it executable denied a
+    command that never runs.
+    """
+    spans: list[tuple[int, int]] = []
+    i, n = 0, len(body)
+    while i < n:
+        char = body[i]
+        if char == "\\":
+            i += 2
+            continue
+        if char == "$" and i + 1 < n and body[i + 1] == "(":
+            depth, j = 0, i + 1
+            while j < n:
+                if body[j] == "\\":
+                    j += 2
+                    continue
+                if body[j] == "(":
+                    depth += 1
+                elif body[j] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        spans.append((i, j + 1))
+                        break
+                j += 1
+            i = j + 1 if j < n else n
+            continue
+        if char == "`":
+            j = i + 1
+            while j < n:
+                if body[j] == "\\":
+                    j += 2
+                    continue
+                if body[j] == "`":
+                    spans.append((i, j + 1))
+                    break
+                j += 1
+            i = j + 1 if j < n else n
+            continue
+        i += 1
+    return spans
 
 
 def _mask_heredoc_bodies(cmd: str) -> str:
     """Blank heredoc bodies, keeping what an unquoted one would still execute."""
-
-    def blank(match: "re.Match[str]") -> str:
-        body = match.group(3)
+    cmd = cmd or ""
+    out = list(cmd)
+    pos = 0
+    while True:
+        start = _HEREDOC_START.search(cmd, pos)
+        if start is None:
+            break
+        dash, quote, delimiter = start.group(1), start.group(2), start.group(3)
+        indent = "[ \t]*" if dash else ""
+        terminator = re.compile(rf"^{indent}{re.escape(delimiter)}$", re.MULTILINE)
+        end = terminator.search(cmd, start.end())
+        if end is None:
+            pos = start.end()
+            continue
+        body = cmd[start.end() : end.start()]
         kept = [" "] * len(body)
-        if not match.group(1):
-            for sub in _SUBSTITUTION.finditer(body):
-                kept[sub.start() : sub.end()] = body[sub.start() : sub.end()]
-        return match.group(0)[: len(match.group(0)) - len(body)] + "".join(kept)
-
-    return _HEREDOC_BODY.sub(blank, cmd or "")
+        if not quote:
+            for sub_start, sub_end in _substitution_spans(body):
+                kept[sub_start:sub_end] = body[sub_start:sub_end]
+        out[start.end() : end.start()] = kept
+        pos = end.end()
+    return "".join(out)
 
 
 def git_write_without_named_dir(cmd: str) -> str | None:

--- a/skills/git-workflow/references/claude-code-hooks.md
+++ b/skills/git-workflow/references/claude-code-hooks.md
@@ -246,6 +246,10 @@ The write is found by scanning tokens rather than by one pattern, because a patt
 
 Quoting decides whether text is a command. A quoted run is blanked before the scan, so `git -C /r commit -m "fix git push"` is not read as a second, unnamed write. The exception is a payload a local shell will run: `bash -c 'git push'` is the write it looks like and is denied, while `bash -c 'cd /repo && git push'` passes because the `cd` is in the payload's own scope. `ssh host '…'` is deliberately not inspected — its working directory is on another machine, which is not what this gate is about.
 
+A heredoc body is data, not a command. `cat > doc.md <<'EOF' … git commit … EOF` writes text ABOUT a commit; it makes none. Scanning it denied writing documentation, release notes and the gate's own test fixtures — the same false denial the harness-local ancestor of this gate produced, from the same cause. Bodies are blanked before the scan, with one exception that decides the rule: an UNQUOTED body expands, so a `$( … )` or backtick span inside one really does run and stays in, while the prose around it does not. In a quoted body nothing expands, so the whole body goes. The blanking is length-preserving, because the scan reasons about offsets when it looks backwards for a `cd`.
+
+The same blind spot bit a harness-local attribution gate on the same day, in its other form: it read a `git commit` inside `bash -c '…'` as text and let an undisclosed commit through. Both are the one question — does this span reach a shell? — and a hook that answers it in one place should answer it in the other.
+
 The escape hatch counts only where a shell would read it as an environment assignment, and only on the statement it prefixes: as a substring it disabled the gate from inside a commit message that merely named it (which the messages in this repository do), and as a whole-command test `DESTRUCTIVE_GIT_GATE_OFF=1 true; git push origin main` disabled it for a write the assignment never prefixed. That predicate is shared with `blanket_git_add()`, which had the same weakness.
 
 Escape hatch, shared with the destructive-git gate: `DESTRUCTIVE_GIT_GATE_OFF=1`. Verify both directions: `python3 -m unittest discover -s scripts -p 'test_*.py'` denies `git push origin x` and passes `git -C /repo push origin x`.
@@ -261,6 +265,7 @@ Escape hatch, shared with the destructive-git gate: `DESTRUCTIVE_GIT_GATE_OFF=1`
 | Per-hook large shell scripts inline in JSON | Unreadable, un-testable | Keep inline ≤3 lines; call external script for more |
 | An exception the gate reads from the environment | The hook is its own process; a `VAR=1 cmd` prefix never reaches it, so the documented way out is inert | Read it off the command text, anchored as a leading assignment, and copy the mechanism from the gate already shipping in that hook |
 | A deny text whose promises nothing tests | The message is the contract; an untested promise is usually the case the gate gets wrong | One test per clause of the message — see below |
+| A gate that scans a heredoc body | A body is data unless it expands; scanning it denies writing any document that mentions the command | Blank the body, length-preserving, keeping `$( … )` spans in an unquoted one |
 | A gate built from an incident that covers one command shape | An incident is plural; the shape you remember is rarely the only one it used | Extract every command shape from the transcript and assert the predicate on each |
 
 ### The deny message is a specification


### PR DESCRIPTION
A false denial in the gate [#270](https://github.com/netresearch/git-workflow-skill/pull/270) shipped, found while writing documentation that mentions a git write.

`git_write_without_named_dir()` scanned the raw command, so this was denied:

```
cat > doc.md <<'EOF'
run: git commit -m x
EOF
```

That writes text *about* a commit and makes none. Any release note, reference page or test fixture naming a git write was blocked the same way — including this repository's own material, which is where it surfaced.

## The rule, and its one exception

Heredoc bodies are blanked before the scan. The exception is what decides the rule: an **unquoted** body expands, so a `$( … )` or backtick span inside it really does run and stays in, while the prose around it does not. In a **quoted** body nothing expands, so the whole body goes. Blanking is length-preserving, because the scan reasons about offsets when it looks backwards for a `cd`.

| command | before | after |
|---|---|---|
| `cat > f <<'EOF'` … `git commit` … | deny | allow |
| `cat > f <<EOF` … `git commit` … | deny | allow |
| `cat > f <<EOF` … `$(git commit …)` … | deny | **deny** |
| `cat > f <<'EOF'` … `$(git commit …)` … | deny | allow |
| heredoc, then a real bare `git commit` | deny | **deny** |

## Tests

Six fixtures and one test for the distinction. Against the code they replace, four fail — the two prose cases and the quoted-substitution case, plus the dedicated test. `python3 -m unittest discover -s scripts -p 'test_*.py'`: 74 pass with the change, 4 fail without it. Nothing else in the suite moves.

## The sibling case

The same blind spot bit a harness-local attribution gate on the same day in its other form: it read a `git commit` inside `bash -c '…'` as text and let an undisclosed commit through. This gate already handles that half, from #270. Recipe 9 now records both, because they are one question — does this span reach a shell? — and a hook that answers it in one place should answer it in the other.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014LbhshbQ8jBjLU2ymEZHbr)_
