### PR TITLE
docs(advanced-git): a pipefail fallback can contradict its own output

### DIFF
--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1301,6 +1301,36 @@ grep -E 'OK|FAILURES' out.txt          # read it, but don't gate on it
 (`set -o pipefail` does the same in bash, zsh and ksh, but it is not in POSIX
 `sh` — a script with `#!/bin/sh` under dash will fail on it.)
 
+#### `pipefail` makes `… | grep … || echo "not found"` lie
+
+The `||` fallback beside a pipeline reads as "the grep found nothing". Under
+`pipefail` it also fires when the grep *matched* and the command feeding it
+failed, because the pipeline then carries the writer's status:
+
+```bash
+bash -c '(echo MATCH; exit 1) | grep -q MATCH; echo $?'                  # 0 — grep's
+bash -c 'set -o pipefail; (echo MATCH; exit 1) | grep -q MATCH; echo $?'  # 1 — the writer's
+```
+
+The result is a message contradicting the output directly above it — a verifier
+printing its findings and then "nothing found", or a guard visibly firing under
+the line `GUARD DID NOT FIRE`. Both were observed within one session, and the
+false line was believed once.
+
+Since `set -o pipefail` belongs at the top of every multi-step block, the
+fallback is the part to change, not the option. Test the exit code you actually
+mean:
+
+```bash
+set -o pipefail
+out=$(producer) || { echo "producer failed"; exit 1; }   # writer, on its own
+printf '%s\n' "$out" | grep -q PATTERN || echo "pattern absent"
+```
+
+Failing that, put the fallback on the grep alone (`{ grep -q P || echo absent; }`)
+so a broken producer surfaces as a failure rather than as a finding about the
+data.
+
 Afterwards verify what actually landed, on the remote rather than locally.
 Match one unique line from the change — `grep -c` counts matching *lines*, so a
 multi-line pattern will not match at all; `-F` avoids regex surprises in code:

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1317,18 +1317,44 @@ printing its findings and then "nothing found", or a guard visibly firing under
 the line `GUARD DID NOT FIRE`. Both were observed within one session, and the
 false line was believed once.
 
+**The writer does not have to be broken.** `grep -q` exits at the first match,
+which closes the pipe; a writer still pushing data then dies of SIGPIPE and the
+pipeline carries *its* status. So the fallback fires on a match — the more input
+there is, the more reliably:
+
+```bash
+set -o pipefail
+out=$(awk 'BEGIN { for (i = 1; i <= 100000; i++) print "MATCH" }')
+printf '%s\n' "$out" | grep -q MATCH || echo "pattern absent"   # prints it
+```
+
+This is what makes the trap durable: the same line passes on a one-line
+fixture and fails on real data, so a test written alongside it agrees with the
+bug.
+
 Since `set -o pipefail` belongs at the top of every multi-step block, the
-fallback is the part to change, not the option. Test the exit code you actually
-mean:
+fallback is the part to change, not the option. Remove the pipe where the input
+is already in hand — a here-string cannot SIGPIPE and has no pipeline status:
 
 ```bash
 set -o pipefail
 out=$(producer) || { echo "producer failed"; exit 1; }   # writer, on its own
-printf '%s\n' "$out" | grep -q PATTERN || echo "pattern absent"
+grep -q PATTERN <<< "$out" || echo "pattern absent"      # reader, on its own
 ```
 
-Failing that, put the fallback on the grep alone (`{ grep -q P || echo absent; }`)
-so a broken producer surfaces as a failure rather than as a finding about the
+Where the producer must stream, read the grep's own status out of
+`PIPESTATUS` — `$?` after a pipeline is the *pipeline's* status, so under
+`pipefail` it is 141 (SIGPIPE) on exactly the match this is meant to detect:
+
+```bash
+set -o pipefail
+producer | grep -q PATTERN
+found=${PIPESTATUS[1]}          # 0 matched, 1 absent — $? here would be 141
+[ "$found" -eq 0 ] || echo "pattern absent"
+```
+
+That also keeps a broken producer visible: `${PIPESTATUS[0]}` is its status, and
+it is worth checking separately rather than folding into one verdict about the
 data.
 
 Afterwards verify what actually landed, on the remote rather than locally.


### PR DESCRIPTION
From a `/retro`. The `||` fallback beside a pipeline reads as "the grep found nothing". Under `pipefail` it also fires when the grep **matched** and the command feeding it failed, because the pipeline then carries the writer's status rather than the grep's.

Measured, not reasoned:

```bash
bash -c '(echo MATCH; exit 1) | grep -q MATCH; echo $?'                   # 0 — grep's
bash -c 'set -o pipefail; (echo MATCH; exit 1) | grep -q MATCH; echo $?'  # 1 — the writer's
```

## Why it is worth a paragraph

The failure mode is not a wrong exit code, it is a **message that contradicts the output directly above it**: a verifier that prints its findings and then "nothing found", or a guard visibly firing beneath the line `GUARD DID NOT FIRE`. Both occurred in one session here, and the false line was believed once before the exit codes were checked. A contradiction in one's own output is easy to read past when the fallback text sounds like a conclusion.

It sits beside the existing `pipefail` note in `advanced-git.md`, which is where a reader meets the option, and next to the verification recipes where this shape actually gets typed.

## What it recommends

Changing the **fallback**, not the option — `set -o pipefail` belongs at the top of every multi-step block, so removing it is the wrong lesson. Capture the producer separately so its failure is a failure, or scope the `||` to the grep alone.

## Scope

Docs only, one file, one new subsection. No script, recipe or existing wording is altered. `markdownlint-cli2` clean; the repo's test suite passes.

## Round 2 — the prescribed fix had the bug it was warning about

CodeRabbit caught the section reproducing its own trap by a second route, and it was right. `grep -q` exits at the first match and closes the pipe; a writer still pushing data dies of SIGPIPE, and under `pipefail` the pipeline carries that status:

```bash
out=$(awk 'BEGIN { for (i = 1; i <= 100000; i++) print "MATCH" }')
printf '%s\n' "$out" | grep -q MATCH || echo "pattern absent"   # prints it
```

**Why it survived being written and checked:** the identical line passes on a one-line fixture, and my verification used a small input — the control never reached the failure mode. A test written alongside such an example agrees with the bug. That is now stated in the section, because it is the property that makes this trap durable rather than a curiosity.

The recommendation is now a here-string where the input is already in hand: no pipe, so neither SIGPIPE nor a pipeline status.

**A second error of mine, found while verifying the first fix.** The streaming variant advised `rc=$?` to capture the grep's status. After a pipeline that is the *pipeline's* status — measured as **141** on exactly the match it was meant to detect. Replaced with `${PIPESTATUS[1]}` (0 matched, 1 absent), with `${PIPESTATUS[0]}` keeping a broken producer visible instead of folded into one verdict about the data.

Every recipe in the section was then run verbatim, in both the match and the absent direction.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_

