### PR TITLE
feat(pr-merge): name the review path a bot-authored PR does have

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -230,6 +230,31 @@ state it claims to observe — the same reason the old "review-yourself"
 it only when the diff was actually reviewed, and say what was looked at in
 the review-note comment beside it.
 
+### A bot-authored pull request takes the other path (#280)
+
+The attestation is an assertion by the author, so it is unavailable on a
+Renovate or Dependabot pull request: nobody can authenticate as the bot, and
+`--self-reviewed` refuses. That leaves the ordinary path, which was open the
+whole time and went unnamed — a human `APPROVED` review on the current head
+satisfies the never-merge-unreviewed policy on its own, in the
+`copilot_code_review` branch as well as the generic one:
+
+```bash
+gh pr review 123 --repo owner/repo --approve   # after reading the diff
+pr-merge.sh -R owner/repo 123                  # no flag
+```
+
+A `COMMENTED` review is not enough — that is what a CodeRabbit note or a
+thread reply registers as, and the gate reads the approval list, not
+`has_review_on_head`. `pr-status.sh` reports `author_is_bot` and swaps the
+attestation advice for this command; `pr-merge.sh --self-reviewed` names it in
+its refusal. Nothing about the gate is relaxed: a third party still cannot mint
+an attestation for someone else's pull request, and the approval is a real
+review on the record rather than a flag. This is the case `deps-no-automerge`
+and `deps-major` route to a human by design — `netresearch/.github`'s
+`auto-merge-deps.yml` excludes both labels, and its own documentation says
+majors are approved but left for a human to merge.
+
 ### Before believing a script cannot do something: ask which copy is running
 
 Every script in `scripts/` answers `--version`, and prints the resolved path beneath it:

--- a/skills/git-workflow/scripts/pr-merge.sh
+++ b/skills/git-workflow/scripts/pr-merge.sh
@@ -125,9 +125,10 @@ if [ "$SELF_REVIEWED" = "1" ] && [ "$ACTION" = "request-review" ]; then
   SR_FIELDS=$(printf '%s' "$STATUS" | jq -er '
     [ (.next.reason // "-"),
       ((.self_review_on_head // false)|tostring),
-      (.headOid // ""), (.author // "")
+      (.headOid // ""), (.author // ""),
+      ((.author_is_bot // false)|tostring)
     ] | @tsv') || die "pr-status.sh returned unexpected JSON"
-  IFS=$'\t' read -r SR_REASON SR_HAVE SR_HEAD SR_AUTHOR <<EOF
+  IFS=$'\t' read -r SR_REASON SR_HAVE SR_HEAD SR_AUTHOR SR_AUTHOR_BOT <<EOF
 $SR_FIELDS
 EOF
   # Keyed on the reason the REFUSING BRANCH stamped, never re-derived from the
@@ -138,6 +139,15 @@ EOF
   # history there.
   if [ "$SR_REASON" != "bot-review-unsatisfiable" ]; then
     die "--self-reviewed refused: this request-review is not the unsatisfiable-bot-review case (reason: $SR_REASON) — a live review path exists, use it"
+  fi
+  # A bot-authored pull request can never satisfy the author check below, so
+  # the generic refusal would send the operator looking for a way to become
+  # renovate. Named separately, with the path that does exist: approving the
+  # head as yourself satisfies the same gate, and pr-merge then merges without
+  # any flag (#280). No relaxation — a third party still cannot mint an
+  # attestation for someone else's pull request.
+  if [ "$SR_AUTHOR_BOT" = "true" ]; then
+    die "--self-reviewed refused: $SR_AUTHOR is a bot, and the attestation is an assertion by the PR author — a bot never reads the diff, so this flag has no meaning here. Review the diff and approve it as yourself: gh pr review $PR --repo $REPO --approve, then re-run this script without --self-reviewed."
   fi
   VIEWER=$(gh api user --jq .login 2>/dev/null) || die "--self-reviewed: could not resolve the authenticated gh user"
   if [ "$VIEWER" != "$SR_AUTHOR" ]; then

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -73,7 +73,7 @@
 # `.mergeStateStatus == "CLEAN"` never fires and reads as "still running"
 # forever. Top-level keys:
 #
-#   state mergeable mergeState draft number title repo author
+#   state mergeable mergeState draft number title repo author author_is_bot
 #   base head headOid
 #   checks checks_settled threads unresolved_threads
 #   unanswered_comments unanswered_human unanswered_by unanswered_urls
@@ -259,7 +259,7 @@ collect() {
       pullRequest(number:$pr){
         number title state isDraft mergeable mergeStateStatus reviewDecision
         mergeQueueEntry{ state position estimatedTimeToMerge }
-        author{login}
+        author{login __typename}
         baseRefName headRefName headRefOid isCrossRepository
         # The last page, not the first: a Self-review attestation (see the
         # header) is posted at the end of a conversation, and an old page
@@ -358,6 +358,14 @@ evaluate() {
     | ([$r[]? | .type] | unique) as $ruletypes
     | (($ruletypes | index("copilot_code_review")) != null) as $needs_copilot
     | ($p.author.login) as $author
+    # A bot author can never post the attestation below: it authenticates as
+    # nobody and reviews nothing, so the whole `Self-review:` path is closed on
+    # a Renovate or Dependabot pull request and the advice has to name a
+    # different one (#280). Same predicate as $unanswered_human further down —
+    # __typename is the authority, the login patterns are the fallback for a
+    # REST-shaped author and for App-backed User accounts.
+    | ((($p.author.__typename // "") == "Bot")
+       or ($author | test("\\[bot\\]$|^(dependabot|renovate)"; "i"))) as $author_is_bot
     # Self-review attestation (#203). An EXPLICIT operator assertion, not an
     # observation: a PR comment BY THE AUTHOR whose body carries a line
     # `Self-review: <sha>` prefix-matching the current head. This is the
@@ -570,6 +578,7 @@ evaluate() {
                           then ($self_review_comments | last | .url)
                           else null end),
         author: $author,
+        author_is_bot: $author_is_bot,
         requested_reviewers: [$p.reviewRequests.nodes[]?.requestedReviewer|(.login // .slug)],
         unresolved_threads: ($unresolved|length),
         unanswered_comments: ($unanswered_comments|length),
@@ -660,13 +669,26 @@ evaluate() {
        + " same month and go again minutes later, so the record above expires on its own and"
        + " is dropped as soon as a Copilot review is observed. Review the diff yourself, note"
        + " in the PR that the bot review was unavailable, and decide on that."
-       + " To proceed on a documented self-review, post a PR comment (as the PR author)"
-       + " containing the line `Self-review: <head-sha>` with at least the first 12"
-       + " chars of \($s.headOid[0:12]) — pr-merge.sh --self-reviewed posts it and merges in"
-       + " one step; the attestation is honoured only while this wall stands and dies with"
-       + " the next push. The placeholder here is deliberate: this very advice gets pasted"
-       + " into PR comments, and a paste must never mint an attestation, so the accepting"
-       + " sequence never appears in it") as $quota_why
+       # The attestation is an assertion BY THE AUTHOR, so on a bot-authored pull
+       # request nobody can make it and pr-merge.sh --self-reviewed refuses. What
+       # is left there is the ordinary review a human can give: an APPROVED review
+       # on this head satisfies the policy on its own, in this branch and in the
+       # generic one below (#280).
+       + (if $s.author_is_bot
+          then " The pull request is authored by \($author), so the self-review attestation is"
+               + " not available on it: that attestation is an assertion by the author, and a bot"
+               + " never authenticates and never reads a diff. Review the diff and approve it as"
+               + " yourself instead — an approval on this head satisfies the gate, and pr-merge.sh"
+               + " then merges without any flag:"
+               + " gh pr review \($s.number) --repo \($s.repo) --approve"
+          else " To proceed on a documented self-review, post a PR comment (as the PR author)"
+               + " containing the line `Self-review: <head-sha>` with at least the first 12"
+               + " chars of \($s.headOid[0:12]) — pr-merge.sh --self-reviewed posts it and merges in"
+               + " one step; the attestation is honoured only while this wall stands and dies with"
+               + " the next push. The placeholder here is deliberate: this very advice gets pasted"
+               + " into PR comments, and a paste must never mint an attestation, so the accepting"
+               + " sequence never appears in it"
+          end)) as $quota_why
     | .next =
         (if $s.state != "OPEN" then
            {action:"none", why:"PR is \($s.state)"}

--- a/skills/git-workflow/scripts/pr-status.sh
+++ b/skills/git-workflow/scripts/pr-status.sh
@@ -364,8 +364,14 @@ evaluate() {
     # different one (#280). Same predicate as $unanswered_human further down —
     # __typename is the authority, the login patterns are the fallback for a
     # REST-shaped author and for App-backed User accounts.
+    # Every alternative is anchored, and each covers a form measured on a real
+    # Renovate pull request: GraphQL answers login `renovate` with __typename
+    # Bot, `gh pr view --json author` answers `app/renovate`, and the webhook
+    # payload answers `renovate[bot]`. An unanchored `^renovate` would also
+    # read the human login `renovate-maintainer` as a bot, which refuses that
+    # person --self-reviewed on their own pull request.
     | ((($p.author.__typename // "") == "Bot")
-       or ($author | test("\\[bot\\]$|^(dependabot|renovate)"; "i"))) as $author_is_bot
+       or ($author | test("\\[bot\\]$|^app/|^(dependabot|renovate)$"; "i"))) as $author_is_bot
     # Self-review attestation (#203). An EXPLICIT operator assertion, not an
     # observation: a PR comment BY THE AUTHOR whose body carries a line
     # `Self-review: <sha>` prefix-matching the current head. This is the

--- a/tests/test_pr_merge_self_reviewed.sh
+++ b/tests/test_pr_merge_self_reviewed.sh
@@ -53,7 +53,8 @@ make_status_json() {
 {
   "repo": "o/r", "number": 559, "queue_active": false,
   "merge_methods": ["merge", "rebase"],
-  "headOid": "$HEAD_OID", "author": "the-author",
+  "headOid": "$HEAD_OID", "author": "${PR_AUTHOR:-the-author}",
+  "author_is_bot": ${AUTHOR_IS_BOT:-false},
   "copilot_quota_exhausted": true, "copilot_error_count": 2,
   "self_review_on_head": $4,
   "next": {"action": "$2", $reason_line "why": "$why", "method": "--merge"}
@@ -217,6 +218,37 @@ if grep -q '^pr merge$' "$STUB_DIR/calls.log"; then
 else
     echo "  ok   no merge on a refusing re-read"
 fi
+
+# --- #280: on a bot-authored PR the author check can never be satisfied. The
+# --- refusal must say so and name the path that IS open, instead of asking the
+# --- operator to become renovate.
+echo "case 8: bot-authored PR + --self-reviewed — refused, and the refusal names the approve path"
+make_status_stub; make_gh; set_viewer_raw "a-human"
+PR_AUTHOR="renovate[bot]" AUTHOR_IS_BOT=true \
+  make_status_json status.1.json request-review bot-review-unsatisfiable false
+out=$(run --self-reviewed); rc=$?
+err=$(cat "$STUB_DIR/err")
+check "exit code" "2" "$rc"
+says "names the bot author"   "renovate[bot] is a bot"                     "$err"
+says "names the approve path" "gh pr review 559 --repo o/r --approve"      "$err"
+# The generic author-identity refusal is the one this case exists to replace:
+# it is true but unactionable here, and it was what sent a merge around the
+# script.
+says_not "not the generic identity refusal" "the attestation must come from the PR author" "$err"
+if grep -q '^pr comment$' "$STUB_DIR/calls.log"; then
+    echo "  FAIL an attestation was posted for a bot-authored PR"; fail=1
+else
+    echo "  ok   no comment was posted"
+fi
+# The flag is refused; the gate itself is not relaxed. Once a human has
+# approved, pr-status answers merge and the plain call goes through.
+echo "case 9: same PR after a human approval — the plain call merges"
+make_status_stub; make_gh; set_viewer_raw "a-human"
+PR_AUTHOR="renovate[bot]" AUTHOR_IS_BOT=true \
+  make_status_json status.1.json merge - false
+out=$(run); rc=$?
+check "exit code" "0" "$rc"
+says "merged" "559 merged (--merge)" "$out"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -66,6 +66,10 @@ STUB
 import sys, json, os
 out, bodies = sys.argv[1], sys.argv[2:]
 head = "deadbeefcafe"
+# PR_AUTHOR / AUTHOR_TYPE: the PR author as GraphQL reports it. AUTHOR_TYPE is
+# the authority for bot-ness (#280); the login is only the fallback.
+author = {"login": os.environ.get("PR_AUTHOR", "someone"),
+          "__typename": os.environ.get("AUTHOR_TYPE", "User")}
 # COMMENTS_JSON: issue comments on the PR, as [{"author": ..., "body": ...}] —
 # the surface the Self-review attestation (#203) is read from.
 comments = [{"author": {"login": c["author"]}, "body": c["body"],
@@ -95,7 +99,7 @@ json.dump({"data": {"repository": {
     "pullRequest": {
         "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
         "mergeable": "MERGEABLE", "mergeStateStatus": merge_state, "reviewDecision": review_decision,
-        "author": {"login": "someone"},
+        "author": author,
         "baseRefName": "main", "headRefName": "f", "headRefOid": head,
         "isCrossRepository": False,
         "comments": {"nodes": comments},
@@ -139,8 +143,10 @@ cat "$STUB_DIR/graphql.json"
 STUB
     chmod +x "$STUB_DIR/gh"
     python3 - "$STUB_DIR/graphql.json" "$@" <<'PY'
-import sys, json
+import sys, json, os
 out, specs = sys.argv[1], sys.argv[2:]
+author = {"login": os.environ.get("PR_AUTHOR", "someone"),
+          "__typename": os.environ.get("AUTHOR_TYPE", "User")}
 head = "deadbeefcafe"
 reviews = []
 approved = False
@@ -162,7 +168,7 @@ json.dump({"data": {"repository": {
         "number": 1, "title": "t", "state": "OPEN", "isDraft": False,
         "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
         "reviewDecision": ("APPROVED" if approved else None),
-        "author": {"login": "someone"},
+        "author": author,
         "baseRefName": "main", "headRefName": "f", "headRefOid": head,
         "isCrossRepository": False,
         "reviews": {"nodes": reviews},
@@ -833,6 +839,66 @@ echo "case SR11: CHANGES_REQUESTED + attestation + quota — a human NO is a liv
 COMMENTS_JSON="$SR_MARKER" REVIEW_DECISION=CHANGES_REQUESTED make_stub
 plant_marker
 check "next.action" "request-review" "$(run_next)"
+
+# --- #280: a bot-authored PR cannot use the attestation, so the advice must ---
+# --- name the path that is open to a human instead.                        ---
+APPROVE_CMD="gh pr review 1 --repo o/r --approve"
+SELF_REVIEW_ADVICE="post a PR comment (as the PR author)"
+
+echo "case B1: quota marker + renovate-authored PR — the why names the approve path"
+PR_AUTHOR="renovate[bot]" AUTHOR_TYPE=Bot make_stub
+plant_marker
+check "author_is_bot" "true"           "$(run_flag author_is_bot)"
+check "next.action"   "request-review" "$(run_next)"
+if status | jq -e --arg c "$APPROVE_CMD" '.next.why | index($c) != null' >/dev/null; then
+    echo "  ok   why names the approve command"
+else
+    echo "  FAIL why does not name the approve command"
+    fail=1
+fi
+# The attestation sentence is not merely redundant here, it is unfollowable:
+# nobody can authenticate as the bot, so leaving it in sends the operator at a
+# refusal pr-merge.sh will always answer.
+if status | jq -e --arg a "$SELF_REVIEW_ADVICE" '.next.why | index($a) != null' >/dev/null; then
+    echo "  FAIL why still advertises the attestation a bot author cannot make"
+    fail=1
+else
+    echo "  ok   the unusable attestation advice is gone"
+fi
+
+# The login is the fallback, not the authority: an App-backed author reaches
+# GraphQL as __typename Bot with an ordinary-looking login and no [bot] suffix.
+echo "case B2: __typename Bot with a plain login — still a bot author"
+PR_AUTHOR="some-app" AUTHOR_TYPE=Bot make_stub
+plant_marker
+check "author_is_bot" "true" "$(run_flag author_is_bot)"
+
+# ... and the authority can be absent: a REST-shaped author carries no
+# __typename at all, which is what the login patterns are kept for.
+echo "case B3: renovate login without __typename — the fallback still catches it"
+PR_AUTHOR="renovate[bot]" AUTHOR_TYPE="" make_stub
+plant_marker
+check "author_is_bot" "true" "$(run_flag author_is_bot)"
+
+echo "case B4: a human author is untouched — the attestation advice stays"
+make_stub
+plant_marker
+check "author_is_bot" "false" "$(run_flag author_is_bot)"
+if status | jq -e --arg a "$SELF_REVIEW_ADVICE" '.next.why | index($a) != null' >/dev/null; then
+    echo "  ok   the attestation advice survives for a human author"
+else
+    echo "  FAIL the attestation advice was dropped for a human author"
+    fail=1
+fi
+
+# The load-bearing half: the command the advice names must actually open the
+# gate. Without this the fix would be a message pointing at a second dead end.
+echo "case B5: bot author + human APPROVED on the head — the gate opens"
+PR_AUTHOR="renovate[bot]" AUTHOR_TYPE=Bot make_stub_reviews "a-human|APPROVED|reviewed the diff, LGTM"
+plant_marker
+check "author_is_bot"      "true"  "$(run_flag author_is_bot)"
+check "has_review_on_head" "true"  "$(run_flag has_review_on_head)"
+check "next.action"        "merge" "$(run_next)"
 
 if [ "$fail" -eq 0 ]; then
     echo "all pass"

--- a/tests/test_pr_status_errored_review.sh
+++ b/tests/test_pr_status_errored_review.sh
@@ -880,6 +880,28 @@ PR_AUTHOR="renovate[bot]" AUTHOR_TYPE="" make_stub
 plant_marker
 check "author_is_bot" "true" "$(run_flag author_is_bot)"
 
+# The REST-shaped form `gh pr view --json author` answers for the very same
+# account — measured on netresearch/github-release-skill#110, which GraphQL
+# reports as login `renovate` with __typename Bot.
+echo "case B3b: the app/ prefix — the other login form of the same account"
+PR_AUTHOR="app/renovate" AUTHOR_TYPE="" make_stub
+plant_marker
+check "author_is_bot" "true" "$(run_flag author_is_bot)"
+
+# The fallback must not reach past the bot logins it names: a person called
+# renovate-maintainer would otherwise be refused --self-reviewed on their own
+# pull request and handed advice written for a bot.
+echo "case B3c: a human login merely starting with a bot name — not a bot"
+PR_AUTHOR="renovate-maintainer" AUTHOR_TYPE="" make_stub
+plant_marker
+check "author_is_bot" "false" "$(run_flag author_is_bot)"
+if status | jq -e --arg a "$SELF_REVIEW_ADVICE" '.next.why | index($a) != null' >/dev/null; then
+    echo "  ok   the attestation stays available to them"
+else
+    echo "  FAIL a human was handed the bot-only advice"
+    fail=1
+fi
+
 echo "case B4: a human author is untouched — the attestation advice stays"
 make_stub
 plant_marker


### PR DESCRIPTION
Closes #280.

A Renovate or Dependabot pull request that a repository deliberately routes to a human had no sanctioned command. `pr-merge.sh` refuses without a review on the head; `--self-reviewed` refuses because the attestation must come from the PR author, and a bot never authenticates and never reads a diff. Both refusals are correct in isolation, and together they left nothing to run — netresearch/github-release-skill#110 was merged with a bare `gh pr merge`, around the script that exists to be the safe path.

## What the issue got wrong

The issue weighed three options, two of which would have relaxed the gate. Neither is needed, and one of them cannot work: `pr-status.sh` filters attestation comments with `select(.author.login == $author)`, so relaxing only the writer would post a comment the reader discards. Reading the ladder to the end shows why nothing has to move — a human `APPROVED` review on the current head already satisfies the never-merge-unreviewed policy. With the `copilot_code_review` ruleset the branch at `pr-status.sh:860` requires `$no_current_approval`; an approval on the head makes it false, the generic branch below sees `has_review_on_head`, and `NEXT` is `merge`. The suite has proved this since #214 (case 20), for a PR whose Copilot review was never requested and whose quota wall was known only from the month marker.

So the gap was never a missing capability. It was advice that named the one path the case cannot take and stayed silent about the one it can.

## The change

`pr-status.sh` fetches the PR author's `__typename`, reports `author_is_bot`, and in the quota advice swaps the attestation sentence for the command that works: `gh pr review PR --repo owner/repo --approve`. `__typename` is the authority; the login fallback carries the forms it can be absent for, each anchored — measured on netresearch/github-release-skill#110, one account reaches callers as `renovate` (GraphQL), `app/renovate` (`gh pr view --json author`) and `renovate[bot]` (webhook payload).

`pr-merge.sh --self-reviewed` refuses a bot-authored pull request by name and points at that command, instead of the author-identity message that is true and unactionable here.

Nothing about the gate is relaxed. A third party still cannot mint an attestation for someone else's pull request, a `COMMENTED` review still does not count, and what opens the gate is a real review on the record rather than a flag.

## Tests

Seven cases in `test_pr_status_errored_review.sh` and two in `test_pr_merge_self_reviewed.sh`. Both files were run against `origin/main`'s revision of their subject with the new cases in place: 9 assertions fail on the old `pr-status.sh`, 3 on the old `pr-merge.sh`, and no pre-existing case moved. Case B5 is the load-bearing one — it asserts that the command the advice names actually opens the gate, so the fix cannot become a message pointing at a second dead end; B3b and B3c pin the login fallback from both sides, an App-shaped bot login that must be caught and a human login starting with a bot name that must not be. All 17 shell suites, the Python suite, and `pre-commit` (markdownlint, shellcheck, ruff) pass.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5)_
