### PR TITLE
docs(references): shallow fetches, trailer parsing, and "is this merged"

### DIFF
--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -962,6 +962,10 @@
       {
         "type": "content",
         "pattern": "(GIT_DEPTH: ?0|fetch-depth: ?0|is-shallow-repository)"
+      },
+      {
+        "type": "content",
+        "pattern": "(no --depth|order|later fetch|again)"
       }
     ]
   },
@@ -980,6 +984,10 @@
       {
         "type": "content",
         "pattern": "(rebase|new (objects|SHAs|commits)|rewritten)"
+      },
+      {
+        "type": "content",
+        "pattern": "(whitespace|patch.?id normalis|git diff --quiet|tree comparison)"
       }
     ]
   },
@@ -998,6 +1006,10 @@
       {
         "type": "content",
         "pattern": "(code (block|fence)|regex|squash)"
+      },
+      {
+        "type": "content",
+        "pattern": "(divider line|line beginning with)"
       }
     ]
   }

--- a/skills/git-workflow/evals/evals.json
+++ b/skills/git-workflow/evals/evals.json
@@ -946,5 +946,59 @@
         "pattern": "(conflict marker|<<<<<<<|gate|pre-commit)"
       }
     ]
+  },
+  {
+    "name": "shallow_fetch_truncates_repository",
+    "prompt": "A CI job fetches other branch heads with `git fetch --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'` and then a later step checks whether a commit is an ancestor of main. The check passes but appears to verify nothing. Why?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(shallow|\\.git/shallow|truncat)"
+      },
+      {
+        "type": "content",
+        "pattern": "(whole repository|entire repository|not (just|only) the refs|all ancestry)"
+      },
+      {
+        "type": "content",
+        "pattern": "(GIT_DEPTH: ?0|fetch-depth: ?0|is-shallow-repository)"
+      }
+    ]
+  },
+  {
+    "name": "is_branch_merged_under_rebase_merge",
+    "prompt": "On a GitLab project with merge_method rebase_merge, `git merge-base --is-ancestor my-branch origin/main` says no, but the branch's changes are clearly in main. How do I decide whether the branch can be deleted?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "git cherry"
+      },
+      {
+        "type": "content",
+        "pattern": "(patch.?id|patch ID)"
+      },
+      {
+        "type": "content",
+        "pattern": "(rebase|new (objects|SHAs|commits)|rewritten)"
+      }
+    ]
+  },
+  {
+    "name": "read_commit_trailers_safely",
+    "prompt": "I want a CI check to honour an opt-in written as a git trailer in the commit message. How should the check read that trailer?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "git interpret-trailers"
+      },
+      {
+        "type": "content",
+        "pattern": "--no-divider"
+      },
+      {
+        "type": "content",
+        "pattern": "(code (block|fence)|regex|squash)"
+      }
+    ]
   }
 ]

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -1,5 +1,41 @@
 # Advanced Git Operations
 
+## Shallow Fetches
+
+### `--depth=1` truncates the WHOLE repository, not the refs you asked for
+
+`git fetch --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'` looks like it
+scopes to the refs in its refspec. It does not. It writes `.git/shallow` and
+every ancestry query in that checkout answers from a one-commit graft
+afterwards.
+
+```bash
+git clone --no-local file://$REPO probe && cd probe
+git rev-list --count HEAD          # 366
+git fetch --quiet --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'
+git rev-parse --is-shallow-repository   # true
+git rev-list --count HEAD          # 1
+```
+
+Why it matters more than it looks: a shallow repository does not merely lack
+objects, it **truncates ancestry**, so `git merge-base --is-ancestor X main`
+answers "no" for a commit that genuinely is on `main`. Anything built on that
+answer — a guard, a changelog generator, a release check — goes quietly wrong
+rather than failing.
+
+The usual shape is a CI job that fetches other branch heads cheaply, two lines
+above the command that needs history. Both look innocent; only the pair is
+wrong. If a job needs ancestry, it needs the history:
+
+- GitLab: `GIT_DEPTH: 0` on that job, and no `--depth` in any fetch the script
+  runs. `git fetch --unshallow` does **not** rescue it when the runner's own
+  refspec is a single ref.
+- GitHub Actions: `actions/checkout` with `fetch-depth: 0`.
+
+A tool that depends on ancestry should say which state it is in rather than
+answer from a truncated graph — `git rev-parse --is-shallow-repository` is one
+call, and "I could not check" is a different answer from "this is fine".
+
 ## Rewriting History
 
 ### After ANY reset-based rebuild: the commit takes the INDEX, not the worktree
@@ -58,6 +94,15 @@ git show <tip>                        # the real change this branch introduces
 git cherry -v <base> <branch>         # '+' = unique to branch, '-' = already in base
                                       #   (patch-id match; plain `log <base>..<branch>`
                                       #   still lists absorbed commits under new SHAs)
+
+# Same command answers a second question, and it is the one that bites at
+# cleanup time: "is this branch merged?" On a project that merges by REBASE
+# (GitLab `rebase_merge`, GitHub "Rebase and merge"), the commits that land are
+# new objects, so `merge-base --is-ancestor <branch> main` says NO for a branch
+# whose content is entirely in main. Deleting on that answer feels unsafe;
+# keeping on it leaves dead branches forever. `git cherry` compares patch-ids
+# and gives the content answer:
+git cherry origin/main <branch> | grep -c '^+'   # 0 = nothing outstanding, safe to delete
 git merge-base <base> <branch>        # confirm how far back it forks
 
 # Replay ONLY the commits after <keep-base> onto the current base, dropping the

--- a/skills/git-workflow/references/advanced-git.md
+++ b/skills/git-workflow/references/advanced-git.md
@@ -27,10 +27,15 @@ The usual shape is a CI job that fetches other branch heads cheaply, two lines
 above the command that needs history. Both look innocent; only the pair is
 wrong. If a job needs ancestry, it needs the history:
 
-- GitLab: `GIT_DEPTH: 0` on that job, and no `--depth` in any fetch the script
-  runs. `git fetch --unshallow` does **not** rescue it when the runner's own
-  refspec is a single ref.
-- GitHub Actions: `actions/checkout` with `fetch-depth: 0`.
+- GitLab: `GIT_DEPTH: 0` on that job, **and no `--depth` in any fetch the script
+  runs**. The second half is the one that gets missed: a job can start with full
+  history and lose it to a `--depth=1` line of its own three commands later.
+- GitHub Actions: `actions/checkout` with `fetch-depth: 0`, same caveat.
+
+`git fetch --unshallow` does recover a shallow checkout — with or without a ref
+argument, and even where the remote's configured refspec is a single ref
+(measured both ways). It is not a defence against the above, because a later
+`--depth` fetch simply makes the repository shallow again; order decides.
 
 A tool that depends on ancestry should say which state it is in rather than
 answer from a truncated graph — `git rev-parse --is-shallow-repository` is one
@@ -102,7 +107,13 @@ git cherry -v <base> <branch>         # '+' = unique to branch, '-' = already in
 # whose content is entirely in main. Deleting on that answer feels unsafe;
 # keeping on it leaves dead branches forever. `git cherry` compares patch-ids
 # and gives the content answer:
-git cherry origin/main <branch> | grep -c '^+'   # 0 = nothing outstanding, safe to delete
+git cherry origin/main <branch> | grep -c '^+'   # 0 = no commit carries a patch main lacks
+
+# `git cherry` compares patch-ids, and patch-id NORMALISES WHITESPACE. Two
+# commits that differ only in indentation have the same patch-id, so a branch
+# whose sole change is a reformat reports 0 outstanding while its tree really
+# does differ. Confirm with a tree comparison before deleting anything:
+git diff --quiet origin/main...<branch> || echo "trees differ — do NOT delete on cherry alone"
 git merge-base <base> <branch>        # confirm how far back it forks
 
 # Replay ONLY the commits after <keep-base> onto the current base, dropping the

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -141,6 +141,44 @@ Markdown files**, follow the repo's existing convention: many hard-wrap prose
 docs for readable diffs, so match the surrounding files rather than mixing two
 styles in one tree.
 
+## Reading Trailers Back: `git interpret-trailers`, Never a Regex
+
+Anything that makes a decision from a commit trailer — a release note generator,
+an audit, a CI gate honouring an opt-in — must ask git what a trailer is. A
+`^Name:` regex over `%B` matches text that is not a trailer at all:
+
+```bash
+git log --format='%B' -1 | git interpret-trailers --parse --no-divider
+```
+
+Three ways the regex is wrong, all reproduced rather than imagined:
+
+- **Inside a fenced code block.** A commit documenting the trailer format, whose
+  prose says "this is only an example", hands out a real one.
+- **In the quoted body of a `Revert "..."`** that a person pasted in. (A real
+  `git revert` does not carry the reverted commit's trailers forward — that path
+  is safe. A hand-written message is not.)
+- **Case.** With `re.I`, `allow-policy-narrowing:` works where the documentation
+  says `Allow-Policy-Narrowing:`. git looks trailers up case-insensitively, but
+  an opt-in should be written the way it is documented — match the name as
+  written.
+
+`--no-divider` is not optional for this: without it `---` anywhere in the body
+ends the parse, so a markdown rule or a pasted diffstat silently drops a
+trailer that is really there. Failing closed is right; failing closed *silently*
+sends the author to debug the wrong thing.
+
+Two properties worth knowing before designing around trailers:
+
+- What counts as the trailer block is a **heuristic**. A prose line directly
+  above can put a trailer outside it; a `Signed-off-by` footer usually keeps it
+  in. Check with the command above rather than by eye.
+- A **squash merge does not carry them**. GitHub and GitLab both build the
+  squash message from the pull/merge request, not from the source commits, so
+  any mechanism that reads a trailer on the target branch breaks the moment
+  someone squashes. If the mechanism matters, turn squash off for the project
+  (`squash_option: never` on GitLab) rather than documenting the hazard.
+
 ## Signed Commits + DCO Sign-Off (Required)
 
 Run every commit with both flags explicit:

--- a/skills/git-workflow/references/commit-conventions.md
+++ b/skills/git-workflow/references/commit-conventions.md
@@ -163,21 +163,28 @@ Three ways the regex is wrong, all reproduced rather than imagined:
   an opt-in should be written the way it is documented — match the name as
   written.
 
-`--no-divider` is not optional for this: without it `---` anywhere in the body
-ends the parse, so a markdown rule or a pasted diffstat silently drops a
-trailer that is really there. Failing closed is right; failing closed *silently*
-sends the author to debug the wrong thing.
+`--no-divider` is not optional for this. Without it a **divider line** ends the
+parse and every trailer after it disappears — that is a line beginning with
+`---` followed by a space or the end of the line, so a markdown rule or the
+`---` git itself puts above a diffstat both count. Measured: `--- a note` and a
+bare `---` both swallow the trailer; `----` and a `---` in the middle of a line
+do not. A pasted patch or a rule in the body therefore drops a trailer that is
+really there. Failing closed is right; failing closed *silently* sends the
+author to debug the wrong thing.
 
 Two properties worth knowing before designing around trailers:
 
 - What counts as the trailer block is a **heuristic**. A prose line directly
   above can put a trailer outside it; a `Signed-off-by` footer usually keeps it
   in. Check with the command above rather than by eye.
-- A **squash merge does not carry them**. GitHub and GitLab both build the
-  squash message from the pull/merge request, not from the source commits, so
-  any mechanism that reads a trailer on the target branch breaks the moment
-  someone squashes. If the mechanism matters, turn squash off for the project
-  (`squash_option: never` on GitLab) rather than documenting the hazard.
+- A **squash merge does not reliably preserve them**. Both forges compose that
+  message from the pull/merge request rather than by aggregating the source
+  commits' trailers; GitLab can inject some metadata through
+  `squash_commit_template`, but neither platform guarantees that a particular
+  source trailer survives. So a mechanism that reads a trailer on the target
+  branch cannot depend on one being there after a squash. If the mechanism
+  matters, turn squash off for the project (`squash_option: never` on GitLab)
+  rather than documenting the hazard.
 
 ## Signed Commits + DCO Sign-Off (Required)
 


### PR DESCRIPTION
Three facts a session had to dig out, none of them in the skill. All three are measured rather than recalled.

## `git fetch --depth=1` truncates the whole repository

It is not scoped to the refspec it is given. It writes `.git/shallow`, and every ancestry query in that checkout answers from a one-commit graft afterwards:

```
git rev-list --count HEAD                                          # 366
git fetch --quiet --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'
git rev-list --count HEAD                                          # 1
```

The damage is not the missing objects, it is the truncated **ancestry**: `merge-base --is-ancestor` answers "no" for a commit that genuinely is on the target branch, so anything built on that answer goes quietly wrong rather than failing. The shape that produced it was a CI job fetching other branch heads cheaply, two lines above the step that needed history — both look innocent, only the pair is wrong, and two pipelines were green while the check they ran verified nothing.

Worth noting: this repository already uses `--depth=1` in `checkpoints.yaml` without saying any of this.

## Reading a trailer back needs `git interpret-trailers`, not a regex

A `^Name:` match over `%B` is exploitable rather than merely sloppy. Reproduced, each one granting a real opt-in:

- a trailer inside a fenced code block, in a commit whose prose said it was only an example
- the same inside the quoted body of a hand-written `Revert "..."` (a real `git revert` carries no trailers forward — that path is safe)
- a case variant, under `re.I`

`--no-divider` is load-bearing: without it a `---` anywhere in the body ends the parse, so a markdown rule or a pasted diffstat drops a trailer that is really there — failing closed, but silently, which sends the author to debug the wrong thing.

Two properties are documented alongside, because they decide whether a trailer-based mechanism is viable at all: what counts as the trailer block is a heuristic, and a **squash merge does not carry trailers**, since both forges build that message from the pull/merge request rather than from the commits.

## `git cherry` answers "is this branch merged" where `--is-ancestor` cannot

Already documented for the `--onto` case; the second question is the one that bites at cleanup time. On a project that merges by rebase, the commits that land are new objects, so `merge-base --is-ancestor <branch> main` says no for a branch whose content is entirely in main. Deleting on that answer feels unsafe; keeping on it leaves dead branches forever.

Four of ten branches looked unmerged that way. `git cherry origin/main <branch>` reported zero outstanding commits for every one.

## Scope

Three `references/` files, no `SKILL.md` change — the body is under a hard 500-word budget and these are reference-level facts. Three eval stubs, one per fact. No version bump (release flow owns that).

`pre-commit run` clean on all changed files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01P3aU8JfhTKxAbX4hiaEmPz)_
