### PR TITLE
docs(pull-request-workflow): a third cause of "stale info" — the branch is gone

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1734,12 +1734,14 @@ The tell is in the fetch, not the push, and it is easy to miss because the fetch
 
 ```bash
 git fetch origin "$BR:refs/remotes/origin/$BR"
-# fatal: couldn't find remote ref release/v1.8.2
-git push --force-with-lease="$BR:$(git rev-parse origin/"$BR")"
-# ! [rejected]  (stale info)     ← same message, different world
+# fatal: couldn't find remote ref release/v1.8.2   ← the answer is HERE
+git push --force-with-lease
+# ! [rejected]  (stale info)                       ← same message, different world
 ```
 
-So when a lease refresh does not fix `stale info`, read the fetch's own output before pinning the lease harder, and check the PR rather than the ref: `gh pr view <n> --json state,mergedAt`. If it says `MERGED`, the amend is no longer available — the commit is on the default branch, and rewriting shared history to improve a commit message is worse than the message. Observed on a fleet release sweep where four bump PRs auto-merged between the commit and the amend; two rounds went into the lease before the `couldn't find remote ref` line was read.
+The local `origin/<branch>` usually still exists — your own earlier push created it — so the tracking ref looks healthy and only the fetch knows the truth. Do not pin the lease to it as a workaround: `--force-with-lease="$BR:$(git rev-parse origin/"$BR")"` is the documented remedy for the *first* cause, and here `git rev-parse` may fail outright, leaving the substitution empty and the expectation meaningless.
+
+So when a lease refresh does not fix `stale info`, read the fetch's own output before pinning the lease harder, and check the PR rather than the ref: `gh pr view <n> --json state,mergedAt`. If it says `MERGED`, the PR's changes are on its base branch — under squash or rebase merges as new commits, so the original head SHA need not be there at all — and a local `git commit --amend` cannot change the merged result. Do not recreate or rewrite the branch only to change a commit message. Observed on a fleet release sweep where four bump PRs auto-merged between the commit and the amend; two rounds went into the lease before the `couldn't find remote ref` line was read.
 
 ### Complex Conflicts
 

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -1686,7 +1686,7 @@ tail -20 build.log            # inspection only — never part of the gate
 
 ### `--force-with-lease` Rejected with "stale info"
 
-Two different causes produce this message: the tracking ref moved (below), or there is no tracking ref at all (the subsection after it). Neither is a reason to escalate to plain `--force`.
+Three different causes produce this message: the tracking ref moved (below), there is no tracking ref at all (the subsection after it), or the remote branch is gone because the PR already merged (the subsection after that). None of them is a reason to escalate to plain `--force`.
 
 On PRs that bots touch (auto-approve, Renovate/Dependabot, a CI step that pushes), `git push --force-with-lease` can be rejected with `stale info` even when your local work is correct: a bot updated the remote branch since your last fetch, so the lease's expected ref (your `origin/<branch>` tracking ref) no longer matches and the push aborts. This is the safety check working — don't escalate to plain `--force`.
 
@@ -1725,6 +1725,21 @@ git push --force-with-lease fork HEAD:my-branch
 ```
 
 `git remote -v` before force-pushing is the cheap check: if the target is not listed there, the lease cannot work. Do not reach for plain `--force` — that discards the protection instead of supplying it.
+
+#### When the branch is gone because the PR already merged
+
+The same `stale info` appears when there is nothing left to push to: auto-merge took the PR while you were preparing the amend, and the merge deleted the branch. The lease has no remote ref to compare against, so it refuses — identically to the two cases above, and the documented remedy for the first one does not help.
+
+The tell is in the fetch, not the push, and it is easy to miss because the fetch is usually run with its output discarded:
+
+```bash
+git fetch origin "$BR:refs/remotes/origin/$BR"
+# fatal: couldn't find remote ref release/v1.8.2
+git push --force-with-lease="$BR:$(git rev-parse origin/"$BR")"
+# ! [rejected]  (stale info)     ← same message, different world
+```
+
+So when a lease refresh does not fix `stale info`, read the fetch's own output before pinning the lease harder, and check the PR rather than the ref: `gh pr view <n> --json state,mergedAt`. If it says `MERGED`, the amend is no longer available — the commit is on the default branch, and rewriting shared history to improve a commit message is worse than the message. Observed on a fleet release sweep where four bump PRs auto-merged between the commit and the amend; two rounds went into the lease before the `couldn't find remote ref` line was read.
 
 ### Complex Conflicts
 


### PR DESCRIPTION
From a retro on a 36-repository release sweep.

## The gap

`### --force-with-lease Rejected with "stale info"` opens by naming two causes: the tracking ref moved, or there is no tracking ref at all. A third produces the identical message and is not covered — the remote branch is **gone**, because auto-merge took the PR while the amend was being prepared and the merge deleted the branch. The lease has nothing to compare against, so it refuses exactly as in the other two cases.

## Why it earns its own subsection rather than a clause

Because the documented remedy for the first cause actively leads away from it. That remedy is "fetch, then push" — and here the fetch is precisely what holds the answer:

```
fatal: couldn't find remote ref release/v1.8.2
```

That line is usually discarded (the fetch is run with its output redirected), the push is retried with a lease pinned to the tracking ref, and it fails the same way. On the sweep this came out of, two rounds went into the lease before the fetch output was read — and by then the question was no longer "how do I push" but "this PR merged four commits ago".

The subsection therefore says two things the other two causes do not need: read the fetch before pinning the lease harder, and check the PR rather than the ref. A `MERGED` state means the amend is not available at all — the commit is on the default branch, and rewriting shared history to improve a commit message is worse than the message.

## Bounded

One new `####` subsection after *When the push target is a URL, not a remote*, plus the intro's count from two to three. The two existing causes, their commands and the standing refusal to escalate to plain `--force` are untouched.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5
