### PR TITLE
docs: complete the marketplace setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-mar
 
 ### Without a marketplace
 
-Since Claude Code 2.1.157 a plugin directory under your personal skills directory loads on its own, hooks and commands included:
+Since Claude Code 2.1.157 a plugin directory under your personal skills directory loads on its own, including the hooks and commands this repo ships:
 
 ```bash
+mkdir -p ~/.claude/skills
 git clone https://github.com/netresearch/git-workflow-skill.git \
   ~/.claude/skills/git-workflow
 ```
 
-It loads as `git-workflow@skills-dir` on the next session. Update with `git pull`; remove it by deleting the directory. This route has no `claude plugin update`.
+It loads as `git-workflow@skills-dir` on the next session. Update with `git -C ~/.claude/skills/git-workflow pull` and start a new session; remove it by deleting the directory. This route has no `claude plugin update`.
 
 ### npx ([skills.sh](https://skills.sh))
 
@@ -55,6 +56,8 @@ Install with any [Agent Skills](https://agentskills.io)-compatible agent:
 npx skills add https://github.com/netresearch/git-workflow-skill --skill git-workflow
 ```
 
+> **Limitation:** `npx skills` installs `SKILL.md`-based skills only. This repo also ships `hooks`, `commands`, which it does not install — use the marketplace or the skills directory for those.
+
 ### Download Release
 
 Download the [latest release](https://github.com/netresearch/git-workflow-skill/releases/latest) and extract to your agent's skills directory.
@@ -62,8 +65,6 @@ Download the [latest release](https://github.com/netresearch/git-workflow-skill/
 ### Git Clone
 
 ```bash
-
-> **Limitation:** `npx skills` installs `SKILL.md`-based skills only. This repo also ships `hooks`, `commands`, which it does not install — use the marketplace or the skills directory for those.
 git clone https://github.com/netresearch/git-workflow-skill.git
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-mar
 ```bash
 # Claude Code
 /plugin marketplace add netresearch/claude-code-marketplace
+/plugin install git-workflow@netresearch-claude-code-marketplace
 ```
+
+### Without a marketplace
+
+Since Claude Code 2.1.157 a plugin directory under your personal skills directory loads on its own, hooks and commands included:
+
+```bash
+git clone https://github.com/netresearch/git-workflow-skill.git \
+  ~/.claude/skills/git-workflow
+```
+
+It loads as `git-workflow@skills-dir` on the next session. Update with `git pull`; remove it by deleting the directory. This route has no `claude plugin update`.
 
 ### npx ([skills.sh](https://skills.sh))
 
@@ -50,6 +62,8 @@ Download the [latest release](https://github.com/netresearch/git-workflow-skill/
 ### Git Clone
 
 ```bash
+
+> **Limitation:** `npx skills` installs `SKILL.md`-based skills only. This repo also ships `hooks`, `commands`, which it does not install — use the marketplace or the skills directory for those.
 git clone https://github.com/netresearch/git-workflow-skill.git
 ```
 


### PR DESCRIPTION
The README named the catalog correctly, but stopped one step short of a working setup: it documented `/plugin marketplace add netresearch/claude-code-marketplace` and never the `/plugin install` line that has to follow it. Following it left you with a registered marketplace and no plugin.

```text
/plugin marketplace add netresearch/claude-code-marketplace
/plugin install git-workflow@netresearch-claude-code-marketplace
```

The install target is the **catalog entry name** — `git-workflow` here — which is not always the repo name, and the right-hand side is the marketplace name rather than `owner/repo`.

## Also added

The marketplace-free route, which is supported rather than a workaround. Claude Code 2.1.157: *"Plugins in `.claude/skills` directories are now automatically loaded, no marketplace required."* A clone under `~/.claude/skills/git-workflow` loads as `git-workflow@skills-dir` with hooks, agents and commands intact.

The `npx skills` section now says what it leaves out: it installs `SKILL.md`-based skills only, so this repo's `hooks`, `commands` are not installed by it.
## Context

This came out of netresearch/retro-skill#90, where a user found the documented steps unusable. That repo pointed `marketplace add` at itself, which fails outright; this repo was never broken, only incomplete. The shared template both came from is fixed in netresearch/skill-repo-skill#291.

`markdownlint-cli2` clean.

## Review round

Review on this PR found four defects in the section above, all fixed here:

- The limitation note sat **inside** the `bash` fence under "Git Clone", so it rendered as shell input and would be copied along with the command. It now follows the npx example, which is what it is about.
- `git clone` into `~/.claude/skills/<name>` fails on a fresh setup where that parent does not exist. `mkdir -p ~/.claude/skills` precedes it.
- "Update with `git pull`" ran wherever the reader happened to stand. It now names the directory and says a new session is needed for the change to load.
- The sentence claimed hooks and commands unconditionally. It now names only what this repository actually ships.

One finding was declined: that the skills-directory route should not be published, because `.claude-plugin/plugin.json` lists only `skills`. `hooks/hooks.json` is discovered by convention rather than declared — of twelve installed plugins carrying a `hooks/` directory, Anthropic's own included, none declares a `hooks` key. The key's absence proves nothing, so the route stays.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_