### PR TITLE
docs(pull-request-workflow): stop reading an empty requested_reviewers as the quota tell

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -183,14 +183,21 @@ reset rather than being aged out; delete the file to undo a verdict recorded in
 error.
 
 The quota wall has a second, earlier face: the `requested_reviewers` POST
-itself can be **silently dropped** — HTTP 200, but the response's
-`requested_reviewers` array is empty and a read-back seconds later still shows
-no pending request, with no errored review anywhere yet. That empty read-back
-right after the POST is the earliest quota tell there is; it looks like "the
-bot will pick it up asynchronously" and is not (five requests across four repos
-were swallowed this way on 2026-08-18 before a later errored review named the
-quota). Read `requested_reviewers` back after the **first** request of a
-session; empty means stop requesting — everywhere — and go straight to the
+itself can be **silently dropped** — HTTP 200, but no pending request appears
+and no errored review follows either (five requests across four repos were
+swallowed this way on 2026-08-18 before a later errored review named the
+quota).
+
+An empty `requested_reviewers` does **not** establish that, and reading it as
+the quota tell states a swallowed request where there was none. The array has
+three producers and cannot tell them apart: the response body never echoes a
+**bot** reviewer at all, a reviewer that has **started** drops off the list
+without having submitted, and only the third case is a genuinely dropped POST.
+Confirm off the **timeline** or the reviews list instead, as
+`merge-gate-watcher.md` § *"What still works while GraphQL is drained"*
+prescribes — an errored Copilot row on the head is the same wall, said out
+loud, and `pr-status.sh` reports it as `copilot_quota_hit`. Once the wall is
+established by either route, stop requesting everywhere and go to the
 self-review path above.
 
 ### Putting the self-review on the record (#203)
@@ -254,6 +261,16 @@ review on the record rather than a flag. This is the case `deps-no-automerge`
 and `deps-major` route to a human by design — `netresearch/.github`'s
 `auto-merge-deps.yml` excludes both labels, and its own documentation says
 majors are approved but left for a human to merge.
+
+**One bot account reaches you under three logins**, so any check written
+against a hardcoded name is wrong for two of them. Measured on
+`netresearch/github-release-skill#110`, all three naming the same Renovate
+install: GraphQL answers `renovate` with `__typename: Bot`, `gh pr view --json
+author` answers `app/renovate` with `is_bot: true`, and the webhook payload
+(what `auto-merge-deps.yml` matches on) answers `renovate[bot]`. `__typename`
+is the only authority — prefer it, and anchor every login pattern you fall back
+to, or `renovate-maintainer` reads as a bot and that person is refused
+`--self-reviewed` on their own pull request.
 
 ### Before believing a script cannot do something: ask which copy is running
 


### PR DESCRIPTION
Two references in this skill gave opposite readings of the same measurement, and following the wrong one produced a false statement in a live session.

`references/merge-gate-watcher.md` says to confirm a review request off the timeline, "not off `requested_reviewers`: the response body does not echo a bot reviewer, and a reviewer that has started drops off that list without having submitted". `references/pull-request-workflow.md` said the opposite — that an empty read-back right after the POST "is the earliest quota tell there is", and that empty means stop requesting everywhere.

## What it cost

Requesting a Copilot review on netresearch/git-workflow-skill#281, the read-back came back empty. Following the second instruction I reported the request as swallowed by the quota. It had not been: `pr-status.sh` showed a minute later that Copilot had answered on that very pull request, with an error body naming the quota limit — `copilot_quota_hit` was true off the review row, not off the empty array.

## The edit

The observation from 2026-08-18 stays — a POST really can be dropped, and that is a genuine early face of the wall. The instruction derived from it does not, because the array has three producers and cannot tell them apart: a bot reviewer is never echoed at all, a reviewer that has started has already left the list, and only the third case is a dropped request. The paragraph now says that and points at the timeline check the other reference already prescribes. No third instruction is added on top of the two; the stale side is superseded.

## Also recorded

One bot account reaches callers under three logins, all naming the same Renovate install and measured on netresearch/github-release-skill#110: GraphQL answers `renovate` with `__typename: Bot`, `gh pr view --json author` answers `app/renovate`, and the webhook payload — what `auto-merge-deps.yml` matches on — answers `renovate[bot]`. A check against any one hardcoded name is wrong for the other two. This lived only in a code comment in `pr-status.sh` after #281; anyone writing a bot check elsewhere would re-derive it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5)_
