### PR TITLE
docs(ci): gh run list takes no --arg, and a failed query is not an unmet condition

### DIFF
--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -238,10 +238,26 @@ gh run list --repo "$R" --commit "$SHA" --json name,status,conclusion \
 
 `--commit` (`-c`) is the supported way to scope runs to one SHA, and it is what
 the merge-triggered runs on the base branch need after a merge — `--branch main`
-alone also matches the runs of every earlier merge. The general rule behind it:
-**a polling loop must distinguish "the query failed" from "the condition is not
-met yet"**. Assert the query's exit status, or count a field you know is
-present, before comparing the value.
+alone also matches the runs of every earlier merge.
+
+The general rule behind it: **a polling loop must distinguish "the query failed"
+from "the condition is not met yet"**, and it has to *act* on the difference.
+Counting instead of testing emptiness is not enough on its own — a failed query
+still yields the empty string, and `[ "$pending" = "0" ]` reads that as "not met"
+and keeps polling. Gate on the exit status, or refuse a value that is not a
+number:
+
+```bash
+if ! out=$(gh run list --repo "$R" --commit "$SHA" --json status 2>&1); then
+  echo "query failed: $out" >&2; exit 1
+fi
+pending=$(printf '%s' "$out" | jq '[.[] | select(.status != "completed")] | length')
+case $pending in ''|*[!0-9]*) echo "unusable count: ${pending@Q}" >&2; exit 1 ;; esac
+[ "$pending" -eq 0 ] && break
+```
+
+A loop that cannot fail loudly waits out its whole timeout and then reports on a
+condition it never evaluated.
 
 ## Before you add or edit a workflow file: read the repo's Actions policy
 

--- a/skills/git-workflow/references/ci-cd-integration.md
+++ b/skills/git-workflow/references/ci-cd-integration.md
@@ -222,6 +222,27 @@ branch. On a repo with the `copilot_code_review` ruleset, `NEXT:` says
 state now rides along in that answer's `why`, but a script should read the
 field.
 
+**`gh run list --jq` is not `jq`: it takes no `--arg`.** The filter is evaluated
+by `gh`'s embedded jq, which accepts the expression and nothing else, so
+`--jq --arg s "$SHA" '… select(.headSha==$s) …'` exits with
+`unknown command "s" for "gh run list"`. Inside a poll loop that failure is
+silent in the worst way: `pending=$(gh run list … )` captures the empty output,
+the `[ "$pending" = "0" ]` test is false forever, and the loop reports "still
+running" until its timeout — describing a condition it never actually
+evaluated. Filter with the flag instead of a jq variable:
+
+```bash
+gh run list --repo "$R" --commit "$SHA" --json name,status,conclusion \
+  --jq '.[] | "\(.status) \(.conclusion // "-") \(.name)"'
+```
+
+`--commit` (`-c`) is the supported way to scope runs to one SHA, and it is what
+the merge-triggered runs on the base branch need after a merge — `--branch main`
+alone also matches the runs of every earlier merge. The general rule behind it:
+**a polling loop must distinguish "the query failed" from "the condition is not
+met yet"**. Assert the query's exit status, or count a field you know is
+present, before comparing the value.
+
 ## Before you add or edit a workflow file: read the repo's Actions policy
 
 A workflow that violates the repository's Actions policy fails at **`Set up job`**


### PR DESCRIPTION
Merging this documents a `gh` flag trap that turns a hand-rolled CI poll loop into a silent no-op, and names the supported way to scope runs to one commit.

`gh run list --jq` is gh's embedded jq and takes the expression only. Passing jq's own `--arg` exits with `unknown command "s" for "gh run list"`, which inside a loop means the command substitution captures nothing, the comparison against `"0"` is false forever, and the loop reports "still running" until its timeout — describing a condition it never evaluated. That is how it was found on 2026-09-10, waiting on merge-triggered runs: the loop would have burned its full hour without querying anything.

The supported form is `--commit` (`-c`), and it is what merge-triggered runs on the base branch need — `--branch main` alone also matches every earlier merge's runs.

Both halves were verified against a live repository before writing them down: the documented form returns the eight runs of the named commit, and the wrong form returns the quoted error verbatim.

Placed directly after the existing paragraph on hand-rolled poll loops, which already argues that a zero-pending snapshot cannot tell "before runs start" from "after they finish". This is the same class one step earlier — the query itself failing — so the paragraph ends by stating it: a polling loop must distinguish "the query failed" from "the condition is not met yet".

**Bounded to** `references/ci-cd-integration.md`. `merge-gate-watcher.md` and `pull-request-workflow.md` are untouched; the latter already shows `gh run list --commit` correctly, and this adds why the variable form a script author reaches for instead does not work.

`scripts/verify-harness.sh` reports Level 3 COMPLETE, 0 errors, 0 warnings. Pre-commit hooks pass.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_019jovJfNacqEn1YFb4wGhD4)_
