### PR TITLE
chore(release): v1.32.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.31.2"
+  version: "1.32.0"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
Version bump to 1.32.0 (minor). Changes since v1.31.2:

- docs: complete the marketplace setup steps
- docs: correct the skills-directory install instructions
- fix(hooks): a heredoc body is text, so the named-directory gate stops denying it
- fix(hooks): parse heredocs by shell rules, not by two flat regexes
- docs(commit-conventions): a fix that removes behaviour is at least MINOR
- feat(pr-merge): name the review path a bot-authored PR does have
- fix(pr-status): anchor every alternative of the bot-login fallback
- docs(pull-request-workflow): stop reading an empty requested_reviewers as the quota tell
- docs(pr-workflow): CodeRabbit declines out loud and does not catch up
- docs(pr-workflow): a clean CodeRabbit review leaves no review object
- docs(pr-workflow): link the two empty-array traps
- docs(pr-workflow): read CodeRabbit by commit range, not by phrase
- docs(pr-workflow): the review limit is not a free-tier-only concern
- chore(dependabot): remove the Dependabot configuration
- docs(advanced-git): pipefail makes a `|| echo "not found"` fallback lie
- docs(advanced-git): the recommended form had the bug it was warning about
- docs(ci): gh run list takes no --arg, and a failed query is not an unmet condition
- docs(ci): counting is not enough — the loop has to act on a failed query

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5