### PR TITLE
docs(pull-request-workflow): a review bot can be older than your toolchain

### DIFF
--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -992,20 +992,24 @@ enforces — apply it here too, before ever declaring the review done.
 
 ## A Review Bot Can Be Older Than Your Toolchain
 
-A bot reviews with the language it was trained on. When a PR raises a toolchain
-or language version, the constructs that raise enables are exactly the ones the
-bot has never seen — and it reports them as **compile errors**, usually as
-`Critical`, with a suggested fix that undoes the upgrade. Two of those landed on
-one 10-line diff; the suggestion would have removed the feature the PR existed
-to adopt.
+When a PR raises a toolchain or language version, some of what it enables is
+newer than what the reviewing bot knows, and the bot can report those constructs
+as **compile errors** with a suggested fix that undoes the upgrade. Observed
+once, on a Go 1.27 promoted-field literal: two `Critical` findings on one
+10-line diff, whose suggestion would have removed the feature the PR existed to
+adopt. Which component produced such a finding is not observable from outside —
+treat the pattern as the thing to recognise, not the mechanism.
 
-The tell is a finding that contradicts an artefact you already have: CI compiled
-that exact head minutes ago. So do not reach for the editor. Answer with evidence
-and resolve:
+The tell is a finding that contradicts an artefact you already have. So do not
+reach for the editor. Answer with evidence and resolve:
 
-1. **Name the run that disproves it.** The required check on this head built and
-   tested those lines. A bot's claim that they do not compile is refuted by the
-   pipeline, not by argument.
+1. **Name the run that disproves it — after checking it says what you need.**
+   Two preconditions, both cheap and both easy to skip. The thread is a snapshot
+   of the commit it was posted against, so confirm that commit is the head the
+   run built; a stale thread is refuted by nothing. And confirm the run actually
+   compiled the affected target with the toolchain the repository declares — a
+   required check can be green without building the package in question, which
+   is the same trap as treating a suite's existence as proof it runs.
 2. **Add the version probe.** Build the same construct under the old and the new
    language version and paste both outputs — a compiler that says
    `requires go1.27 or later` (or the equivalent) settles it in one line, and
@@ -1014,10 +1018,12 @@ and resolve:
    often bundle a correct observation with a wrong diagnosis, and acknowledging
    the correct part is what stops the next round re-raising it.
 
-Then resolve the thread. This is one of the few cases where "not applying this"
-is the right outcome on a `Critical` finding, so the reply has to carry the
-evidence — a bare "false positive" leaves the next reader with two claims and no
-way to choose.
+Then resolve the thread, where the thread is one a reply can resolve — some
+classes are not (see the note on `github-advanced-security` above), and resolving
+does not clear a `CHANGES_REQUESTED` review, which still needs a re-review on the
+new head. This is one of the few cases where "not applying this" is the right
+outcome on a `Critical` finding, so the reply has to carry the evidence — a bare
+"false positive" leaves the next reader with two claims and no way to choose.
 
 The same shape appears without a version bump whenever a repository is ahead of
 the bot: a new stdlib package, a new builtin, a lint rule the project adopted

--- a/skills/git-workflow/references/pull-request-workflow.md
+++ b/skills/git-workflow/references/pull-request-workflow.md
@@ -990,6 +990,39 @@ Only once `SEEN >= 1` is the unresolved-threads query above meaningful. This is
 the same "review the latest head SHA" gate the [Merge-Gate Watcher](merge-gate-watcher.md)
 enforces — apply it here too, before ever declaring the review done.
 
+## A Review Bot Can Be Older Than Your Toolchain
+
+A bot reviews with the language it was trained on. When a PR raises a toolchain
+or language version, the constructs that raise enables are exactly the ones the
+bot has never seen — and it reports them as **compile errors**, usually as
+`Critical`, with a suggested fix that undoes the upgrade. Two of those landed on
+one 10-line diff; the suggestion would have removed the feature the PR existed
+to adopt.
+
+The tell is a finding that contradicts an artefact you already have: CI compiled
+that exact head minutes ago. So do not reach for the editor. Answer with evidence
+and resolve:
+
+1. **Name the run that disproves it.** The required check on this head built and
+   tested those lines. A bot's claim that they do not compile is refuted by the
+   pipeline, not by argument.
+2. **Add the version probe.** Build the same construct under the old and the new
+   language version and paste both outputs — a compiler that says
+   `requires go1.27 or later` (or the equivalent) settles it in one line, and
+   makes the thread useful to a human reader later.
+3. **Say which half of the suggestion is already true**, where one is. Bots
+   often bundle a correct observation with a wrong diagnosis, and acknowledging
+   the correct part is what stops the next round re-raising it.
+
+Then resolve the thread. This is one of the few cases where "not applying this"
+is the right outcome on a `Critical` finding, so the reply has to carry the
+evidence — a bare "false positive" leaves the next reader with two claims and no
+way to choose.
+
+The same shape appears without a version bump whenever a repository is ahead of
+the bot: a new stdlib package, a new builtin, a lint rule the project adopted
+deliberately. Check the artefact before the argument.
+
 ## Merge Strategies
 
 ### Merge Commit


### PR DESCRIPTION
Merging this adds one section to `references/pull-request-workflow.md` for a review finding that is wrong in a specific, recurring way: the bot's model is older than the repository's toolchain. Documentation only.

A PR that raises a language version can enable constructs newer than what the reviewing bot knows, and the bot may report them as compile errors with a suggested fix that removes the feature the PR exists to adopt. On the change that prompted this, a bot flagged four sites as "Go rejects these composite literals" minutes after the required check had compiled and tested those same four lines on that same head.

The tell is that the finding contradicts an artefact already in hand. So the section says to answer with evidence rather than with the editor: confirm the run covers the affected target and the thread's commit, cite it, add a two-version compiler probe whose diagnostic names the required version, and acknowledge whichever half of the suggestion is correct — an unacknowledged half comes back next round.

It also states the uncomfortable part plainly. This is one of the few situations where not applying a `Critical` finding is right, which means the reply has to carry the evidence: a bare "false positive" leaves a later reader with two claims and no way to choose between them.

Generalised past version bumps, because the shape is not specific to them — it appears whenever a repository is ahead of the bot, including a new standard-library package or a lint rule the project adopted deliberately.

## Review round

Corrected in `a7fffa3`, after the section was found asserting something this file contradicts two sections earlier.

Step 1 told the reader to cite the required check as proof the lines compiled. A required check can be green without having built the affected target — the same trap as treating a suite's existence as proof that it runs — and, worse, the step presumed the thread's commit is the head that run built. This file already says a thread is a snapshot of the commit it was posted against, so a stale thread is refuted by nothing. Both preconditions are now named before the run may be cited.

Two mechanism claims are gone. "A bot reviews with the language it was trained on" asserted something inside a closed product that nothing here can observe, and "exactly the ones the bot has never seen" claimed a coextension that does not hold. What the reader needs is the pattern, not a theory of how it is produced. "Usually `Critical`" rested on the n=2 in the following sentence and now says so.

Resolving is qualified too: some thread classes cannot be resolved by a reply, and resolving does not clear a `CHANGES_REQUESTED` review — both already documented in this file, and the new section read as if neither existed.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NTk1ART7kB8M4ZZRJjcAzn)_

https://claude.ai/code/session_01NTk1ART7kB8M4ZZRJjcAzn
