### PR TITLE
chore(release): v1.32.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "git-workflow",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "Git workflow best practices with commit validation hooks",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires git, gh CLI; yq for .spec-cleanup.yml."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.32.1"
+  version: "1.32.2"
   repository: https://github.com/netresearch/git-workflow-skill
 allowed-tools: Bash(git:*) Bash(gh:*) Read Write
 ---


### PR DESCRIPTION
`pull-request-workflow.md` gains a section for a review finding that is wrong in a recurring way: the repository is ahead of the reviewing bot, so a construct the version raise enables is reported as a compile error with a fix that undoes the upgrade.

The section says to answer with evidence rather than the editor, and names the two preconditions before a CI run may be cited — that the run covered the affected target, and that the thread's commit is the head it built. A required check can be green without building the package in question, and a thread is a snapshot of the commit it was posted against.

It also states the uncomfortable part: this is one of the few cases where not applying a `Critical` finding is right, so the reply has to carry the evidence.